### PR TITLE
Added sleep command and documentation

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,5 +1,8 @@
 OpenVnmrJ Release Notes.
 
+July 2018
+    Added sleep command (see manual/sleep)
+
 June 2018
     Added options to accounting so that it can be used in a non-interactive
       mode. Added doAcct that uses these options. (see manual/vnmr_accounting)

--- a/src/common/manual/sleep
+++ b/src/common/manual/sleep
@@ -1,0 +1,15 @@
+*******************************************************************************
+sleep(seconds) - Cause OpenVnmrJ to sleep
+*******************************************************************************
+
+The sleep command will cause OpenVnmrJ to pause execution. Without arguments,
+sleep defaults to sleeping for 1 second. The number of seconds to sleep can
+be provided as an argument. The sleep command will sleep for a maximum of 60
+seconds. The number of seconds to sleep can be specified to the thousandths
+of a second.
+
+Examples:
+
+sleep         // sleep for 1 second
+sleep(2)      // sleep for 2 seconds
+sleep(0.009)  // sleep of 9 thousandths of a second.

--- a/src/vnmr/asmfuncs.c
+++ b/src/vnmr/asmfuncs.c
@@ -953,6 +953,33 @@ void sleepMilliSeconds(int msecs)
 }
 
 #ifdef VNMRJ
+int vnmrSleep(int argc, char *argv[], int retc, char *retv[])
+{
+   struct timespec req;
+   double sTime = 0.0;
+   req.tv_sec = 1;
+   req.tv_nsec = 0;
+   if (argc > 1)
+   {
+      sTime= atof(argv[1]);
+      if (sTime >= 60.0)
+      {
+         req.tv_sec = 60;
+      }
+      else
+      {
+         if (sTime <= 0.0)
+            RETURN;
+         int sec = (int) (sTime*1000.0 + 0.1);
+         req.tv_sec = sec / 1000;
+         req.tv_nsec = (sec % 1000) * 1000000 ;
+      }
+   }
+// printf(stderr,"sleep sec= %d nano= %ld\n", (int) req.tv_sec, req.tv_nsec);
+   nanosleep( &req, NULL);
+   RETURN;
+}
+
 static void blockedByGet(char *dir, char *name)
 {
    struct timespec req;

--- a/src/vnmr/table.c
+++ b/src/vnmr/table.c
@@ -460,6 +460,7 @@ extern int trackCursor();
 extern int tune();
 extern int unit();
 extern int unixtime();
+extern int vnmrSleep(int argc, char *argv[], int retc, char *retv[]);
 extern int vnmr_unlock();
 extern int vnmrInfo();
 #ifdef VNMRJ
@@ -1063,6 +1064,7 @@ static cmd_t vnmr_table[] = {
 	{"show_remote_files", show_remote_files,  NO_REEXEC, 0},
 	{"showbuf"    , showbuf,	NO_REEXEC, 0},
 	{"sin"        , ln,	 	NO_REEXEC, 10},
+	{"sleep"      , vnmrSleep,	NO_REEXEC, 0},
 	{"small"      , small,		NO_REEXEC, 0},
 	{"solvinfo"   , solvinfo,	NO_REEXEC, 0},
 	{"spa"        , spa,		NO_REEXEC, 0},


### PR DESCRIPTION
This can be used in place of the previously used shell call to the
system sleep command, which incurred substantial overhead. For example,
calling shell('sleep 0.001') a thousand times should take 1 second.
It takes over 6 seconds and cpu usage goes over 50%. Calling sleep(0.001)
a thousand times takes 1 second and has insignificant cpu usage.