### PR TITLE
fidmax and dpcon updated

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,5 +1,11 @@
 OpenVnmrJ Release Notes.
 
+May 2018
+    makefid could fail if called many times, such as when creating a 2D or
+      arrayed 1D data set.
+    dpcon can now be cancelled.
+    fidmax could fail if makefid is used to make a new fid.
+
 Mar 2018
     Study queue errors fixed
 

--- a/src/ncomm/sockets.c
+++ b/src/ncomm/sockets.c
@@ -1099,6 +1099,8 @@ writeSocket( Socket *pSocket, const char *datap, int bcount )
 /* char *datap */
 /* int bcount */
 {
+        ssize_t written = 0;
+        ssize_t nwrite;
 	if (pSocket == NULL) {
 		errno = EFAULT;
 		return( -1 );
@@ -1107,8 +1109,23 @@ writeSocket( Socket *pSocket, const char *datap, int bcount )
 		errno = EBADF;
 		return( -1 );
 	}
+        while (written < bcount)
+        {
+           nwrite = write( pSocket->sd, datap+written, bcount - written );
+           if (nwrite < 0)
+           {
+              if (errno != EINTR)
+                 return(-1);
+           }
+           else
+           {
+              written += nwrite;
+           }
+              
+        }
 
-	return( write( pSocket->sd, datap, bcount ) );
+//	return( write( pSocket->sd, datap, bcount ) );
+        return(bcount);
 }
 
 int

--- a/src/vnmrbg/dfid.c
+++ b/src/vnmrbg/dfid.c
@@ -2000,6 +2000,7 @@ int fidmax(int argc, char *argv[], int retc, char *retv[])
   int doNF = 0;
   int argnum = 0;
   double tmp;
+  int tmpFn;
 
   revflag = 0;
   if(initfid(1)) return(ERROR);
@@ -2024,6 +2025,7 @@ int fidmax(int argc, char *argv[], int retc, char *retv[])
      }
   }
 
+  tmpFn = -fn;
   if (doNF)
   {
      char *argv1[4];
@@ -2044,7 +2046,7 @@ int fidmax(int argc, char *argv[], int retc, char *retv[])
         cttemp = 1;
      datamax /= (double) cttemp;
   }
-  else if ((spectrum = get_one_fid(trace-1,&fn,&c_block, dcflag)) == 0)
+  else if ((spectrum = get_one_fid(trace-1,&tmpFn,&c_block, dcflag)) == 0)
   {
      datamax = 0.0;
   }

--- a/src/vnmrbg/dpcon.c
+++ b/src/vnmrbg/dpcon.c
@@ -41,6 +41,7 @@ extern int dcon_displayparms();
 extern void setcolormap(int firstcolor, int numcolors, int th, int phcolor);
 extern int currentindex();
 extern void set_spectrum_thickness(char *min, char *max, double ratio);
+extern int      interuption;	/* flag for "cancel command "		*/
 
 static int b_colors;
 static int colors,numcont;
@@ -798,6 +799,10 @@ int phase_display;
     I cannot explain this and find that a value of "l" works.	*/
 
 	  if (colorflag) changecolor(l,plusminus,phase_display);
+	  if (  interuption )
+           {  release(pbuf[0]); release(pbuf[1]); release(fulltrace);
+	     ABORT;
+	   }
 	  if ((phasfl=gettrace(f1,fpnt))==0)
            {  release(pbuf[0]); release(pbuf[1]); release(fulltrace);
 	     ABORT;


### PR DESCRIPTION
fidmax could fail if makefid is used to make a new FID.
dpcon could not be cancelled. It now looks at the interuption
flag. writeSocket() needed to be fixed in case the interruption
occurred while it was writing a message to the java front end.
The java front end requires a complete message.