### PR TITLE
Fix psglib warning messages

### DIFF
--- a/src/biopack/psg/CompSens.h
+++ b/src/biopack/psg/CompSens.h
@@ -31,9 +31,10 @@ char  *fname;
 int    xni, xni2, xni3;
 {
   FILE  *src;
-  char   cmd[MAXSTR];
+  char   cmd[2*MAXSTR];
   double d[4];
-  int    s[4], i, j, k, m;
+  int    i, j, k, m;
+  char *ret __attribute__((unused));
 
   k = 1; j = 0; m = -1; 
   if(xni > 1) k *= xni;      
@@ -46,7 +47,7 @@ int    xni, xni2, xni3;
     psg_abort(1);
   }
 
-  fgets(cmd, 512, src);
+  ret = fgets(cmd, 512, src);
   xdim = sscanf(cmd, "%lf %lf %lf", &d[0], &d[1], &d[2]);  
   if(xdim < 1) 
   {
@@ -89,7 +90,6 @@ int    xni, xni2, xni3;
 void set_RS(opt)  /* set CS schedule */
 char *opt;        // reserved for weighted sampling modes
 {
-  FILE     *src;
   char      stype[MAXSTR], cmd[2*MAXSTR], fname[MAXSTR], path[MAXSTR];
   int       i, j, i1, i2, i3, jx, ni, ni2, ni3, skey;
   double    dkey;
@@ -109,7 +109,9 @@ char *opt;        // reserved for weighted sampling modes
   ni = (int) (0.5 + getval("ni"));        /* assuming ni is always present */
   if(find("ni2") > 0) ni2 = (int) (0.5 + getval("ni2"));
   if(find("ni3") > 0) ni3 = (int) (0.5 + getval("ni3"));
-  if(ni<1) ni=1; if(ni2<1) ni2=1; if(ni3<1) ni3=1;
+  if(ni<1) ni=1;
+  if(ni2<1) ni2=1;
+  if(ni3<1) ni3=1;
 
   if(ni>1)
   {
@@ -138,6 +140,7 @@ char *opt;        // reserved for weighted sampling modes
     sprintf(fname,"%s/sampling.sch", curexp);
     if((stype[0] =='a') || (stype[0] == 'y'))
     {
+      int ret __attribute__((unused));
       skey=169; dkey=0.0;
       if(find("skey") > 0)
       {
@@ -152,7 +155,7 @@ char *opt;        // reserved for weighted sampling modes
               path, fname, ni, nimax, ni2, ni2max, ni3, ni3max, skey);
       else
         abort_message("Failed to find mkCSsc sampling schedule program");
-      system(cmd);
+      ret = system(cmd);
     }
     if(!(kk=get_RS(fname, i1, i2, i3))) 
     {

--- a/src/biopack/psg/Pbox_bio.h
+++ b/src/biopack/psg/Pbox_bio.h
@@ -212,12 +212,13 @@ double bw, ofs, rf_pwr, rf_pw90;
   
     if (sh.pwr > rf_pwr) 
     {
+      int ret __attribute__((unused));
       printf("pbox_Rsh: Warning! Insufficient power for %s\n ", sh.name);
       printf("%.0f dB needed, %.0f dB available\n ", sh.pwr, rf_pwr);
 
       sprintf(str, " -attn %.0f%c\n", rf_pwr, 'd');
 
-      system((char *)strcat(px_cmd,str));                      
+      ret = system((char *)strcat(px_cmd,str));                      
 
       sh = getRsh(shn);
       if (sh.pwrf > 4095.0) 
@@ -268,13 +269,14 @@ double bw, ofs, rf_pwr, rf_pw90;
   
     if (sh.pwr > rf_pwr) 
     {
+      int ret __attribute__((unused));
       printf("\n\n !!!!!!!!!!!!!!!!!!!!!!!! \n\n ");
       printf("pbox_Dsh: Warning! Insufficient power for %s\n ", sh.name);
       printf("%.0f dB needed, %.0f dB available and will be used !\n\n ", sh.pwr, rf_pwr);
 
       sprintf(str, " -attn %.0f%c\n", rf_pwr, 'd');
 
-      system((char *)strcat(px_cmd,str));                      
+      ret = system((char *)strcat(px_cmd,str));                      
 
       sh = getDsh(shn);
       if (sh.pwrf > 4095.0) 

--- a/src/biopack/psg/PpP.h
+++ b/src/biopack/psg/PpP.h
@@ -17,19 +17,20 @@ double pw_bw, ofs, rf_pwr, rf_pw90;
   char   txt[MAXSTR],
          cmd[MAXSTR];
   shape  sh;
+  int ret __attribute__((unused));
        
   sprintf(txt, "Pbox %s -w \"%s %.7f %.1f\" ", shn, wvn, pw_bw, ofs);
   sprintf(txt, "%s -p %.0f -l %.2f ", txt, rf_pwr, 1.0e6*rf_pw90);
   sprintf(cmd, "%s -attn %.0f%c -maxincr 10.0\n", txt, rf_pwr, 'E');
   printf("cmd = %s\n", cmd);
-  system(cmd);                                     /* execute Pbox */
+  ret = system(cmd);                                     /* execute Pbox */
 
   sh = getRsh(shn);
 
   if (sh.pwrf > 4095.0) 
   {
     sprintf(cmd, "%s -attn %.0f%c -maxincr 10.0\n", txt, rf_pwr, 'd');
-    system(cmd);                                   /* execute Pbox */
+    ret = system(cmd);                                   /* execute Pbox */
     sh = getRsh(shn);
     if (sh.pwrf > 4095.0) 
     {

--- a/src/biopack/psg/bionmr.h
+++ b/src/biopack/psg/bionmr.h
@@ -105,7 +105,7 @@ shape getRshapeinfo(char *shname)
   shape    rshape;
   FILE     *inpf;
   int      j;
-  char     ch, str[MAXSTR];
+  char     ch, str[3*MAXSTR];
   extern char userdir[], systemdir[];
 
   strcpy(rshape.name, shname);
@@ -212,6 +212,7 @@ c13pulsepw(excband, nullband, c13shape, c13flip); steps=STEPS; spw=SPW;
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {
+         int ret __attribute__((unused));
          fprintf(fp, "\n Pbox Input File ");
          fprintf(fp, "\n Carrier at: %s   Exc max at: %s      Null at: %s", 
                     			   CURR_C13_OFFSET, excband, nullband);
@@ -223,7 +224,7 @@ c13pulsepw(excband, nullband, c13shape, c13flip); steps=STEPS; spw=SPW;
 						     (int)(pwClvl), pwC*1.0e6);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");
-         system(fs);
+         ret = system(fs);
 	 /*printf("\nFreq Shift = %5.0f  Pulse Width = %0.7f  File Name:%s", 
 							freqshift, spw, SNAME);*/
        }
@@ -378,6 +379,7 @@ void c13adiab_files(char *excband, double bandwidth, char *c13shape, double puls
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {
+         int ret __attribute__((unused));
          fprintf(fp, "\n Pbox Input File ");
          fprintf(fp, "\n Carrier at: %s   Exc max at: %s   Bandwidth(ppm): %s", 
                     			   CURR_C13_OFFSET, excband, fs);
@@ -389,7 +391,7 @@ void c13adiab_files(char *excband, double bandwidth, char *c13shape, double puls
 						     (int)(pwClvl), pwC*1.0e6);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");
-         system(fs);
+         ret = system(fs);
 	 /*printf("\nFreq Shift = %5.0f  Band Width = %5.0f  Pulse Width = %0.7f
   	 			  		File Name: %s",
  					freqshift, bandwidth*dfrq, spw, SNAME);*/
@@ -524,6 +526,7 @@ void fshapefiles(char *anyshape, double pwbw, double flip, double shift)
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {
+         int ret __attribute__((unused));
          fprintf(fp, "\n Pbox Input File ");
          fprintf(fp, "\n { %s %14.8f %12.1f 1.0 0.0 %6.1f } ", fshape, pwbw, 
 								  shift, flip);
@@ -532,7 +535,7 @@ void fshapefiles(char *anyshape, double pwbw, double flip, double shift)
 					(int)(REF_PWR), REF_PW90*1e6);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");
-         system(fs);
+         ret = system(fs);
        /*printf("\nFreq Shift = %5.0f  Pulse Width = %0.7f  File Name:%s", 
 							   shift, pwbw, SNAME);*/
        }
@@ -699,7 +702,7 @@ shape getDshapeinfo(char *shname)
   shape    dshape;
   FILE     *inpf;
   int      j;
-  char     ch, str[MAXSTR];
+  char     ch, str[3*MAXSTR];
   extern char userdir[], systemdir[];
 
   strcpy(dshape.name, shname);
@@ -760,6 +763,7 @@ void c13decfiles(char *decband, char *c13shape, double decbandwidth)
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {                                                                        
+         int ret __attribute__((unused));
          fprintf(fp, "\n Pbox Input File ");                                    
          fprintf(fp, "\n Carrier at: %s   Dec max at: %s  BandWidth: %8.1f",
 				             CURR_C13_OFFSET, decband, dwidth); 
@@ -769,7 +773,7 @@ void c13decfiles(char *decband, char *c13shape, double decbandwidth)
 						     (int)(pwClvl), pwC*1.0e6);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");  
-         system(fs);                                                            
+         ret = system(fs);                                                            
        /*printf("\nFreq Shift = %5.0f  Band Width = %10.0f  File Name:%s", 
 					      freqshift, dwidth, SNAME);*/
        }
@@ -882,13 +886,14 @@ void h1decfiles(char *h1shape, double decbandwidth, double shift)
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {                                                                        
+         int ret __attribute__((unused));
          fprintf(fp, "\n { %s %10.1f %10.1f } ", hshape, dwidth, freqshift);
          fprintf(fp, "\n name = %s   sucyc = d   type = d   attn = e ", SNAME);
          fprintf(fp, "\n RF Calibration Data: ref_pwr = %4d  ref_pw90 = %5.1f",
 						        (int)(tpwr), pw*1.0e6);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");  
-         system(fs);                                                            
+         ret = system(fs);                                                            
        /*printf("\nFreq Shift = %5.0f  Band Width = %10.0f  File Name:%s", 
 					      freqshift, dwidth, SNAME);*/
        }
@@ -1052,11 +1057,12 @@ void installdecshape(char *decshape)
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {                                                                        
+         int ret __attribute__((unused));
          fprintf(fp, "\n { %s } ", decshape);
          fprintf(fp, "\n name = %s   sucyc = d   type = d  attn = e ", SNAME);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");
-	 system(fs);                        
+	 ret = system(fs);                        
        }
      else          { printf("\nUnable to write Pbox.inp file !");  psg_abort(1); }
    }
@@ -1709,6 +1715,7 @@ void hshapefiles(char *anyshape, double bw, double shift)
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {
+         int ret __attribute__((unused));
          fprintf(fp, "\n Pbox Input File ");
          fprintf(fp, "\n { %s %14.8f %12.1f } ", fshape, dwidth, freqshift);
          fprintf(fp, "\n name = %s    sucyc = n", SNAME);
@@ -1716,7 +1723,7 @@ void hshapefiles(char *anyshape, double bw, double shift)
 					(int)(REF_PWR), REF_PW90*1e6);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");
-         system(fs);
+         ret = system(fs);
 
        }
      else          { printf("\nUnable to write Pbox.inp file !");  psg_abort(1); }
@@ -1806,6 +1813,7 @@ void cshapefiles(char *anyshape, double bw, double shift)
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {
+         int ret __attribute__((unused));
          fprintf(fp, "\n Pbox Input File ");
          fprintf(fp, "\n { %s %14.8f %12.1f } ", fshape, dwidth, 
 								  freqshift);
@@ -1814,7 +1822,7 @@ void cshapefiles(char *anyshape, double bw, double shift)
 					(int)(REF_PWR_C), REF_PW90_C*1e6);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");
-         system(fs);
+         ret = system(fs);
         } 
      else          { printf("\nUnable to write Pbox.inp file !");  psg_abort(1); }
   }
@@ -1915,6 +1923,7 @@ void cshapefiles2(char *anyshape1, char *anyshape2, double bw1, double bw2,
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {
+         int ret __attribute__((unused));
          fprintf(fp, "\n Pbox Input File ");
          fprintf(fp, "\n { %s %14.8f %12.1f } ", fshape1, dwidth1, 
 								  freqshift1);
@@ -1925,7 +1934,7 @@ void cshapefiles2(char *anyshape1, char *anyshape2, double bw1, double bw2,
 					(int)(REF_PWR_C), REF_PW90_C*1e6);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");
-         system(fs);
+         ret = system(fs);
        }
      else          { printf("\nUnable to write Pbox.inp file !");  psg_abort(1); }
   }
@@ -2090,6 +2099,7 @@ void nshapefiles(char *anyshape, double bw, double shift)
      (void) sprintf(fname, "%s/shapelib/Pbox.inp", userdir);
      if ( (fp=fopen(fname, "w")) != NULL )
        {
+         int ret __attribute__((unused));
          fprintf(fp, "\n Pbox Input File ");
          fprintf(fp, "\n { %s %14.8f %12.1f } ", fshape, dwidth, 
 								  freqshift);
@@ -2098,7 +2108,7 @@ void nshapefiles(char *anyshape, double bw, double shift)
 					(int)(REF_PWR_N), REF_PW90_N*1e6);
          fclose(fp);
          sprintf(fs,"cd $vnmruser/shapelib; Pbox > /tmp/${LOGNAME}_bionmrfile");
-         system(fs);
+         ret = system(fs);
         } 
      else          { printf("\nUnable to write Pbox.inp file !");  psg_abort(1); }
   }
@@ -2494,7 +2504,7 @@ double	timeTN = getval("timeTN"),	   /* constant time for 15N evolution */
         timeC = getval("timeC"),
         timeNCA = getval("timeNCA"),
         lambda = getval("lambda"),
-  	pwS9,					  /* length of last C13 pulse */
+  	pwS9 __attribute((unused)),					  /* length of last C13 pulse */
         pwN = getval("pwN"),          /* N15 90 degree pulse length at pwNlvl */
 	dpwr2 = getval("dpwr2"),		  /* power for N15 decoupling */
 

--- a/src/biopack/psg/mfpresat.h
+++ b/src/biopack/psg/mfpresat.h
@@ -34,6 +34,7 @@ char    *fnm;
   char     str[MAXSTR];
   double   tm=0.0;
   extern   char curexp[];
+  char *ret __attribute__((unused));
 
   
   (void) sprintf(str, "%s/%s" , curexp, fnm);
@@ -44,7 +45,8 @@ char    *fnm;
     psg_abort(1);
   }
 
-  while ((getc(inpf)) == '#') fgets(str, MAXSTR, inpf);  /* ignore com-s */
+  while ((getc(inpf)) == '#')
+     ret = fgets(str, MAXSTR, inpf);  /* ignore com-s */
   k = ftell(inpf); fseek(inpf, k-1, 0);
 
   j = 0; nn = 0; 
@@ -68,6 +70,7 @@ shape  pbox_mfcw()       /* make mfcw shape */
   int       i, nl;
   char      str[MAXSTR], cmd[MAXSTR], repflg[MAXSTR];
   extern char userdir[];
+  int ret __attribute__((unused));
 
   getstr("repflg", repflg);
 
@@ -94,7 +97,7 @@ shape  pbox_mfcw()       /* make mfcw shape */
   fclose(inpf);
 
   sprintf(cmd, "Pbox mfpresat.DEC -%.0f\n", reps);
-  system(cmd);                                  /* execute Pbox */
+  ret = system(cmd);                                  /* execute Pbox */
   if(reps > 0) printf("  cmd : %s", cmd);
   
   return getDsh("mfpresat");
@@ -109,6 +112,7 @@ double dcyc;
   int       i, nl;
   char      str[MAXSTR], cmd[MAXSTR], repflg[MAXSTR];
   extern char userdir[];
+  int ret __attribute__((unused));
 
   getstr("repflg", repflg);
 
@@ -135,7 +139,7 @@ double dcyc;
   fclose(inpf);
 
   sprintf(cmd, "Pbox mfhdec.DEC -s %.2f -dcyc %.3f, -%.0f\n", 1.0e6*stepsize, dcyc, reps);
-  system(cmd);                                  /* execute Pbox */
+  ret = system(cmd);                                  /* execute Pbox */
   if(reps > 0) printf("  cmd : %s", cmd);
   
   return getDsh("mfhdec");

--- a/src/nvpsg/SConstruct
+++ b/src/nvpsg/SConstruct
@@ -370,6 +370,9 @@ if ('interix' in platform):    # Win7 SUA  or SFU XP Interix
 
 cEnv = cppEnv.Clone()
 cEnv.Append(CPPDEFINES = ['codeint=int', 'codelong=int'])
+
+buildMethods.makeSymLinks(cEnv, paramStaticTarget, cwd, vnmrPath, vnmrHdrList)
+buildMethods.makeSymLinks(cEnv, paramStaticTarget, cwd, vnmrPath, vnmrFileList)
 cparamEnv = cEnv.Clone()
 
 # avoid dependenc cycles use a separate env to build sequence
@@ -386,8 +389,6 @@ else:    # build static for interix
 
 paramStatic = cEnv.StaticLibrary(target  = paramStaticTarget,
                                  source  = vnmrFileList)
-buildMethods.makeSymLinks(cEnv, paramStaticTarget, cwd, vnmrPath, vnmrHdrList)
-buildMethods.makeSymLinks(cEnv, paramStaticTarget, cwd, vnmrPath, vnmrFileList)
 buildMethods.makeSymLinks(cEnv, paramStaticTarget, cwd, ncommPath, srcNcommHeaderList)
 
 if ( ( 'darwin' not in platform ) and ( 'interix' not in platform ) ):
@@ -402,8 +403,8 @@ if (platform=="darwin"):
     paramShared = cparamEnv.SharedLibrary(target  = paramSharedTarget,
                                  source  = vnmrFileList)
     
-buildMethods.makeSymLinks(cparamEnv, paramSharedTarget, cwd, vnmrPath, vnmrHdrList)
-buildMethods.makeSymLinks(cparamEnv, paramSharedTarget, cwd, vnmrPath, vnmrFileList)
+# buildMethods.makeSymLinks(cparamEnv, paramSharedTarget, cwd, vnmrPath, vnmrHdrList)
+# buildMethods.makeSymLinks(cparamEnv, paramSharedTarget, cwd, vnmrPath, vnmrFileList)
 
 psglibStatic = cEnv.StaticLibrary(target  = psglibStaticTarget,
                                   source  = [psgFileList,

--- a/src/nvpsg/chempack.h
+++ b/src/nvpsg/chempack.h
@@ -38,6 +38,7 @@ void shaped_satpulse(const char *shn, double saturation1, codeint sphse1)
   sprintf(shname, "%s_%s",seqfil,shn);
   if (FIRST_FID)
   {
+        int ret __attribute__((unused));
   	uspw90 = (getval("pw90"))*1e6*(getval("tpwr_cf"));
   	sprintf(str, "%s/shapelib/Pbox.inp" , userdir);
   	inpf = fopen(str, "w");
@@ -48,7 +49,7 @@ void shaped_satpulse(const char *shn, double saturation1, codeint sphse1)
   	fclose(inpf);
 
   	sprintf(cmd, "Pbox %s.RF -u %s -%.0f -l %.2f -p %.0f \n", shname,userdir,reps,uspw90,tpwr);
-  	system(cmd);
+  	ret = system(cmd);
   }
   obspower(satpwr);
   shaped_pulse(shname,saturation1,sphse1,rof1,rof1);
@@ -67,6 +68,7 @@ void shaped_saturate(const char *shn2, double saturation2, codeint sphse2)
   sprintf(shname, "%s_%s",seqfil,shn2);
   if (FIRST_FID)
   {
+        int ret __attribute__((unused));
   	uspw90 = (getval("pw90"))*1e6*(getval("tpwr_cf"));
   	sprintf(str, "%s/shapelib/Pbox.inp" , userdir);
   	inpf = fopen(str, "w");
@@ -77,7 +79,7 @@ void shaped_saturate(const char *shn2, double saturation2, codeint sphse2)
   	fclose(inpf);
 
   	sprintf(cmd, "Pbox %s.DEC -u %s -%.0f -l %.2f -p %.0f \n", shname,userdir,reps,uspw90,tpwr);
-  	system(cmd);
+  	ret = system(cmd);
   }
 
   sh = getDsh(shname);

--- a/src/nvpsg/pboxpulse.h
+++ b/src/nvpsg/pboxpulse.h
@@ -131,9 +131,10 @@ PBOXPULSE update_PBOXPULSE(PBOXPULSE shp, int iRec)
       var = getname0("",shp.seqName,"");
       sprintf(shp.pattern,"%s%d_%d",var,shp.nRec,lix);
       if (shp.hasArray == 1) {
+         int ret __attribute__((unused));
 	 sprintf(cmd,"Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f %.2f\" -stepsize 0.2\n",
                 shp.pattern,shp.wv,shp.pw,shp.of,shp.st,shp.ph,shp.fla);
-         system(cmd);
+         ret = system(cmd);
          pboxshp = getRsh(shp.pattern); 
          shp.B1max = pboxshp.B1max; 
       }
@@ -156,7 +157,7 @@ PBOXPULSE combine_PBOXPULSE(PBOXPULSE shp1, PBOXPULSE shp2, int iRec, int calc)
    char *var1, *var2;
    char bar1[256];
    char bar2[256];
-   char cmd[MAXSTR];
+   char cmd[2*MAXSTR];
 
 // The two Shapes must be on the same channel
 
@@ -236,10 +237,11 @@ PBOXPULSE combine_PBOXPULSE(PBOXPULSE shp1, PBOXPULSE shp2, int iRec, int calc)
          strcpy(bar2,var2);  
          sprintf(shp.pattern,"%s%d_%s%d_%d",bar1,shp1.nRec,bar2,shp2.nRec,lix);
          if (shp.hasArray == 1) {
+            int ret __attribute__((unused));
             sprintf(cmd,"Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f %.2f\" \"%s /%.7f %.2f %.2f %.2f %.2f\" -stepsize 0.2" ,
                shp.pattern,shp1.wv,shp1.pw,shp1.of,shp1.st,shp1.ph,shp1.fla, 
                            shp2.wv,shp2.pw,shp2.of,shp2.st,shp2.ph,shp2.fla);
-            system(cmd);
+            ret = system(cmd);
             pboxshp = getRsh(shp.pattern); 
             shp.B1max = pboxshp.B1max; 
          }
@@ -349,9 +351,10 @@ PBOXPULSE getpboxpulse(char *seqName, int iRec, int calc)
       var = getname0("",shp.seqName,"");
       sprintf(shp.pattern,"%s%d_%d",var,shp.nRec,lix);
       if (shp.hasArray == 1) {
+         int ret __attribute__((unused));
 	 sprintf(cmd,"Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f %.2f\" -stepsize 0.2\n",
                 shp.pattern,shp.wv,shp.pw,shp.of,shp.st,shp.ph,shp.fla);
-         system(cmd);
+         ret = system(cmd);
          pboxshp = getRsh(shp.pattern); 
          shp.B1max = pboxshp.B1max; 
       }
@@ -453,9 +456,10 @@ PBOXPULSE getrefpboxpulse(char *seqName, int iRec, int calc)
       var = getname0("",shp.seqName,"");
       sprintf(shp.pattern,"%s%d_%d",var,shp.nRec,lix);
       if (shp.hasArray == 1) {
+         int ret __attribute__((unused));
          sprintf(cmd,"Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f\" -stepsize 0.2 -p %2.0f -l %f -attn e\n",
                 shp.pattern,shp.wv,shp.pw,shp.of,shp.st,shp.ph,ref_db,ref_pw);
-         system(cmd);
+         ret = system(cmd);
       }
    }
 

--- a/src/nvpsg/seqgenmake
+++ b/src/nvpsg/seqgenmake
@@ -22,7 +22,7 @@
 SHELL=/bin/sh
 CFLAGS= -O
 NVFLAGS= -Dcodeint=int -Dcodelong=int -DNVPSG
-WFLAGS= -Wall -Wno-return-type -Wno-implicit-int -Wno-unused-variable -Wno-switch -Wno-format-security
+WFLAGS= -Wall -Wno-return-type -Wno-implicit-int -Wno-unused-variable -Wno-format-security
 CPPFLAGS=
 LDFLAGS=
 LNFLAGS=

--- a/src/nvpsg/sglAdditions.c
+++ b/src/nvpsg/sglAdditions.c
@@ -793,7 +793,7 @@ double writeOutputGradientDBStr(SGL_GRADIENT_T *aOutputGradient,
 {
    char *gradParams;
    char _tempname[MAX_STR];
-   int	_error;
+   int	_error __attribute__((unused));
 	int _startIdx, _endIdx;
 	
 	double *_vec;

--- a/src/nvpsg/sglCommon.c
+++ b/src/nvpsg/sglCommon.c
@@ -3662,6 +3662,7 @@ void readGradientHeader(GRADIENT_HEADER_T *header, FILE *fpin)
    char inString[MAX_STR];
    char seekString[GRAD_HEADER_ENTRIES][MAX_STR];
    long counter;
+   int ret __attribute__((unused));
 
    /* initialize variables */
    counter = 1;       /* loop counter */
@@ -3674,13 +3675,13 @@ void readGradientHeader(GRADIENT_HEADER_T *header, FILE *fpin)
    counter = 0; /* initialize counter */
    while (!feof(fpin) && (counter < (int)GRAD_HEADER_ENTRIES))
    {
-      fscanf(fpin, "%s", inString); /* read string from file */
+      ret = fscanf(fpin, "%s", inString); /* read string from file */
 
       /* assign value if string was found */
       /* check if string has been found */
       if (strstr(inString, seekString[counter]))
       {
-         fscanf(fpin, "%s", inString); /* read value following string */
+         ret = fscanf(fpin, "%s", inString); /* read value following string */
 
          /* assign values to structure */
          switch ((GRADIENT_HEADER_ENTRIES_T)counter)
@@ -3749,6 +3750,7 @@ void readRfPulse (RF_PULSE_T *rfPulse)
    long safetyCheck;
    long searchSteps;
    FILE *fpin;
+   int ret __attribute__((unused));
 
    /* initialize variables */
    counter     = 1;     /* loop counter */
@@ -3790,12 +3792,12 @@ void readRfPulse (RF_PULSE_T *rfPulse)
    counter = 0; /* initialize counter */
    do
    {
-      fscanf(fpin, "%s", inString); /* read string from file */
+      ret = fscanf(fpin, "%s", inString); /* read string from file */
       /* assign value if string was found */
       /* check if string has been found */
       if (strstr(inString, seekString[counter]))
       {
-         fscanf(fpin, "%s", inString); /* read value following string */
+         ret = fscanf(fpin, "%s", inString); /* read value following string */
          /* assign values to structure -> order is important ! */
          switch ((RF_PULSE_HEADER_ENTRIES_T)counter)
          {
@@ -3974,7 +3976,7 @@ void calcSlice (SLICE_SELECT_GRADIENT_T *slice, RF_PULSE_T *rfPulse)
       return;
    }
 
-   if (slice->rampShape == GAUSS)
+   if (slice->rampShape == PRIMITIVE_GAUSS)
    {
       slice->error = ERR_RAMP_SHAPE;
       displayError(slice->error, __FILE__, __FUNCTION__, __LINE__);
@@ -4502,7 +4504,7 @@ void calcRefocus (REFOCUS_GRADIENT_T *refocus)
       displayError(refocus->error, __FILE__, __FUNCTION__, __LINE__);
       return;
    }
-   if (refocus->rampShape == GAUSS)
+   if (refocus->rampShape == PRIMITIVE_GAUSS)
    {
       refocus->error = ERR_RAMP_SHAPE;
       displayError(refocus->error, __FILE__, __FUNCTION__, __LINE__);
@@ -4703,7 +4705,7 @@ void calcReadout (READOUT_GRADIENT_T *ro)
       displayError(ro->error, __FILE__, __FUNCTION__, __LINE__);
       return;
    }
-   if (ro->rampShape == GAUSS || ro->rampShape == SINE) 
+   if (ro->rampShape == PRIMITIVE_GAUSS || ro->rampShape == PRIMITIVE_SINE) 
    {
       ro->error = ERR_RAMP_SHAPE;
       displayError(ro->error, __FILE__, __FUNCTION__, __LINE__);
@@ -5195,7 +5197,7 @@ void calcDephase (REFOCUS_GRADIENT_T *dephase)
       return;
    }
 
-   if (dephase->rampShape == GAUSS)
+   if (dephase->rampShape == PRIMITIVE_GAUSS)
    {
       dephase->error = ERR_RAMP_SHAPE;
       displayError(dephase->error, __FILE__, __FUNCTION__, __LINE__);
@@ -5351,7 +5353,7 @@ void calcPhase (PHASE_ENCODE_GRADIENT_T *phase)
       displayError(phase->error, __FILE__, __FUNCTION__, __LINE__);
       return;
    }
-   if (phase->rampShape == GAUSS)
+   if (phase->rampShape == PRIMITIVE_GAUSS)
    {
       phase->error = ERR_RAMP_SHAPE;
       displayError(phase->error, __FILE__, __FUNCTION__, __LINE__);
@@ -6153,7 +6155,7 @@ void calcReadoutFlowcomp(FLOWCOMP_T *fc, READOUT_GRADIENT_T *readout)
 			int    noIterator;      /* Number of iterations */
 			int    maxIterations;   /* Max number of iterations */
    double deltaT;          /* time shift for 2nd lobe  */
-   double slew;            /* gradient slew */
+//   double slew;            /* gradient slew */
    MERGE_GRADIENT_T mg1;
    MERGE_GRADIENT_T mg2;
 //   char grad_params[MAX_STR];
@@ -6184,7 +6186,7 @@ void calcReadoutFlowcomp(FLOWCOMP_T *fc, READOUT_GRADIENT_T *readout)
    area            = fabs(readout->m0ref);
    areaSquare      = area * area;
    rampAreaSquared = rampArea * rampArea;
-   slew            = risetime / GRAD_MAX;
+//   slew            = risetime / GRAD_MAX;
    areaLobe1       = 0.0;
    areaLobe2       = 0.0;
 			momentLobe1     = 0.0;
@@ -6601,9 +6603,10 @@ int mergeGradient (char *waveform1, char *waveform2,
    char   start[MAX_STR];
    char   inString1[MAX_STR], inString2[MAX_STR];
    long   dacValue;
-   long   counter;
+//   long   counter;
    long   points1, points2; /* points from header, calc points*/
    double scale;
+   int ret __attribute__((unused));
 			
    GRADIENT_HEADER_T header1;
    GRADIENT_HEADER_T header2;
@@ -6613,7 +6616,7 @@ int mergeGradient (char *waveform1, char *waveform2,
    FILE   *fpout;
 
    /* initialize variables */
-   counter = 1; /* conter variable */
+//   counter = 1; /* conter variable */
    points1 = 0; /* points for merged waveform from headers*/
    points2 = 0; /* points for merged waveform ticks*/
    error   = ERR_NO_ERROR; /* error flag */
@@ -6711,12 +6714,12 @@ int mergeGradient (char *waveform1, char *waveform2,
    /* scaling factor to normalize gradient scale */
    while (!strstr(inString1, start))
    {
-      fscanf(fpin1, "%s", inString1);
+      ret = fscanf(fpin1, "%s", inString1);
    }
    while (!feof(fpin1))
    {
       /* read waveform values */
-      fscanf(fpin1, "%s %s", inString1, inString2);
+      ret = fscanf(fpin1, "%s %s", inString1, inString2);
 
       if (!feof(fpin1))
       {
@@ -6748,11 +6751,11 @@ int mergeGradient (char *waveform1, char *waveform2,
 
    while (!strstr(inString1, start))
    {
-      fscanf(fpin1, "%s", inString1);
+      ret = fscanf(fpin1, "%s", inString1);
    }
    while (!feof(fpin2))
    {
-      fscanf(fpin2, "%s %s", inString1, inString2);
+      ret = fscanf(fpin2, "%s %s", inString1, inString2);
       if ( !feof(fpin2) )
       {
          /* normalize waveform values */
@@ -7535,7 +7538,7 @@ void durationFromMomentRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int crusherNum)
 {
 
    CALC_FLAG_T *calcFlag;
-   double *slewRate;
+//   double *slewRate;
    double *crAmplitude;
    double *crDuration;
 
@@ -7547,24 +7550,24 @@ void durationFromMomentRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int crusherNum)
    double *rampToCrDuration;
    double *rampToSsDuration;
    
-   double polarity;
-   double tempSlew;
-			double tempMoment;
-			double tempRamp1;
-			double tempRamp2;
+//   double polarity;
+//   double tempSlew;
+//			double tempMoment;
+//			double tempRamp1;
+//			double tempRamp2;
 			
    crError= 0;
-   polarity = 1.0;
-			tempSlew = 0.0;
-			tempMoment = 0.0;
-			tempRamp1 = 0.0;
-			tempRamp2 = 0.0;
+//   polarity = 1.0;
+//			tempSlew = 0.0;
+//			tempMoment = 0.0;
+//			tempRamp1 = 0.0;
+//			tempRamp2 = 0.0;
 			
    /* copy pointers */
 			if (crusherNum == 1)
    {
       calcFlag         = &bfly->cr1CalcFlag;
-      slewRate         = &bfly->cr1.slewRate;
+ //     slewRate         = &bfly->cr1.slewRate;
       crAmplitude      = &bfly->cr1amp;
       crDuration       = &bfly->cr1.duration;
       crError          = &bfly->cr1.error;
@@ -7578,7 +7581,7 @@ void durationFromMomentRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int crusherNum)
    else if (crusherNum == 2)
    {
       calcFlag         = &bfly->cr2CalcFlag;
-      slewRate         = &bfly->cr2.slewRate;
+//      slewRate         = &bfly->cr2.slewRate;
       crAmplitude      = &bfly->cr2amp;
       crDuration       = &bfly->cr2.duration;
       crError          = &bfly->cr2.error;
@@ -7596,10 +7599,10 @@ void durationFromMomentRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int crusherNum)
       return;
    }   
 
-   if (FP_LT(*crMoment0,0))
-   {
-      polarity = -1.0;
-   }		
+//   if (FP_LT(*crMoment0,0))
+//   {
+//      polarity = -1.0;
+//   }		
 			
 			/* ss amplitude must be supplied or we don't know what to ramp down to */
    if(bfly->ssamp == 0)
@@ -7675,7 +7678,7 @@ void durationFromMomentRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int crusherNum)
 ***********************************************************************/
 void momentFromDurationAmplitudeRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int crusherNum)
 {
-   double *slewRate;
+//   double *slewRate;
    double *crAmplitude;
    double *crDuration;
    ERROR_NUM_T *crError;
@@ -7691,7 +7694,7 @@ void momentFromDurationAmplitudeRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int cr
    /* copy pointers */
    if (crusherNum == 1)
    {
-      slewRate        = &bfly->cr1.slewRate;
+ //     slewRate        = &bfly->cr1.slewRate;
       crAmplitude     = &bfly->cr1amp;
       crDuration      = &bfly->cr1.duration;
       crError         = &bfly->cr1.error;
@@ -7704,7 +7707,7 @@ void momentFromDurationAmplitudeRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int cr
    }
    else if (crusherNum == 2)
    {
-      slewRate        = &bfly->cr2.slewRate;
+//      slewRate        = &bfly->cr2.slewRate;
       crAmplitude     = &bfly->cr2amp;
       crDuration      = &bfly->cr2.duration;
       crError         = &bfly->cr2.error;
@@ -7783,13 +7786,13 @@ void momentFromDurationAmplitudeRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int cr
 ***********************************************************************/
 void amplitudeFromMomentDurationRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int crusherNum)
 {
-   double *slewRate;
+//   double *slewRate;
    double *crAmplitude;
    double *crDuration;
    ERROR_NUM_T *crError;
    double *crTotalDuration;
    double *crMoment0;
-   double *crResolution;
+//   double *crResolution;
 
    double *rampToCrDuration;
    double *rampToSsDuration;
@@ -7799,12 +7802,12 @@ void amplitudeFromMomentDurationRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int cr
    /* copy pointers */
    if (crusherNum == 1)
    {
-      slewRate        = &bfly->cr1.slewRate;
+//      slewRate        = &bfly->cr1.slewRate;
       crAmplitude     = &bfly->cr1amp;
       crDuration      = &bfly->cr1.duration;
       crError         = &bfly->cr1.error;
       crMoment0       = &bfly->cr1Moment0;
-      crResolution    = &bfly->cr1.resolution;
+//      crResolution    = &bfly->cr1.resolution;
       crTotalDuration = &bfly->cr1TotalDuration;
 
       rampToCrDuration = &bfly->ramp1.duration;
@@ -7812,12 +7815,12 @@ void amplitudeFromMomentDurationRampButterfly(BUTTERFLY_GRADIENT_T *bfly, int cr
    }
    else if (crusherNum == 2)
    {
-      slewRate        = &bfly->cr2.slewRate;
+//      slewRate        = &bfly->cr2.slewRate;
       crAmplitude     = &bfly->cr2amp;
       crDuration      = &bfly->cr2.duration;
       crError         = &bfly->cr2.error;
       crMoment0       = &bfly->cr2Moment0;
-      crResolution    = &bfly->cr2.resolution;
+//      crResolution    = &bfly->cr2.resolution;
       crTotalDuration = &bfly->cr2TotalDuration;
 
       rampToCrDuration = &bfly->ramp4.duration;
@@ -9899,7 +9902,7 @@ void calcPrimitive (PRIMITIVE_GRADIENT_T *prim)
       displayError(prim->error, __FILE__, __FUNCTION__, __LINE__);
       return;
    }
-   if ((prim->shape.function == SINE || prim->shape.function == GAUSS) &&
+   if ((prim->shape.function == PRIMITIVE_SINE || prim->shape.function == PRIMITIVE_GAUSS) &&
        FP_GT(prim->shape.startX, prim->shape.endX))
    {
       /* endX should be less than startX */
@@ -10540,6 +10543,7 @@ void calcPower (RF_PULSE_T *rf_pulse, char rfcoil[MAX_STR])
    double powerCoarse =0;                         /* RF power coarse */
    double attnStep = 0;                           /* attenuation step size */
    double flipangle;                              /* product of flip*flipmult */
+   int ret __attribute__((unused));
    
    /* assign attenuation step size */
    if (CATTN_MAX < 127)
@@ -10615,7 +10619,7 @@ void calcPower (RF_PULSE_T *rf_pulse, char rfcoil[MAX_STR])
   /* find coil entry */ 
    do
    {
-      fscanf(fpin, "%s", coil);  
+      ret = fscanf(fpin, "%s", coil);
    }    
    while ( (strcmp(rfcoil,coil) ) &&  (!feof(fpin)) );
    if (feof(fpin))
@@ -10626,7 +10630,7 @@ void calcPower (RF_PULSE_T *rf_pulse, char rfcoil[MAX_STR])
       return;
    }
    /* read calibration entries */
-   fscanf(fpin,"%f %f %f ",&calPulseWidth,&calFlip,&calPower);
+   ret = fscanf(fpin,"%f %f %f ",&calPulseWidth,&calFlip,&calPower);
  
    /* close RF calibration file */  
    fclose(fpin);

--- a/src/nvpsg/sglCommon.h
+++ b/src/nvpsg/sglCommon.h
@@ -77,9 +77,9 @@
 /* floating point comparison macros */
 #define EPSILON 1e-9      /* largest allowable deviation due to floating */
                			/* point storage */
-#define FP_LT(A,B) (((A) < (B)) && (fabs((A) - (B)) > EPSILON)) /* A less than B */
-#define FP_GT(A,B) (((A) > (B)) && (fabs((A) - (B)) > EPSILON)) /* A greater than B */
-#define FP_EQ(A,B) (fabs((A) - (B)) <= EPSILON)             /* A equal to B */
+#define FP_LT(A,B) (((A) < (B)) && (fabs((double)(A) - (double)(B)) > EPSILON)) /* A less than B */
+#define FP_GT(A,B) (((A) > (B)) && (fabs((double)(A) - (double)(B)) > EPSILON)) /* A greater than B */
+#define FP_EQ(A,B) (fabs((double)(A) - (double)(B)) <= EPSILON)             /* A equal to B */
 
 /* A not equal to B */
 #define FP_NEQ(A,B) (!FP_EQ(A,B))
@@ -92,9 +92,9 @@
 
 /* custom floating point comparison macros */
 /* these allow you to set EPSILON on a case by case basis */
-#define FPC_LT(A,B,EPSILON_C) (((A) < (B)) && (fabs((A) - (B)) > (EPSILON_C))) /* A less than B */
-#define FPC_GT(A,B,EPSILON_C) (((A) > (B)) && (fabs((A) - (B)) > (EPSILON_C))) /* A greater than B */
-#define FPC_EQ(A,B,EPSILON_C) ((fabs((A) - (B))) <= (EPSILON_C))             /* A equal to B */
+#define FPC_LT(A,B,EPSILON_C) (((A) < (B)) && (fabs((double)(A) - (double)(B)) > (EPSILON_C))) /* A less than B */
+#define FPC_GT(A,B,EPSILON_C) (((A) > (B)) && (fabs((double)(A) - (double)(B)) > (EPSILON_C))) /* A greater than B */
+#define FPC_EQ(A,B,EPSILON_C) ((fabs((double)(A) - (double)(B))) <= (EPSILON_C))             /* A equal to B */
 
 /* A not equal to B */
 #define FPC_NEQ(A,B,EPSILON_C) (!FPC_EQ(A,B,EPSILON_C))

--- a/src/nvpsg/sglEPI.c
+++ b/src/nvpsg/sglEPI.c
@@ -291,7 +291,8 @@ void calc_epi(EPI_GRADIENT_T          *epi_grad,
               int write_flag) {
 
   /* Variables for generating gradient shapes */
-  double dwint,blipint,skip,dw;
+//  double dwint;
+  double blipint,skip,dw;
   int    np_ramp, np_flat, npro;
   double *dwell, *dac;
   double pos, neg;
@@ -409,7 +410,7 @@ void calc_epi(EPI_GRADIENT_T          *epi_grad,
   calcReadout(ro_grad);
 
   dw    = granularity(1/sw,1/epi_grad->ddrsr);
-  dwint = dw*ro_grad->amp;
+//  dwint = dw*ro_grad->amp;
 
   skip  = getval("skip");              /* User specified min delay between acquisitions */
   skip  = MAX(skip,pe_grad->duration); /* Is PE blip longer? Then use that */

--- a/src/nvpsg/sglGradientLists.c
+++ b/src/nvpsg/sglGradientLists.c
@@ -643,6 +643,8 @@ double getMomentOfNode( struct SGL_GRAD_NODE_T *aGradNode )
 			case READOUT_GRADIENT_TYPE:
 				moment = aGradNode->grad->_as_READOUT_GRADIENT.m0;
 				break;
+                        default:
+				break;
 		}
 	} else {
 		moment = 0;
@@ -1662,7 +1664,8 @@ void add_gradient( SGL_GRADIENT_T *grad, char *label, SGL_LOGICAL_AXIS_T logical
 					SGL_GRAD_PLACEMENT_ACTION_T action, char *refLabel,
 					double actionTime, SGL_CHANGE_POLARITY_T polarity )
 {
-	double _eventStart, _totalTime;
+	double _eventStart __attribute__((unused));
+        double _totalTime;
 	
 	_eventStart = addToGradList( workingList, grad, label, logicalAxis,
 						action, refLabel, actionTime, polarity, &_totalTime );
@@ -1670,7 +1673,8 @@ void add_gradient( SGL_GRADIENT_T *grad, char *label, SGL_LOGICAL_AXIS_T logical
 
 void add_marker( char *label, SGL_GRAD_PLACEMENT_ACTION_T action, char *refLabel, double actionTime )
 {
-	double _eventStart, _totalTime;
+	double _eventStart __attribute__((unused));
+        double _totalTime;
 	
 	_eventStart = addToGradList( workingList, (void *)&marker, label, MARKER,
 						action, refLabel, actionTime, PRESERVE, &_totalTime );

--- a/src/nvpsg/sglHelper.c
+++ b/src/nvpsg/sglHelper.c
@@ -586,6 +586,8 @@ void calc_diffTime(DIFFUSION_T *diffusion,double *temin)
         diffusion->d1 = GRADIENT_RES;
       }
       break;
+    default:
+      break;
   }
 
   /* calculate the duration of all diffusion components */
@@ -1731,9 +1733,9 @@ void sgl_abort_message(char *format, ...)
   va_end(vargs);
 
   if (!sglabort)
-    abort_message(msg);
+    abort_message("%s",msg);
   else
-    warn_message(msg);
+    warn_message("%s",msg);
 
   sglerror = 2;  /* We've already printed some error messages, 
                     no need to print an error in error_check */

--- a/src/nvpsg/sglPrepulses.c
+++ b/src/nvpsg/sglPrepulses.c
@@ -212,7 +212,7 @@ if (mt[0] == 'y')
 ***********************************************************************/
 void create_satbands()
 {
-	int     nthk,npos,npsi,nphi,ntheta,i,_i;
+	int     nthk,npos,npsi,nphi,ntheta,i;
 	double  minthk;
 	
 	if( sat[0] == 'y' )
@@ -632,7 +632,8 @@ void create_arterial_spin_label()
   int caslsinemod=FALSE;
   int stardoubletag=FALSE;
   double power,powerlimit,aslb1max,fpwrscale;
-  double minpss,maxpss,centrepss;
+  double minpss,maxpss;
+//  double centrepss;
   double *pssval,*controlpos;
   int npssvals,sliceindex=0;
   double tmpval;
@@ -654,9 +655,9 @@ void create_arterial_spin_label()
   int vnps      = virblock;     /* Number of PS pulses */
   int vnips     = vnirpulses;   /* Number of IPS pulses */
   int vnq2      = vir;          /* Number of Q2TIPS pulses */
-  int vspoil    = virslice_ctr; /* Gradient spoil multiplier */
-  int vloop_ctr = vnir;         /* Loop counter */
-  int vpwrf     = vnir_ctr;     /* Fine power */
+//  int vspoil    = virslice_ctr; /* Gradient spoil multiplier */
+//  int vloop_ctr = vnir;         /* Loop counter */
+//  int vpwrf     = vnir_ctr;     /* Fine power */
 
   if (asl[0] == 'y') {
 
@@ -1308,6 +1309,7 @@ double calc_aslTime(double asladd,double trepmin,int *treptype)
     */
     /* Only perform auto calculation for first array element */
     if (autoirtime[0]=='y' && ix==1) {
+      int ret __attribute__((unused));
       /* Figure the number of T1s and get their values */
       P_getVarInfo(CURRENT,"mirt1",&dvarinfo);
       getarray("mirt1",mirt1);
@@ -1320,7 +1322,7 @@ double calc_aslTime(double asladd,double trepmin,int *treptype)
       /* Check that the aslmirtime binary is present */
       sprintf(timefile,"/tmp/aslmirtimestatus_%s",getenv("USER"));
       sprintf(timecmd,"which aslmirtime > %s",timefile);
-      system(timecmd);
+      ret = system(timecmd);
       if (stat(timefile,&buf) == -1)
         abort_message("calc_aslTime MIR error: Unable to access file /tmp/aslmirtimestatus\n");
       if (buf.st_size == 0)
@@ -1330,7 +1332,7 @@ double calc_aslTime(double asladd,double trepmin,int *treptype)
       sprintf(timecmd,"aslmirtime -n %d -d %f -t %d",nmir,mirTime,(int)dvarinfo.size);
       for (i=0;i<(int)dvarinfo.size;i++) sprintf(timecmd,"%s %f",timecmd,mirt1[i]);
       /* Execute the system call */
-      system(timecmd);
+      ret = system(timecmd);
       sprintf(timefile,"/tmp/aslmirtime_%s.txt",getenv("USER"));
       /* Open timefile for reading */
       if ((fp=fopen(timefile,"r")) == NULL)
@@ -1463,7 +1465,7 @@ void arterial_spin_label()
   int vpwrf     = vnir_ctr;     /* Fine power */
   /* Use more meaningful names for v41,v42 */
   int vnmir     = v42;          /* Number of MIR pulses (before Q2TIPS if q2tips='y') */
-  int vnmirq2   = v41;          /* Number of MIR pulses after Q2TIPS (if q2tips='y') */
+//  int vnmirq2   = v41;          /* Number of MIR pulses after Q2TIPS (if q2tips='y') */
 
   if (asl[0] == 'y') {
 

--- a/src/nvpsg/sglWrappers.c
+++ b/src/nvpsg/sglWrappers.c
@@ -775,6 +775,8 @@ void init_rf (RF_PULSE_T *rf, char rfName[MAX_STR], double pw, double flip,
      case ERR_RF_HEADER_ENTRIES:
        sgl_abort_message("ERROR rf shape '%s': incorrect header information",rfName);
        break;
+     default:
+       break;
    }
    if ((rf->header.rfFraction < 0) || (rf->header.rfFraction > 1))
      sgl_abort_message("ERROR rf shape '%s': RF Fraction must be between 0 and 1",rfName);
@@ -830,6 +832,8 @@ void shape_rf (RF_PULSE_T *rf, char rfBase[MAX_STR], char rfName[MAX_STR], doubl
      case ERR_RF_HEADER_ENTRIES:
        sgl_abort_message("ERROR rf shape '%s': incorrect header information",rfName);
        break;
+     default:
+       break;
    }
    if ((rf->header.rfFraction < 0) || (rf->header.rfFraction > 1))
      sgl_abort_message("ERROR rf shape '%s': RF Fraction must be between 0 and 1",rfName);
@@ -856,6 +860,8 @@ void calc_rf (RF_PULSE_T *rf, char VJparam_tpwr[], char VJparam_tpwrf[])
      case ERR_RFPOWER_COARSE:
        sgl_abort_message("ERROR rf pulse '%s': Coarse power too large (pw = %.2fus, flip = %.2f",
          rf->pulseName, rf->rfDuration*1e6,rf->flip);
+     default:
+       break;
    }
 
    if ((rf->flip >= 0) && (!sglpower) && (ix == 1)) {

--- a/src/nvpsg/sgl_ws.c
+++ b/src/nvpsg/sgl_ws.c
@@ -78,7 +78,7 @@ void get_wsparameters() {
 void create_ovsbands() {
   double posoff;        /* positional offset relative to voxel position */
   double csdvox,csdovs; /* chemical shift displacement errors */
-  int sglpowerSave;
+//  int sglpowerSave;
 
   if (ovs[0] == 'y') {
   

--- a/src/nvpsg/solidchoppers.h
+++ b/src/nvpsg/solidchoppers.h
@@ -33,7 +33,7 @@ SHAPE make_shape(SHAPE s)
 {
    FILE *fp;
    extern char userdir[];
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[3*MAXSTR],str[MAXSTR+16];
    int ntick,nstep,nrpuls,naccumpuls,nstub,nindex,chnl,ninit,ntot,npuls;
    double t,dph,ph,phShape,phCurrent,phLast,phOut,ph0Out,phInc,aCurrent,
           aLast,aOut,a0Out,aInc,gCurrent,gLast,gOut,phase;
@@ -276,9 +276,10 @@ SHAPE make_shape1(SHAPE s)
 {
    FILE *fp;
    extern char userdir[];
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[3*MAXSTR],str[MAXSTR+16];
    int ntick,nstep,nrpuls,naccumpuls,nstub,nindex,chnl,ninit,ntot,npuls;
-   double t,dph,ph,phShape,phCurrent,phLast,phOut,ph0Out,phInc,aCurrent,
+   double phInc __attribute__((unused));
+   double t,dph,ph,phShape,phCurrent,phLast,phOut,ph0Out,aCurrent,
           aLast,aOut,a0Out,aInc,gCurrent,gLast,gOut,phase;
    STATE state;
 
@@ -645,7 +646,7 @@ MPSEQ MPchopper(MPSEQ seq)
 
    FILE *fp;
    extern char userdir[];
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[3*MAXSTR],str[MAXSTR+16];
    int npuls,iph,ntick,nrpuls,naccumpuls,nindex,nstub,nstep,chnl,ninit,ntotal,ntot;
    int i = 0;
    double phase,ph,t,dph,phCurrent,phLast,phOut,ph0Out,phInc,
@@ -928,7 +929,7 @@ CP make_cp(CP cp)
 {
    FILE *fp;
    extern char userdir[];
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[3*MAXSTR],str[MAXSTR+16];
    int ntick,nstep,nrpuls,naccumpuls,nstub,nindex,chnl,ninit,ntot;
    double norm,mean,at,t,ph,dph,phCurrent,phLast,phOut,ph0Out,phInc,
           aCurrent,aLast,aOut,a0Out,aInc,gOut,phase;  

--- a/src/nvpsg/soliddecshapes.h
+++ b/src/nvpsg/soliddecshapes.h
@@ -529,7 +529,7 @@ PARIS getparis(char *name)
 
 void make_tppm(TPPM dec)
 {
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[MAXSTR+16],str[3*MAXSTR];
    FILE *fp;
    int i;
    extern char userdir[];
@@ -627,7 +627,7 @@ void _tppm(TPPM dec)
 
 void make_spinal(SPINAL dec)
 {
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[MAXSTR+16],str[3*MAXSTR];
    FILE *fp;
    extern char userdir[];
    int n,i;
@@ -726,7 +726,7 @@ void _spinal(SPINAL dec)
 
 void make_spinal2(SPINAL2 dec)
 {
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[MAXSTR+16],str[3*MAXSTR];
    FILE *fp;
    extern char userdir[];
    int n,i;
@@ -825,7 +825,7 @@ void _spinal2(SPINAL2 dec)
 
 void make_waltz(WALTZ dec)
 {
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[MAXSTR+16],str[3*MAXSTR];
    FILE *fp;
    extern char userdir[];
    int i;
@@ -924,7 +924,7 @@ void _waltz(WALTZ dec)
 
 void make_paris(PARIS p)
 {
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[MAXSTR+16],str[3*MAXSTR];
    FILE *fp;
    extern char userdir[];
    int i;
@@ -1191,7 +1191,7 @@ void dseqoff_emergency(char* message)
      decprgoff();
      dec2prgoff();
      dec3prgoff();
-     abort_message(message);
+     abort_message("%s",message);
 }
 
 void _dseqon(DSEQ dseq)

--- a/src/nvpsg/solidelements.h
+++ b/src/nvpsg/solidelements.h
@@ -274,7 +274,7 @@ char varName[MAXSTR];
 
 char* getname0(char *varType, char *varSuffix, char *chXtra)
 {
-   int i,chCount, descrCount, typeCount, capCount;
+   int i, descrCount, typeCount, capCount;
    extern char varName[];
    char chDescr[MAXSTR];
    char chSeqType[MAXSTR];
@@ -288,7 +288,7 @@ char* getname0(char *varType, char *varSuffix, char *chXtra)
 // Will fail if the caps section contains digits
 //====================================================================
     
-   chCount = 0; descrCount = 0;typeCount = 0; capCount = 0;
+   descrCount = 0;typeCount = 0; capCount = 0;
    for (i = 0; i< strlen(varSuffix); i++){
       if (islower(varSuffix[i]) || isdigit(varSuffix[i])) {
          if (capCount == 0) chSeqType[typeCount++] = varSuffix[i];
@@ -319,7 +319,7 @@ char* getname0(char *varType, char *varSuffix, char *chXtra)
 
 char* getname1(char *varType, char *varSuffix, int chnl)
 {
-   int i,chCount, descrCount, typeCount, capCount;
+   int i, descrCount, typeCount, capCount;
    extern char varName[];
    char chDescr[MAXSTR];
    char chSeqType[MAXSTR];
@@ -333,7 +333,7 @@ char* getname1(char *varType, char *varSuffix, int chnl)
 // Will fail if the caps section contains digits
 //================================================================
 
-   chCount = 0; descrCount = 0;typeCount = 0; capCount = 0;
+   descrCount = 0;typeCount = 0; capCount = 0;
    for (i = 0; i< strlen(varSuffix); i++) {
       if (islower(varSuffix[i]) || isdigit(varSuffix[i])) {
          if (capCount == 0) chSeqType[typeCount++] = varSuffix[i];

--- a/src/nvpsg/solidhhdec.h
+++ b/src/nvpsg/solidhhdec.h
@@ -62,7 +62,7 @@ MPDEC getmpdec(char *name, int iph , double p, double phint, int iRec, int calc)
 {
    MPDEC d;
    char *var;
-   sprintf(d.seqName,name);
+   strcpy(d.seqName,name);
    var = getname0("seq",d.seqName,"");
    Getstr(var,d.seq,sizeof(d.seq));
 
@@ -74,7 +74,7 @@ MPDEC getmpdec(char *name, int iph , double p, double phint, int iRec, int calc)
 // mpsName - seqName for mpseq
 
    var = getname0(d.seq,d.seqName,"");
-   sprintf(d.mpsName,d.seq);
+   strcpy(d.mpsName,d.seq);
    var = getname0("",d.seqName,"");
    strncat(d.mpsName,var,1);
 
@@ -110,7 +110,7 @@ MPDEC setmpdec(char *name, int iph, double p, double phint, int iRec, int calc)
 {
    MPDEC d;
    char *var;
-   sprintf(d.seqName,name);
+   strcpy(d.seqName,name);
    var = getname0("seq",d.seqName,"");
    Getstr(var,d.seq,sizeof(d.seq));
 
@@ -837,7 +837,7 @@ MPSEQ getpmlgsuper(char *seqName, int iph ,double p, double phint, int iRec, int
       printf("Error in getpmlgsuper(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(pm.seqName,seqName);
+   strcpy(pm.seqName,seqName);
    pm.calc = calc;
    pm.array = parsearry(pm.array);
 
@@ -912,18 +912,15 @@ MPSEQ getpmlgsuper(char *seqName, int iph ,double p, double phint, int iRec, int
 
    double obsstep = 360.0/8192;
    double delta = 360.0/(sqrt(3)*nsteps);
-   double val = 0.0;
    for (i = 0; i < pm.nphBase/j; i++) {
       k = ccw + mPMLG*i;
       pm.phBase[k] = sign*(i*delta + delta/2.0);
       pm.phBase[k] = roundphase(pm.phBase[k],obsstep);
-      val = pm.phBase[k];
    }
    for (i = pm.nphBase/j; i < 2*pm.nphBase/j; i++) {
       k = ccw + mPMLG*i;
       pm.phBase[k] = 180.0 + sign*((2*nsteps - i)*delta - delta/2.0);
       pm.phBase[k] = roundphase(pm.phBase[k],obsstep);
-      val = pm.phBase[k];
    }
    if ( j%4 == 0 ) {
       for (i = 0; i < pm.nphBase/2; i++) pm.phBase[nphBase - 1 - i] = pm.phBase[i];

--- a/src/nvpsg/solidmpseqs.h
+++ b/src/nvpsg/solidmpseqs.h
@@ -1345,16 +1345,13 @@ MPSEQ getpmlg(char *seqName, int iph ,double p, double phint, int iRec, int calc
 
    double obsstep = 360.0/8192;
    double delta = 360.0/(sqrt(3)*nsteps);
-   double val = 0.0;
    for (i = 0; i < pm.nphBase/2; i++) {
       pm.phBase[i] = sign*(i*delta + delta/2.0);
       pm.phBase[i] = roundphase(pm.phBase[i],obsstep);
-      val = pm.phBase[i];
    }
    for (i = pm.nphBase/2; i < pm.nphBase; i++) {
       pm.phBase[i] = 180.0 + sign*((2*nsteps - i)*delta - delta/2.0);
       pm.phBase[i] = roundphase(pm.phBase[i],obsstep);
-      val = pm.phBase[i];
    }
 
 // Set the Supercycle Phase List
@@ -2579,7 +2576,12 @@ MPSEQ getgrapt(char *seqName, double p, double phint, int iRec, int calc)
    double pw = getval(var);
    r.array = disarry(var, r.array);
 
-   double dstep = r.n90*DTCK;
+   double dstep;
+
+   if (PWRF_DELAY > 0.0)
+      dstep =  INOVAN90 * DTCK;
+   else
+      dstep =  VNMRSN90 * DTCK;
    double steps = pw/(2.0*dstep);
    int nsteps = 2*((int) (steps + 0.5));
    r.array = disarry(var, r.array);
@@ -3848,7 +3850,7 @@ MPSEQ getptrfdr(char *seqName, int iph, double p, double phint, int iRec, int ca
    int nph = 23;
    int nof = 1;
    int na = 1; 
-   int ng = 1; 
+   int ng = 23; 
    MPinitializer(&pt,npw,nph,nof,na,ng,nphBase,nphSuper);
 
 // Set the Step Sizes
@@ -4792,16 +4794,13 @@ MPSEQ getpmlgxmx(char *seqName, int iph ,double p, double phint, int iRec, int c
 
    double obsstep = 360.0/8192;
    double delta = 360.0/(sqrt(3)*nsteps);
-   double val = 0.0;
    for (i = 0; i < pm.nphBase/2; i++) {
       pm.phBase[i] = sign*(i*delta + delta/2.0);
       pm.phBase[i] = roundphase(pm.phBase[i],obsstep);
-      val = pm.phBase[i];
    }
    for (i = pm.nphBase/2; i < pm.nphBase; i++) {
       pm.phBase[i] = 180.0 + sign*((2*nsteps - i)*delta - delta/2.0);
       pm.phBase[i] = roundphase(pm.phBase[i],obsstep);
-      val = pm.phBase[i];
    }
 
 // Set the Supercycle Phase List

--- a/src/nvpsg/solidobjects.h
+++ b/src/nvpsg/solidobjects.h
@@ -3285,12 +3285,6 @@ void _inept(GP in, int ph1, int ph2, int ph3, int ph4)
       psg_abort(1);
    }
 
-   double lsim = in.pw1/2.0;
-   if (in.pw2 > in.pw1) lsim = in.pw2/2.0;
-
-   double lsim1 = in.pw3/2.0;
-   if (in.pw4 > in.pw3) lsim1 = in.pw4/2.0;
-
    double t1a = in.t1;
    double t1b = in.t2;
 
@@ -3334,12 +3328,6 @@ void _ineptref(GP in, int ph1, int ph2, int ph3, int ph4, int ph5, int ph6)
       printf("_ineptref() Error: Source and Destination on Same Channel. Abort!\n");
       psg_abort(1);
    }
-
-   double lsim = in.pw1/2.0;
-   if (in.pw2 > in.pw1) lsim = in.pw2/2.0;
-
-   double lsim1 = in.pw3/2.0;
-   if (in.pw4 > in.pw3) lsim1 = in.pw4/2.0;
 
    double t1a = in.t1;
    double t1b = in.t2;

--- a/src/nvpsg/solidpulses.h
+++ b/src/nvpsg/solidpulses.h
@@ -484,16 +484,8 @@ SHAPE getdumbogenshp(char *seqName, char *coeffName, double p, double phint, int
       s.pars.trap = INOVATRAP;
    }
 
-//set the flag for the supercycle
-
-   int supercyc;
    var = getname0("sc",coeffName,"");
-   supercyc=getval(var);
    s.pars.array = disarry(var, s.pars.array);
-
-   //reset supercycle to normal if shape will be used for windowed acquisition
-   if (!strcmp(s.pars.ch,"obs"))
-	supercyc=0;
 
 //get Fourier coefficients
    char *coef[12]={"ca1","ca2","ca3","ca4","ca5","ca6","cb1","cb2","cb3","cb4","cb5","cb6"};

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -1369,9 +1369,8 @@ RAMP make_ramp(RAMP r)
    extern void dumpRAMP(RAMP r);
    FILE *fp;
    extern char userdir[];
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[3*MAXSTR],str[MAXSTR+16];
    int ntick,nrpuls,naccumpuls;
-   int nph;
    int nmin = r.n90;
    double norm,mean;
    norm = 0.0; mean = 0.0;
@@ -1419,11 +1418,9 @@ RAMP make_ramp(RAMP r)
    }
    if (fabs(r.of) > 1.0) {
       dph = 360.0*r.of*DTCK;
-      nph = 1;
    }
    else {
       dph = 0.0;
-      nph = 0;
    }
    r.t = nmin*DTCK*(int)(r.t/(nmin*DTCK) + 0.5);
    r.n = (int)(r.t/DTCK + 0.5);

--- a/src/nvpsg/solidstates.h
+++ b/src/nvpsg/solidstates.h
@@ -37,8 +37,6 @@ STATE const_state(double t, SHAPE_PARS p)
 STATE sinc_state(double t, SHAPE_PARS p)
 {
    STATE s;
-   double bw;
-   bw = p.dp[0];             //bandwidth
    double tzc = p.dp[1];     //zero crossing time
    double arg;
    arg = PI*(t - 0.5*p.t)/tzc;
@@ -138,8 +136,7 @@ STATE sfm_state(double t, SHAPE_PARS p)
 STATE tanramp_state(double t, SHAPE_PARS p)
 {
    double norm,mean;
-   double at,ampl;
-   ampl = 0.0;
+   double at;
    enum polarity {NORMAL, UP_UP, DOWN_DOWN, DOWN_UP, UP_DOWN};
    enum polarity POL = NORMAL;
    STATE s;


### PR DESCRIPTION
With newer gcc compilers, a lot of warnings are generated from pulse
sequence compilations (psglib). Fixed these but tried to avoid changing
any software logic.