### PR TITLE
Autoproc was not removing entries from psgQ

### DIFF
--- a/src/nautoproc/autofuncs.c
+++ b/src/nautoproc/autofuncs.c
@@ -175,7 +175,7 @@ int getPsgQentry(char *filename, PSG_Q_ENTRY *pPsgQentry)
 *
 *			Author Greg Brissey 11-9-94
 */
-void deletePsgQentry(char *filename,struct sample_info *s)
+static void deletePsgQentry(char *filename,struct sample_info *s)
 {
     char shellcmd[3*MAXPATHL];
     char tmp[91];
@@ -198,8 +198,8 @@ void deletePsgQentry(char *filename,struct sample_info *s)
      * 1 entry = (tail + (nlines+1))
      * nline = 1 (psg msge) + (index + 1) + 1
      */
-    sprintf(shellcmd,"tail +%d %s > /tmp/psgQtmp; mv -f /tmp/psgQtmp %s",
-        entryindex+3,filename,filename);
+    sprintf(shellcmd,"cd %s; tail -n +%d psgQ > psgQtmp; mv -f psgQtmp psgQ",
+        autodir,entryindex+3);
   
     DPRINT1(1,"Autoproc shellcmd to delete psgQ entry:'%s'\n",shellcmd);
  
@@ -259,6 +259,7 @@ int getEnterQentry(char *enterfile, struct sample_info *pQentry)
     return(ENTRY_PRESENT);
 }
 
+#ifdef XXX
 /****************************************************************
 *
 * deleteEnterQentry - delete entry from enterQ
@@ -300,6 +301,7 @@ void deleteEnterQentry(char *enterfile)
  
     unlockfile(enterfile);   /* unlock file */
 } 
+#endif
 
 /****************************************************************
 *
@@ -1004,7 +1006,7 @@ int Resume(char *argstr)
       if (stat(lastPath, &statbuf) == 0)
       {
           char shellcmd[2*strlen(lastPath)+100];
-          sprintf(shellcmd, "tail +2 %s > /tmp/entertmp; "
+          sprintf(shellcmd, "tail -n +2 %s > /tmp/entertmp; "
                             "mv -f /tmp/entertmp %s",
                      lastPath, lastPath);
           system(shellcmd);

--- a/src/psg/SConstruct
+++ b/src/psg/SConstruct
@@ -232,7 +232,7 @@ env = Environment(CCFLAGS    = '-c -O -m32 -Wall',
                   CPPPATH    = [cwd])
 
 if ( 'darwin' in platform ):
-	env.Replace(CC = 'clang')
+    env.Replace(CC = 'clang')
     env.Replace(LINKFLAGS = ['-install_name','@loader_path/../lib/library.dylib','-m32'])
     env.Replace(CCFLAGS = '-c -Os -m32 -Wall -Wno-return-type')
     env.Replace(CPPFLAGS = '-Os -m32 -Wall -fPIC -Wno-format-security -Wno-return-type -mmacosx-version-min=10.8')


### PR DESCRIPTION
autofuncs.c used the tail command to remove lines from psgQ. However,
without the -n option, the +12 was interpreted as a file name, causing
tail to add a filename to psgQ.