### PR TITLE
Fixed a Viewport bug and a Vnmrbg crash

### DIFF
--- a/src/Asp/AspDataInfo.C
+++ b/src/Asp/AspDataInfo.C
@@ -35,6 +35,7 @@ AspDataInfo::~AspDataInfo() {
 
 void AspDataInfo::initDataInfo() {
 	rank=0;
+        hasData = false;
  	haxis.name="?";
 	haxis.label="?";
 	haxis.dunits="?";
@@ -70,6 +71,9 @@ void AspDataInfo::updateDataInfo() {
 
 	char str[20];
         Wgetgraphicsdisplay(str, 20);
+
+        if (str[0] == '\0')
+           return;
 
         int procdim = (int) AspUtil::getReal("procdim",1);
         if(procdim > 0) rank = procdim;

--- a/src/vnmrj/src/vnmr/ui/ExpPanel.java
+++ b/src/vnmrj/src/vnmr/ui/ExpPanel.java
@@ -7976,7 +7976,8 @@ public class ExpPanel extends JPanel
                    sPan.setBusy(bz);
 	    }
         }
-        vcanvas.setBusy(vbgBusy);
+        if (vcanvas != null)
+           vcanvas.setBusy(vbgBusy);
 /*
         if (bz)
             setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));


### PR DESCRIPTION
For the viewport bug, just need to check for a null pointer before setting
the "busy" cursor. This error showed up in a VnmrjMsgLog when changing
viewports.
To reproduce the Vnmrbg core dump, process 2D data in exp4, then
process 1D data in exp5 and display the spectrum (ds). jexp4 and then
reposition the command line. Vnmrbg will generate "Data file is not open
currently" messages and core dump.