### PR TITLE
changed git-repo to OpenVnmrJ to reflect name of repo on GitHub

### DIFF
--- a/src/scripts/ovjddrout.sh
+++ b/src/scripts/ovjddrout.sh
@@ -17,7 +17,7 @@ then
    workspacedir=$HOME
 fi
 
-gitdir=$workspacedir/git-repo
+gitdir=$workspacedir/OpenVnmrJ
 vnmrdir=$gitdir/../vnmr
 standardsdir=$gitdir/../options/standard
 optionsdir=$gitdir/../options

--- a/src/scripts/ovjmacout.sh
+++ b/src/scripts/ovjmacout.sh
@@ -21,7 +21,7 @@ then
    dvdBuildName1=dvdimageOVJ
 fi
 
-gitdir=$workspacedir/git-repo
+gitdir=$workspacedir/OpenVnmrJ
 vnmrdir=$gitdir/../vnmr
 standardsdir=$gitdir/../options/standard
 optddrdir=$gitdir/../options/console/ddr

--- a/src/scripts/ovjmiout.sh
+++ b/src/scripts/ovjmiout.sh
@@ -17,7 +17,7 @@ then
    workspacedir=$HOME
 fi
 
-gitdir=$workspacedir/git-repo
+gitdir=$workspacedir/OpenVnmrJ
 vnmrdir=$gitdir/../vnmr
 standardsdir=$gitdir/../options/standard
 optionsdir=$gitdir/../options


### PR DESCRIPTION
Cloning the repository from github results in the repository named OpenVnmrJ not git-repo. 