### PR TITLE
ds program may show the wrong spectrum

### DIFF
--- a/src/Asp/AspDataInfo.C
+++ b/src/Asp/AspDataInfo.C
@@ -47,6 +47,8 @@ void AspDataInfo::initDataInfo() {
 	haxis.rev=0;
 	haxis.npts=0;
 	haxis.orient=0;
+	haxis.ydataMax=-1.0;
+	haxis.ydataMin=0.0;
 
  	vaxis.name="?";
 	vaxis.label="?";
@@ -60,6 +62,8 @@ void AspDataInfo::initDataInfo() {
 	vaxis.rev=0;
 	vaxis.npts=0;
 	vaxis.orient=0;
+	vaxis.ydataMax=-1.0;
+	vaxis.ydataMin=0.0;
 }
 
 void AspDataInfo::updateDataInfo() {
@@ -125,6 +129,7 @@ void AspDataInfo::getYminmax(string nucleus, double &ymin, double &ymax) {
      int i;
      for(i=0;i<npts;i++) {
 
+
         data = SpecDataMgr::get()->getTrace("SPEC", i, 1.0, haxis.npts);
         if(!data) continue;
 
@@ -141,6 +146,11 @@ void AspDataInfo::getYminmax(string nucleus, double &ymin, double &ymax) {
 //Winfoprintf("ymin ymax %f %f",ymin,ymax);
 }
 
+void AspDataInfo::resetYminmax() {
+   vaxis.ydataMin=0.0;
+   vaxis.ydataMax=-1.0;
+}
+
 void AspDataInfo::init1D_vaxis() {
 
    vaxis.orient=VERT;
@@ -152,13 +162,25 @@ void AspDataInfo::init1D_vaxis() {
    vaxis.npts=getNtraces(haxis.name);
    string aig = AspUtil::getString("aig","ai");
    if(aig == "nm") {
-      double ymin=0, ymax=0;
-      getYminmax(haxis.name, ymin, ymax);
-      vaxis.minfirst = ymin;
-      vaxis.maxwidth = ymax - ymin;
+      if ( (vaxis.ydataMin == 0.0) && (vaxis.ydataMax < vaxis.ydataMin) )
+      {
+         double ymin=0, ymax=0;
+         getYminmax(haxis.name, ymin, ymax);
+         vaxis.minfirst = ymin;
+         vaxis.maxwidth = ymax - ymin;
+         vaxis.ydataMin=ymin;
+         vaxis.ydataMax=ymax;
+      }
+      else
+      {
+         vaxis.minfirst = vaxis.ydataMin;
+         vaxis.maxwidth = vaxis.ydataMax - vaxis.ydataMin;
+      }
    } else {
       vaxis.maxwidth = 0.0; 
       vaxis.minfirst = 0.0;
+      vaxis.ydataMin=0.0;
+      vaxis.ydataMax=-1.0;
    }
 
    vaxis.scale = getVscale();

--- a/src/Asp/AspDataInfo.h
+++ b/src/Asp/AspDataInfo.h
@@ -44,6 +44,7 @@ public:
 	string getFidPath();
         int getNtraces(string nucleus);
 	void getYminmax(string nucleus, double &ymin, double &ymax);
+	void resetYminmax();
 
 	void dprint(aspAxisInfo_t *axis);
 

--- a/src/Asp/AspDis1D.C
+++ b/src/Asp/AspDis1D.C
@@ -607,7 +607,7 @@ int AspDis1D::mspec(spAspFrame_t frame, int argc, char *argv[]) {
       if(maxTraces < 1) return 0;
    }
 
-   int i, count=0, npts, ind, iColor, jk=0;
+   int i=0, count=0, npts, ind, iColor, jk=0;
    double minX, maxX,scale=1.0;
    char str[16];
    char color[16];

--- a/src/Asp/AspFrame.C
+++ b/src/Asp/AspFrame.C
@@ -241,6 +241,12 @@ void AspFrame::setDefaultFOV() {
    cellList->addCell(0,cell); 
 }
 
+void AspFrame::resetYminmax() {
+
+   spAspDataInfo_t dataInfo = getDefaultDataInfo(true);
+   dataInfo->resetYminmax();
+}
+
 void AspFrame::draw() {
 
      if(annoTop) set_top_frame_on_top(1);

--- a/src/Asp/AspFrame.h
+++ b/src/Asp/AspFrame.h
@@ -41,6 +41,7 @@ public:
     double pstx,pwd,psty,pht; // pixels of FOV 
 
         void setDefaultFOV();
+        void resetYminmax();
         void setCellFOV(int rows, int cols);
         void setFullSize();
 

--- a/src/Asp/AspFrameMgr.C
+++ b/src/Asp/AspFrameMgr.C
@@ -569,6 +569,9 @@ int AspFrameMgr::frameFunc(char *keyword, int frameID, int x, int y, int w, int 
 	frame->setDefaultFOV();
 	frame->displayTop();
 	return 0;
+    } else if(key=="resetVscale") {
+	frame->resetYminmax(); // clear data min max for vertical display
+	return 0;
     } else if(key=="redraw") {
 	frame->draw(); 
 	return frame->ownScreen();

--- a/src/Asp/AspUtil.h
+++ b/src/Asp/AspUtil.h
@@ -194,6 +194,8 @@ typedef struct aspiAxisInfo {
    double minfirst; // rflrfp+sw (note, from left to right) in default units
    double width; // wp
    double start; // sp+sw 
+   double ydataMax; // max y value for vertical scale display
+   double ydataMin; // min y value for vertical scale display
    int rev;
    int npts;
    int orient;

--- a/src/aip/aipSpecDataMgr.C
+++ b/src/aip/aipSpecDataMgr.C
@@ -21,6 +21,7 @@ SpecDataMgr *SpecDataMgr::specDataMgr = NULL;
 SpecDataMgr::SpecDataMgr() {
     specDataMap = new SpecDataMap;
     selData = NULL;
+    selDatanpt = 0;
 }
 
 SpecDataMgr *SpecDataMgr::get()
@@ -160,8 +161,17 @@ float *SpecDataMgr::getTrace(string key, int ind, double scale, float *outData, 
 // note, fpt and npt are for real data. So multiple 2 for complex data. 
 // selData is a member variable.
 float *SpecDataMgr::getTrace(string key, int ind, double scale, int npt) {
-    if(selData != NULL) delete[] selData;
-    selData = new float[npt];
+    if ((selData != NULL) && (selDatanpt != npt) )
+    {
+       delete[] selData;
+       selData = NULL;
+    }
+    if (selData == NULL)
+    {
+       selData = new float[npt];
+       selDatanpt = npt;
+    }
+
     return getTrace(key, ind, scale, selData, npt);
 }
 
@@ -226,8 +236,16 @@ float *SpecDataMgr::getTrace4ComboKey(string key, int ind, double scale, int npt
 	  delete[] trace2;
 	  return data1;
 	}
-        if(selData != NULL) delete[] selData;
-        selData = new float[npt];
+        if ((selData != NULL) && (selDatanpt != npt) )
+        {
+           delete[] selData;
+           selData = NULL;
+        }
+        if (selData == NULL)
+        {
+           selData = new float[npt];
+           selDatanpt = npt;
+        }
 	if(add) {
 	  for(int i=0; i<npt; i++) selData[i]=data1[i]+data2[i];
 	} else {
@@ -252,8 +270,16 @@ float *SpecDataMgr::getTrace4ComboKey(string key, int ind, double scale, int npt
 	   scale1 = atof(num.c_str());
 	   key1 = key1.substr(0,pos);
 	}
-        if(selData != NULL) delete[] selData;
-        selData = new float[npt];
+        if ((selData != NULL) && (selDatanpt != npt) )
+        {
+           delete[] selData;
+           selData = NULL;
+        }
+        if (selData == NULL)
+        {
+           selData = new float[npt];
+           selDatanpt = npt;
+        }
 	return getTrace(key1, ind1, scale1, selData, npt);
     }
 }

--- a/src/aip/aipSpecDataMgr.h
+++ b/src/aip/aipSpecDataMgr.h
@@ -56,6 +56,7 @@ private:
 
     SpecDataMap *specDataMap;
     float *selData;
+    int selDatanpt;
 
     SpecDataMgr();
     

--- a/src/vnmr/ds.c
+++ b/src/vnmr/ds.c
@@ -167,7 +167,7 @@ static double  lvltlt_sense;
 static double  phasefine;
 static float  *cur_scl,scl_spec2;
 static float  *phase_data;
-static float  *curspec;
+static float  *curspec = NULL;
 static float  *spectrum;
 static float  *spec2ptr;
 static float  *spec3ptr;
@@ -519,7 +519,8 @@ static void m_newcursor(int butnum, int x, int y, int moveflag)
 {
   (void) moveflag;
   int dez = getDscaleDecimal(0)+2;
-  if (get_dis_setup() != 1)
+  if (get_dis_setup() != 1) 
+  {
     select_init(
         0,
         GRAPHICS,
@@ -530,6 +531,7 @@ static void m_newcursor(int butnum, int x, int y, int moveflag)
         NO_BLOCKPARS,
         NO_PHASEFILE
     );
+  }
   Wgmode();
   if ((butnum==3) && (ds_mode!=BOX_MODE))	/*  box button */
   {
@@ -697,7 +699,7 @@ static void newspec(int inset, int fp, int np, int dfp, int dnp)
      Wturnoff_buttons();
      set_turnoff_routine(turnoff_ds);
   }
-  else if ((spectrum = calc_spec(specIndex-1,0,FALSE,TRUE,&updateflag))==0)
+  else if ((curspec = spectrum = calc_spec(specIndex-1,0,FALSE,TRUE,&updateflag))==0)
   {
      Wturnoff_buttons();
      set_turnoff_routine(turnoff_ds);
@@ -754,7 +756,8 @@ static int exit_phase()
   }
   else if (phaseflag)
   {
-    if ((spectrum = calc_spec(specIndex-1,0,FALSE,TRUE,&updateflag))==0)
+    aspFrame("resetVscale",0,0,0,0,0);
+    if ((curspec = spectrum = calc_spec(specIndex-1,0,FALSE,TRUE,&updateflag))==0)
       return(ERROR);
     Wclear_graphics();
     show_plotterbox();
@@ -1118,7 +1121,10 @@ static void b_phase()
    update_ycursor(1, threshY);
    activate_mouse(m_newphase, exit_phase);
    if ( ! this_is_addi)
+   {
       aspFrame("ds",0,0,0,0,0);
+      aspFrame("resetVscale",0,0,0,0,0);
+   }
 }
 
 
@@ -1577,7 +1583,8 @@ static int m_lvltlt(int butnum, int x, int y, int moveflag)
       }
       P_setreal(CURRENT,"lvl",lvl,0);
       DispField2(FIELD3,-PARAM_COLOR, lvl, 1);
-      if ((spectrum = calc_spec(specIndex-1,0,FALSE,TRUE,&updateflag))==0)
+      aspFrame("resetVscale",0,0,0,0,0);
+      if ((curspec = spectrum = calc_spec(specIndex-1,0,FALSE,TRUE,&updateflag))==0)
         return(ERROR);
       if (intflag)
         intdisp();
@@ -2088,6 +2095,8 @@ static void ds_multiply(int x, int y)
   } 
 
 
+  if ((curspec = spectrum = calc_spec(specIndex-1,0,FALSE,TRUE,&updateflag))==0)
+     return;
   if(get_drawVscale()) new_dscale(TRUE,FALSE);
   if (intflag)
   {
@@ -2135,7 +2144,9 @@ static void ds_multiply(int x, int y)
     if(!isInset()) redo_dpf_dpir();
     ds_sendVs();
     if ( ! this_is_addi)
+    {
        aspFrame("ds",0,0,0,0,0);
+    }
 #endif
   }
 }
@@ -2331,7 +2342,6 @@ static void mspecdisp() {
 static void specdisp()
 /****************/
 {
-
   if(getShowMspec() > 0) mspecdisp();
   else if(getOverlayMode() == OVERLAID_ALIGNED) overlayspecdisp();
   else {
@@ -2414,6 +2424,8 @@ static void intdisp()
         Wturnoff_buttons();
         return;
       }
+    if ((curspec = spectrum = calc_spec(specIndex-1,0,FALSE,TRUE,&updateflag))==0)
+       return;
     integ(spectrum,integral,fn / 2);
     updateflag = FALSE;
   }
@@ -2741,6 +2753,7 @@ static int init_vars2()
   dispcalib = (float) (mnumypnts-ymin) / (float) wc2max;
   integral = 0;
 
+  aspFrame("resetVscale",0,0,0,0,0);
   if ((curspec = spectrum = calc_spec(specIndex-1,0,FALSE,TRUE,&updateflag))==0)
     return(ERROR);
   scale = dispcalib;
@@ -2776,7 +2789,10 @@ static int init_ds(int argc, char *argv[], int retc, char *retv[])
   start_from_ft = 0;
   ds_sendSpecInfo(1);
   if ( ! this_is_addi)
+  {
      aspFrame("clearAspSpec",0,0,0,0,0);
+     aspFrame("resetVscale",0,0,0,0,0);
+  }
   return(COMPLETE);
 }
 


### PR DESCRIPTION
If an arrayed data set has more than nine traces
and the  vertical scale (vs) or vertical position (vp)
is interactively updated, alternating traces will be
displayed. The integral could also be wrong.