### PR TITLE
Supress gfortran warnings.

### DIFF
--- a/src/DOSY/SConstruct.dosy
+++ b/src/DOSY/SConstruct.dosy
@@ -14,7 +14,7 @@ dosyFileList = ['contin.for',
                 'splmod.for',
                 'splmodNUG.for']
 
-fenv = Environment(FORTRANFLAGS = '-fno-f2c -ffast-math -O',
+fenv = Environment(FORTRANFLAGS = '-fno-f2c -ffast-math -O -std=legacy',
                    FORTRAN = 'gfortran')
 
 skipBuild='false'

--- a/src/DOSY/contin.for
+++ b/src/DOSY/contin.for
@@ -3629,7 +3629,7 @@ C-----------------------------------------------------------------------    3564
       DOUBLE PRECISION A, ABS, ALPHA, ASAVE, B, CC, DIFF, DUMMY,            3566
      1 FACTOR, RANGE, RNORM, SM, SQRT, SS, T, TWO, UNORM, UP, W,            3567
      2 WMAX, X, ZERO, ZTEST, ZZ                                             3568
-      DIMENSION A(MDA,N), B(1), X(1), W(1), ZZ(1)                           3569
+      DIMENSION A(MDA,N), B(1), X(1), W(1), ZZ(1), DUMMY(1)                 3569
       INTEGER INDEX(N)                                                      3570
       ABS(T)=DABS(T)                                                        3571
       SQRT(T)=DSQRT(T)                                                      3572


### PR DESCRIPTION
The DOSY fortran programs are old. Using -std=legacy option to
gfortran supresses a lot of warnings. With these warnings suppressed,
a real coding error was found.