### PR TITLE
Recent change for MacOS build broke Linux build

### DIFF
--- a/src/nvpsg/SConstruct
+++ b/src/nvpsg/SConstruct
@@ -436,7 +436,7 @@ buildMethods.makeSymLinks(cEnv, psglibSharedTarget, cwd, psgPath, psgFileList)
 buildMethods.makeSymLinks(cEnv, psglibSharedTarget, cwd, expprocPath, srcExpprocHeaderList)
 buildMethods.makeSymLinks(cEnv, psglibSharedTarget, cwd, nvacqPath, srcNvacqHeaderList)
 
-s2pulcEnv.AppendUnique( LIBS    = ['psglib', 'param', 'acqcomm', 'stdc++', 'm'])
+s2pulcEnv.AppendUnique( LIBS    = ['psglib', 'param', 'acqcomm', 'dummy', 'stdc++', 'm'])
 s2pulcEnv.AppendUnique( LIBPATH = [cwd, psgPath, ncommPath] )
 s2pulcEnv.Append(LINKFLAGS  = ' -Wl,-rpath,/vnmr/lib ')
 


### PR DESCRIPTION
The nvpsg SConstruct no longer puts x_ps.o into libpsglib.so.
When compiling nvpsg, the s2pul target failed. This change will
not change the contents of the final dvd. It only avoids some
errors during the build process. This is related to issue #37 and
pull request #42