### PR TITLE
allow operator names to be all-numeric strings

### DIFF
--- a/src/common/maclib/locaction
+++ b/src/common/maclib/locaction
@@ -130,6 +130,7 @@ elseif ($5 = 'Default') then
          if(appmode = 'imaging') then
            RQaction('loadData', $4, $1)
          else
+           $op=''
            if ($2 = 'vnmr_record') then
                rtv($4+'/acqfil/procpar','noabort','operator_'):$op
            else
@@ -271,6 +272,7 @@ elseif ($5 = 'Canvas') then
          if(appmode = 'imaging') then
            RQaction('loadData', $4, $1)
          else
+           $op=''
            if ($2 = 'vnmr_record') then
                rtv($4+'/acqfil/procpar','noabort','operator_'):$op
            else


### PR DESCRIPTION
fix adapted from Mauro Cremonini on spinsights:
https://spinsights.chem.agilent.com/thread/3431