### PR TITLE
Linear prediction error with large number of increments (#84)

### DIFF
--- a/src/common/maclib/setLP1
+++ b/src/common/maclib/setLP1
@@ -57,7 +57,7 @@ strtext1= $curlenth+1
 lpnupts1= $curlenth  
 strtlp1= $curlenth
 lpext1= $xtndlenth - $curlenth 
-proc1='lp'
+if lpext1 then proc1='lp' else proc1='ft' endif
 if (refsource1='sfrq') then lpfilt1=8 else lpfilt1=4 endif
 if (lpfilt1 > $curlenth/4) then lpfilt1=4 endif
 if (lpfilt1 > $curlenth/4) then proc1='ft' endif

--- a/src/common/maclib/setLP2
+++ b/src/common/maclib/setLP2
@@ -39,7 +39,8 @@
 
     lpopt2 = 'f' strtext2 = $curlenth+1  lpnupts2 = $curlenth  
     strtlp2 = $curlenth  lpext2 = $xtndlenth - $curlenth 
-    lpfilt2 = 4 proc2='lp'
+    lpfilt2 = 4
+    if lpext2 then proc2='lp' else proc2='ft' endif
 
     if ($# > 2) then lpfilt2=$3 endif
 


### PR DESCRIPTION
Data with a large number of increments may not process correctly.
One gets a lpext1<1 or lpext2<1 error