### PR TITLE
Fix for issue 137 3D Gradient shimming failure (#138)

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,5 +1,9 @@
 OpenVnmrJ Release Notes.
 
+Oct 2017
+    Fixed some faults discussed in SpinSights.
+      3D gradient shimming can fail with an uninitialized $isvnmrj variable
+
 Sep 2017
     Fixed some faults discussed in SpinSights.
       improved atcmd 'active' option documentation
@@ -9,16 +13,6 @@ Sep 2017
       Added menu feature to UserPrefs (see manual/UserPrefs)
       Fixed svpdp to follow operator rights when making changes
 
-Aug 2017
-    Fixed scripts used to install OpenVnmrJ. The standard sudo is now
-    used. Linux obsoleted kudzu so we no longer need to deal with it.
-    Also copy some rpms to the dvd for installation (tcl and tk)
-    
-Aug 2017
-    Fixed scripts used to install OpenVnmrJ. The standard sudo is now
-    used. Linux obsoleted kudzu so we no longer need to deal with it.
-    Also copy some rpms to the dvd for installation (tcl and tk)
-    
 Aug 2017
     Fixed scripts used to install OpenVnmrJ. The standard sudo is now
     used. Linux obsoleted kudzu so we no longer need to deal with it.

--- a/src/gxyzshim/maclib/gxyzautoshim
+++ b/src/gxyzshim/maclib/gxyzautoshim
@@ -361,7 +361,7 @@ if ($function='acquireref1D') then "Set up and start 1D measurement"
 	savesampglobal('cp')
 	rtp('/vnmr/tests/H1lshp')
 	getsampglobal('cp')
-	if $isvnmrj then seqfil=seqfil endif
+	seqfil=seqfil
 	setsw($refppm+1,$refppm-1) solvent=$solv fn=2*np
 	tn=$refnuc
 	gain=$gain d1=1


### PR DESCRIPTION
The gxyzautoshim macro will fail with $isvnmrj variable undefined
The bug was introduced in VJ 4.0. Reported in SpinSights.