### PR TITLE
Fixed function signatures

### DIFF
--- a/src/vnmr/macro.c
+++ b/src/vnmr/macro.c
@@ -63,8 +63,8 @@
 #endif 
 
 extern node   *loadMacro(char *n, int search, int *res);
-extern symbol *BaddName(symbol **pp, char *n);
-extern symbol *findName(register symbol *p, register char *n);
+extern symbol *BaddName(symbol **pp, const char *n);
+extern symbol *findName(symbol *p, const char *n);
 extern FILE   *popen_call(char *cmdstr, char *mode);
 extern int More(FILE *stream, int screenLength);
 extern void showTree(int n, char *m, node *p);

--- a/src/vnmr/symtab.c
+++ b/src/vnmr/symtab.c
@@ -144,7 +144,8 @@ void balance(symbol **pp)
 |
 +-----------------------------------------------------------------------------*/
 
-symbol *findName(register symbol *p, const char *n)
+
+symbol *findName(symbol *p, const char *n)
 {  register int d;
 
    while (p)
@@ -254,7 +255,7 @@ int deleteName(symbol **pp, symbol *q, const char *n)
 |
 +-----------------------------------------------------------------------------*/
 
-symbol *addName(register symbol **pp, const char *n)
+symbol *addName(symbol **pp, const char *n)
 {  register symbol *p;
    register symbol *q;
 

--- a/src/vnmr/variables1.c
+++ b/src/vnmr/variables1.c
@@ -51,9 +51,9 @@
 #define letter(c) ((('a'<=(c))&&((c)<='z'))||(('A'<=(c))&&((c)<='Z'))||((c)=='_')||((c)=='$')||((c)=='#')||((c)=='/'))
 #define digit(c) (('0'<=(c))&&((c)<='9'))
 
-extern symbol  *addName();
-extern symbol  *BaddName();
-extern symbol  *findName();
+extern symbol *addName(symbol **pp, const char *n);
+extern symbol *BaddName(symbol **pp, const char *n);
+extern symbol *findName(symbol *p, const char *n);
 extern int assignReal(double d, varInfo *v, int i);
 extern int assignString(const char *s, varInfo *v, int i);
 extern int  writelineToVnmrJ(const char *cmd, const char *message );


### PR DESCRIPTION
The readfile command was failing on one PC but worked correctly on
two others. The failure was in the rfindVar section. It claimed it
could not find a local $ variable, but it was absolutely present.
Not clear what the problem is but I noticed the function signatures
for some of the things used by rfindVar (findName, etc) were  different.
These modifications made it work on all three systems.