### PR TITLE
return dir entries from getfile in alphabetic order #199

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,12 +36,11 @@ jobs: # a collection of steps
             export OVJ_BUILDDIR=$HOME
             export OVJ_ROOT=${OVJ_BUILDDIR}/OpenVnmrJ
             export OVJ_TOOLS=${OVJ_BUILDDIR}/ovjTools
-            ls
             gcc --version
-            g++ --version
             cd ${OVJ_ROOT}
             cp -a ${OVJ_TOOLS}/bin ${OVJ_BUILDDIR}
             OVJ_SCONSFLAGS='-j2' ${OVJ_ROOT}/scripts/build_release.sh build package
+            echo "--- whatsin output ---"
             ${OVJ_TOOLS}/bin/whatsin $(ls -t ${OVJ_BUILDDIR}/logs/build* | head -1) | tail -80
             ls -l ${OVJ_BUILDDIR}/dvdimage*
       - run:
@@ -49,7 +48,7 @@ jobs: # a collection of steps
           when: on_fail
           command: |
             export OVJ_BUILDDIR=$HOME
-            sudo tail -80 ${OVJ_BUILDDIR}/logs/build*
+            sudo tail -180 ${OVJ_BUILDDIR}/logs/build*
       - run:
           name: Install OpenVnmrJ
           command: |
@@ -58,26 +57,23 @@ jobs: # a collection of steps
             export OVJ_TOOLS=${OVJ_BUILDDIR}/ovjTools
             chmod a+xr ${OVJ_BUILDDIR}
             chmod a+xr ${OVJ_BUILDDIR}/dvdimageOVJ*
-            pwd
-            cd ${OVJ_TOOLS}
             sudo ${OVJ_ROOT}/scripts/install_test.sh -f install
       - run:
           name: Install Failed
           when: on_fail
           command: |
             export OVJ_BUILDDIR=$HOME
-            sudo tail -80 ${OVJ_BUILDDIR}/logs/install_test.log
+            sudo tail -180 ${OVJ_BUILDDIR}/logs/install_test.log
       - run:
           name: Test OpenVnmrJ
           command: |
             export OVJ_BUILDDIR=$HOME
             export OVJ_ROOT=${OVJ_BUILDDIR}/OpenVnmrJ
             export OVJ_TOOLS=${OVJ_BUILDDIR}/ovjTools
-            pwd
-            cd ${OVJ_TOOLS}
-            sudo rm -f ~vnmr1/vnmrsys/ovj_qa/ovjtest/reports/20*
             sudo ${OVJ_ROOT}/scripts/install_test.sh -f test
-            sudo cat ~vnmr1/vnmrsys/ovj_qa/ovjtest/reports/20*
+            sudo rm -f ~vnmr1/vnmrsys/ovj_qa/ovjtest/reports/2015-10-27
+            echo "--- diff test output against GOLD ---"
+            sudo diff ~vnmr1/vnmrsys/ovj_qa/ovjtest/reports/20* ~vnmr1/vnmrsys/ovj_qa/ovjtest/reports/gold-circleci || true
       - run:
           name: Tests Failed
           when: on_fail
@@ -85,4 +81,4 @@ jobs: # a collection of steps
             sudo cat ~vnmr1/vnmrsys/ovj_qa/ovjtest/reports/20*
       - store_artifacts:
           name: Store VJQA Results
-          path: ~vnmr1/vnmrsys/ovj_qa/ovjtest/reports
+          path: /home/vnmr1/vnmrsys/ovj_qa/ovjtest/reports

--- a/src/common/manual/getfile
+++ b/src/common/manual/getfile
@@ -1,14 +1,18 @@
 
 *******************************************************************************
-getfile('directory'):$x  	   - how many files are in a directory?
-getfile('directory',i):$name,$ext  - return the name and extension
-                                   - of the ith file.
+getfile('directory'):$x  	           - how many files are in a directory?
+getfile('directory',i<,'alphasort'>):$name,$ext - return the name and extension
+                                                - of the ith file.
 *******************************************************************************
 
   Allows one to determine the number of files within a directory.
   The names of each of these files can then be successively returned.
   Files which begin with a "." are ignored.  The last file extension is
-  returned as a second argument.  For example:
+  returned as a second argument.  With the 'alphasort' argument, the
+  filenames will be returned in alphabetic order, at some cost in speed.
+  Without it the order is random and dependent on the underlying
+  filesystem.  For example:
+
     filename		first argument		second argument
     s2pul.fid		s2pul			fid
     tmp_01.dat		tmp_01			dat
@@ -24,7 +28,7 @@ getfile('directory',i):$name,$ext  - return the name and extension
       .
       .
       .
-      endwhile
+    endwhile
 
   Complete pathnames can be reconstructed as
     if ($ext = '') then

--- a/src/vjqa/vjtest/maclib.futureTests/biolap
+++ b/src/vjqa/vjtest/maclib.futureTests/biolap
@@ -6,7 +6,7 @@ $i = 0
 $file=''
 while ($i < $num) do
   $i = $i + 1
-  getfile($biodir,$i):$file
+  getfile($biodir,$i,'alphasort'):$file
   exists($vnmrdir+'/'+$file,'file'):$e
   if ($e) then
     write('line3','Connon macro: %s',$file)

--- a/src/vjqa/vjtest/maclib.futureTests/testmacro2
+++ b/src/vjqa/vjtest/maclib.futureTests/testmacro2
@@ -9,7 +9,7 @@ while ($j < $num) do
   write('line3','checking %d macros in %s',$nfiles, $dir)
   while ($i<$nfiles) do
      $i=$i+1
-     getfile($dir,$i):$macro_name
+     getfile($dir,$i,'alphasort'):$macro_name
      macrold($dir+$macro_name):$e
      purge($macro_name)
   endwhile

--- a/src/vjqa/vjtest/maclib/getdirs
+++ b/src/vjqa/vjtest/maclib/getdirs
@@ -20,7 +20,7 @@ getfile($dir):$nfiles
   $name=''
   while ($i<$nfiles) do
      $i=$i+1
-     getfile($dir,$i):$name
+     getfile($dir,$i,'alphasort'):$name
      if ($name = $sname) then
        if ($dirs[1] = '') then
          $dirs=$dir+'/'+$name+'/'

--- a/src/vjqa/vjtest/maclib/testLayouts
+++ b/src/vjqa/vjtest/maclib/testLayouts
@@ -41,7 +41,7 @@ while ($num >= 1) do
       $j = 0
       while ($j < $files) do
         $j=$j+1
-        getfile($dir,$j):$xml,$ext
+        getfile($dir,$j,'alphasort'):$xml,$ext
         if ($ext <> '') then
            $xml = $xml +'.' + $ext
            lookup('mfile',$dir+'/'+$xml,'filekey'):$key2

--- a/src/vjqa/vjtest/maclib/testLdd
+++ b/src/vjqa/vjtest/maclib/testLdd
@@ -21,7 +21,7 @@ while ($j < $num) do
   $i=0
   while ($i<$nfiles) do
      $i=$i+1
-     getfile($dir,$i):$filename,$ext
+     getfile($dir,$i,'alphasort'):$filename,$ext
      if ($ext = '') then
        $path = $dir + $filename
      else

--- a/src/vjqa/vjtest/maclib/testMacro
+++ b/src/vjqa/vjtest/maclib/testMacro
@@ -17,7 +17,7 @@ while ($j < $num) do
   $i=0
   while ($i<$nfiles) do
      $i=$i+1
-     getfile($dir,$i):$macro_name
+     getfile($dir,$i,'alphasort'):$macro_name
      macrold($dir+$macro_name):$e
      if ($e) then
        $pass=$pass+1

--- a/src/vjqa/vjtest/maclib/testParfile
+++ b/src/vjqa/vjtest/maclib/testParfile
@@ -29,7 +29,7 @@ while ($j < $num) do
   $i=0
   while ($i<$nfiles) do
      $i=$i+1
-     getfile($dir,$i):$parfile
+     getfile($dir,$i,'alphasort'):$parfile
 //     fread($dir+$parfile+'.par/procpar','current','reset')
 //     write('line3','check par file %s',$parfile)
      if ($parfile <> 'parliblist') then

--- a/src/vjqa/vjtest/maclib/testSeqgen
+++ b/src/vjqa/vjtest/maclib/testSeqgen
@@ -26,7 +26,7 @@ while ($j < $num) do
   $i=0
   while ($i<$nfiles) do
      $i=$i+1
-     getfile($dir,$i):$name
+     getfile($dir,$i,'alphasort'):$name
      seqgen($name)
      write('line3','%s is number %d of %d sequences',$name,$i,$nfiles)
      $cfile=userdir+'/seqlib/'+$name

--- a/src/vjqa/vjtest/maclib/testShellCmds
+++ b/src/vjqa/vjtest/maclib/testShellCmds
@@ -40,7 +40,7 @@ while ($j < $num) do
   $ch=''
   while ($i<$nfiles) do
     $i=$i+1
-    getfile($dir,$i):$macro_name
+    getfile($dir,$i,'alphasort'):$macro_name
     lookup('mfile',$dir+'/'+$macro_name,'delimiter',' \n\'(\t','filekey','count','shell'):$key,$count
     if ($count) then
       $ret=3

--- a/src/vjqa/vjtest/reports/gold-circleci
+++ b/src/vjqa/vjtest/reports/gold-circleci
@@ -1,0 +1,4476 @@
+ 
+ 
+Start QA testing
+Aug 21 2018 at 17:22:21
+ 
+
+OpenVnmrJ VERSION 1.1 REVISION A
+August 21, 2018
+propulse
+ 
+Installation tests
+   Test       : VnmrJ installation
+     ***Failed: VnmrJ installation
+ 
+Macro syntax tests
+   Test       : Macro syntax of /vnmr/autotest/maclib/
+        Passed: 309 macros
+   Test       : Macro syntax of /vnmr/biopack/maclib/
+        Passed: 1052 macros
+   Test       : Macro syntax of /vnmr/biosolidspack/maclib/
+        Passed: 240 macros
+   Test       : Macro syntax of /vnmr/craft/maclib/
+        Passed: 193 macros
+   Test       : Macro syntax of /vnmr/gxyzshim/maclib/
+        Passed: 48 macros
+   Test       : Macro syntax of /vnmr/imaging/maclib/
+        Passed: 459 macros
+   Test       : Macro syntax of /vnmr/maclib/
+        Passed: 2337 macros
+   Test       : Macro syntax of /vnmr/openvnmrj-utils/maclib/
+        Passed: 2 macros
+   Test       : Macro syntax of /vnmr/solidspack/maclib/
+        Passed: 544 macros
+   Test       : Macro syntax of /vnmr/veripulse/maclib/
+        Passed: 168 macros
+   Test       : Tested a total of 5352 macros
+ 
+Parfile rtp tests
+   Test       : Parameter file syntax in /vnmr/biopack/parlib/
+        Passed: 367 parameter sets
+   Test       : Parameter file syntax in /vnmr/biosolidspack/parlib/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-2_04Oct12_01/dirinfo/parlib/
+        Passed: 2 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-5_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-6_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-10-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-10_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-11_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-12_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-13_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-14_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-15_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-1_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-2_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-3_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-4_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-7_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-8_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-11-9_04Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-10_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-11_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-14_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-15_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-16_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-1_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-2_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-3_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-4_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-5_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-6_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-7_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-8_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/craft/fidlib/SoyExtract/Sb15-13-9_10Oct12_01/dirinfo/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/gxyzshim/parlib/
+        Passed: 1 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/ATP/parlib/
+        Passed: 13 parameter sets
+   Test       : Parameter file syntax in /vnmr/imaging/parlib/
+        Passed: 79 parameter sets
+   Test       : Parameter file syntax in /vnmr/parlib/
+        Passed: 237 parameter sets
+   Test       : Parameter file syntax in /vnmr/solidspack/parlib/
+        Passed: 162 parameter sets
+   Test       : Parameter file syntax in /vnmr/veripulse/parlib/
+        Passed: 10 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par200/tests/
+        Passed: 21 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par300/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/stdpar/
+        Passed: 6 parameter sets
+   Test       : Parameter file syntax in /vnmr/par400/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par500/tests/
+        Passed: 25 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par600/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par700/tests/
+        Passed: 24 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par750/tests/
+        Passed: 17 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par800/tests/
+        Passed: 20 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/stdpar/
+        Passed: 5 parameter sets
+   Test       : Parameter file syntax in /vnmr/par900/tests/
+        Passed: 20 parameter sets
+ 
+XML syntax tests
+   Test       : Xml syntax
+        Passed: 6375 xml files
+ 
+Experiment Menu tests
+   Test       : Experiment menus
+        Passed: 336 experiment menu items
+     ***Failed: 6 experiment menu items
+failed experiment menu item: editht
+failed experiment menu item: noesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps  vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: noesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: roesyHT dps vnmrjcmd('setpage','Acquire','Quick')
+failed experiment menu item: Inepthxdec
+        Passed: 339 experiment go('check')
+     ***Failed: 3 experiment go('check')
+go('check') failed for PROTON dn='C13' gHMBCmeAD
+go('check') failed for PROTON gc2hmbcme
+go('check') failed for PROTON gc2h2bcme
+        Passed: 266 experiment exptime
+     ***Failed: 76 experiment exptime
+exptime failed for bashdROESY ()
+exptime failed for zTOCSY1D ()
+exptime failed for ROESY1D ()
+exptime failed for stepNOESY1D ()
+exptime failed for APT ()
+exptime failed for dqcosyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps  vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for dqcosyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for noesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for roesyHT dps vnmrjcmd('setpage','Acquire','Quick') ()
+exptime failed for Hetcortancp2d ()
+exptime failed for Hetcorlgcp2d ()
+exptime failed for Hetcorlgcp2d_1 ()
+exptime failed for Wisetancp2d ()
+exptime failed for Exsy2d ()
+exptime failed for Mashmqc2d ()
+exptime failed for Masapt1d ()
+exptime failed for Mashsqc2d ()
+exptime failed for C7inad2d ()
+exptime failed for Spc5inad2d ()
+exptime failed for Cpinad2d ()
+exptime failed for R14inad2d ()
+exptime failed for Babainad2d ()
+exptime failed for Tancp2drad ()
+exptime failed for Tancp2dspc5 ()
+exptime failed for Pisema2d ()
+exptime failed for Sammy2d ()
+exptime failed for Pisematest1 ()
+exptime failed for Pisematest2 ()
+exptime failed for Lgcp2d ()
+exptime failed for Sc14inad2d ()
+exptime failed for Super2d ()
+exptime failed for Hetcorsamlgcp2d_1 ()
+exptime failed for Hetcorpmlgcp2d_1 ()
+exptime failed for Hetcordumbolgcp2d_1 ()
+exptime failed for Hh2dhdec ()
+exptime failed for IdHetcor ()
+exptime failed for IdInept ()
+exptime failed for Inepthxdec ()
+exptime failed for Tancpxhdec ()
+exptime failed for Tancpxhdeccpmg ()
+exptime failed for Jmasnca2d ()
+exptime failed for Jmasnco2d ()
+exptime failed for Jmascaco2d ()
+exptime failed for Jmascacoipap2d ()
+exptime failed for Jmascacosh2d ()
+exptime failed for Redor1tancp ()
+exptime failed for Redor2tancp ()
+exptime failed for Redor1onepul ()
+exptime failed for Redor2onepul ()
+exptime failed for Fsredor ()
+exptime failed for Dcptan3drad ()
+exptime failed for Dcp2tan3drad ()
+exptime failed for Dcptan3dspc5 ()
+exptime failed for Dcptan ()
+exptime failed for Decorcptan2d ()
+exptime failed for Ineptxyonepul ()
+exptime failed for Ineptxytancp ()
+exptime failed for Ineptxyrefonepul ()
+exptime failed for Ineptxyreftancp ()
+exptime failed for Trapdorycpx ()
+exptime failed for Mrev8 ()
+exptime failed for Mrev8q ()
+exptime failed for Wpmlg1d ()
+exptime failed for Wpmlg2d ()
+exptime failed for C7inadwpmlg2d ()
+exptime failed for Wdumbo1d ()
+exptime failed for Wdumbot1d ()
+exptime failed for C7inadwdumbot2d ()
+exptime failed for C7inadwdumbogen2d ()
+exptime failed for Spsmall ()
+exptime failed for Wpmlgxmx1d ()
+exptime failed for Wdumboxmx1d ()
+exptime failed for Wdumbogen1d ()
+exptime failed for Qcpmgsh1d ()
+ 
+Libraries for binaries tests
+   Test       : Program ldd test of /vnmr/bin/
+        Passed: 207 programs
+     ***Failed: 7 programs
+failed program: /vnmr/bin/addTables
+failed program: /vnmr/bin/calcFit
+failed program: /vnmr/bin/fidelityFit
+failed program: /vnmr/bin/fidelityPlots
+failed program: /vnmr/bin/matlabPlots
+failed program: /vnmr/bin/powerTables
+failed program: /vnmr/bin/shapeFit
+   Test       : Program ldd test of /vnmr/biopack/bin/
+        Passed: 14 programs
+   Test       : Program ldd test of /vnmr/craft/Bayes3/bin/
+     ***Failed: 4 programs
+failed program: /vnmr/craft/Bayes3/bin/bayes_analyze
+failed program: /vnmr/craft/Bayes3/bin/bayes_model
+failed program: /vnmr/craft/Bayes3/bin/bayes_summary1
+failed program: /vnmr/craft/Bayes3/bin/bayes_summary2
+   Test       : Program ldd test of /vnmr/craft/bin/
+        Passed: 4 programs
+   Test       : Program ldd test of /vnmr/dicom/bin/
+        Passed: 8 programs
+   Test       : Program ldd test of /vnmr/dicom/bin/
+        Passed: 8 programs
+   Test       : Program ldd test of /vnmr/openvnmrj-utils/bin/
+        Passed: 3 programs
+   Test       : Program ldd test of /vnmr/tcl/bin/
+        Passed: 11 programs
+     ***Failed: 2 programs
+failed program: /vnmr/tcl/bin/vnmrWish
+failed program: /vnmr/tcl/bin/vnmrwish
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/expressions/bin/
+   Test       : Program ldd test of /vnmr/user_templates/ib_initdir/math/functions/bin/
+        Passed: 11 programs
+   Test       : Program ldd test of /vnmr/lib/
+        Passed: 21 programs
+ 
+Linux commands accessed by shell
+   Test       : Access shell commands from /vnmr/autotest/maclib/
+   Test       : Access shell commands from /vnmr/biopack/maclib/
+   Test       : Access shell commands from /vnmr/biosolidspack/maclib/
+   Test       : Access shell commands from /vnmr/craft/maclib/
+   Test       : Access shell commands from /vnmr/gxyzshim/maclib/
+   Test       : Access shell commands from /vnmr/imaging/maclib/
+   Test       : Access shell commands from /vnmr/maclib/
+   Test       : Access shell commands from /vnmr/openvnmrj-utils/maclib/
+   Test       : Access shell commands from /vnmr/solidspack/maclib/
+   Test       : Access shell commands from /vnmr/veripulse/maclib/
+   Test       : Access shell commands from /vnmr/menujlib/
+        Passed: 97 shell commands
+     ***Failed: 19 shell commands
+command not found: /bin/csh
+command not found: gnuplot
+command not found: pr3db
+command not found: csh
+command not found: gawk
+command not found: enscript
+command not found: ps2pdf
+command not found: acroread
+command not found: gedit
+command not found: gnome-terminal
+command not found: file
+command not found: /bin/gawk
+command not found: ps2pdfwr
+command not found: convert
+command not found: rsync
+command not found: lp
+command not found: dos2unix
+command not found: xterm
+command not found: nautilus
+ 
+DSSL test
+   Test       : dssl bug for multiple arrays
+        Passed: 
+ 
+DEA test
+   Test       : DEA integration and baseline correction
+        Passed:  with secondary values
+ 
+PSG tests
+   Test       : Seqgen syntax of /vnmr/autotest/psglib/ with 18 sequences
+        Passed: 17 pulse sequences
+       *Warned: 1 pulse sequences
+warn  : /vnmr/autotest/psglib/ATCNnoesy
+ATCNnoesy.c: In function 'pulsesequence':
+ATCNnoesy.c:200:14: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+              gzlvl7;
+              ^~~~~~
+ATCNnoesy.c:199:14: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+              gzlvl6,
+              ^~~~~~
+ATCNnoesy.c:170:13: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+             rf0,                        /* full fine power */
+             ^~~
+   Test       : Seqgen syntax of /vnmr/biopack/psglib/ with 405 sequences
+        Passed: 211 pulse sequences
+       *Warned: 194 pulse sequences
+warn  : /vnmr/biopack/psglib/CN4Dnoesy_trosyA
+CN4Dnoesy_trosyA.c: In function 'pulsesequence':
+CN4Dnoesy_trosyA.c:267:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CN4Dnoesy_trosyA.c:269:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t3_counter = (int) ( (d4-d4_init)*sw3 + 0.5);
+      ^~~~~~~~~~
+CN4Dnoesy_trosyA.c:275:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CN4Dnoesy_trosyA.c:277:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+      ^~~~~~~~~~
+CN4Dnoesy_trosyA.c:283:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CN4Dnoesy_trosyA.c:285:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+CN4Dnoesy_trosyA.c:75:14: warning: variable 'gstab' set but not used [-Wunused-but-set-variable]
+              gstab,
+              ^~~~~
+CN4Dnoesy_trosyA.c: In function 'x_pulsesequence':
+CN4Dnoesy_trosyA.c:1649:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CN4Dnoesy_trosyA.c:1651:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t3_counter = (int) ( (d4-d4_init)*sw3 + 0.5);
+      ^~~~~~~~~~
+CN4Dnoesy_trosyA.c:1658:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CN4Dnoesy_trosyA.c:1660:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+      ^~~~~~~~~~
+CN4Dnoesy_trosyA.c:1667:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CN4Dnoesy_trosyA.c:1669:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+CN4Dnoesy_trosyA.c: In function 't_pulsesequence':
+CN4Dnoesy_trosyA.c:3025:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CN4Dnoesy_trosyA.c:3027:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t3_counter = (int) ( (d4-d4_init)*sw3 + 0.5);
+      ^~~~~~~~~~
+CN4Dnoesy_trosyA.c:3034:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CN4Dnoesy_trosyA.c:3036:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+      ^~~~~~~~~~
+CN4Dnoesy_trosyA.c:3043:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CN4Dnoesy_trosyA.c:3045:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/CNfilnoesy
+CNfilnoesy.c: In function 'pulsesequence':
+CNfilnoesy.c:222:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CNfilnoesy.c:224:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+CNfilnoesy.c: In function 'x_pulsesequence':
+CNfilnoesy.c:627:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CNfilnoesy.c:629:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+CNfilnoesy.c: In function 't_pulsesequence':
+CNfilnoesy.c:1037:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CNfilnoesy.c:1039:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/CNfiltocsy
+CNfiltocsy.c: In function 'pulsesequence':
+CNfiltocsy.c:204:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CNfiltocsy.c:206:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+CNfiltocsy.c: In function 'x_pulsesequence':
+CNfiltocsy.c:484:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CNfiltocsy.c:486:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+CNfiltocsy.c: In function 't_pulsesequence':
+CNfiltocsy.c:766:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+CNfiltocsy.c:768:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/CTgChmqc
+CTgChmqc.c: In function 'pulsesequence':
+CTgChmqc.c:412:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+CTgChmqc.c:413:46: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        Wet4(wetpwr,wetshape,wetpw,zero,one); delay(dz);
+                                              ^~~~~
+CTgChmqc.c: In function 'x_pulsesequence':
+CTgChmqc.c:871:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+CTgChmqc.c:872:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        x_Wet4(wetpwr,wetshape,wetpw,zero,one); DPSprint(dz, "10 delay  1 0 1 dz %.9f \n", (float)(dz));
+                                                ^~~~~~~~
+CTgChmqc.c: In function 't_pulsesequence':
+CTgChmqc.c:1334:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+CTgChmqc.c:1335:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        t_Wet4(wetpwr,wetshape,wetpw,zero,one); DPStimer(10,0,0,1,0,0,0,0,(double)dz);
+                                                ^~~~~~~~
+warn  : /vnmr/biopack/psglib/NH_diffusion
+NH_diffusion.c: In function 'pulsesequence':
+NH_diffusion.c:52:21: warning: variable 'ref_pw90' set but not used [-Wunused-but-set-variable]
+  pwN,pwNlvl,ref_pwr,ref_pw90,pwZa,pwClvl,JXH;
+                     ^~~~~~~~
+NH_diffusion.c:52:13: warning: variable 'ref_pwr' set but not used [-Wunused-but-set-variable]
+  pwN,pwNlvl,ref_pwr,ref_pw90,pwZa,pwClvl,JXH;
+             ^~~~~~~
+NH_diffusion.c:50:29: warning: variable 'd4' set but not used [-Wunused-but-set-variable]
+  double tpwrs,pwC,d2,tau,d3,d4,d5,d6,
+                             ^~
+warn  : /vnmr/biopack/psglib/NN4Dnoesy_trosyA
+NN4Dnoesy_trosyA.c: In function 'pulsesequence':
+NN4Dnoesy_trosyA.c:334:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+NN4Dnoesy_trosyA.c:336:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t3_counter = (int) ( (d4-d4_init)*sw3 + 0.5);
+      ^~~~~~~~~~
+NN4Dnoesy_trosyA.c:343:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+NN4Dnoesy_trosyA.c:345:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+      ^~~~~~~~~~
+NN4Dnoesy_trosyA.c:351:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+NN4Dnoesy_trosyA.c:353:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+NN4Dnoesy_trosyA.c: In function 'x_pulsesequence':
+NN4Dnoesy_trosyA.c:1914:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+NN4Dnoesy_trosyA.c:1916:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t3_counter = (int) ( (d4-d4_init)*sw3 + 0.5);
+      ^~~~~~~~~~
+NN4Dnoesy_trosyA.c:1924:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+NN4Dnoesy_trosyA.c:1926:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+      ^~~~~~~~~~
+NN4Dnoesy_trosyA.c:1933:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+NN4Dnoesy_trosyA.c:1935:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/PR42_gChmqcnoesyNhsqcA
+PR42_gChmqcnoesyNhsqcA.c: In function 'pulsesequence':
+PR42_gChmqcnoesyNhsqcA.c:66:28: warning: variable 'pw200' set but not used [-Wunused-but-set-variable]
+         rf0 = 4095, rf200, pw200,
+                            ^~~~~
+warn  : /vnmr/biopack/psglib/PR42_ghn_ca_coP
+PR42_ghn_ca_coP.c: In function 'pulsesequence':
+PR42_ghn_ca_coP.c:139:14: warning: variable 'gzlvl10' set but not used [-Wunused-but-set-variable]
+              gzlvl10,
+              ^~~~~~~
+PR42_ghn_ca_coP.c:108:14: warning: variable 'at' set but not used [-Wunused-but-set-variable]
+              at,
+              ^~
+PR42_ghn_ca_coP.c:107:14: warning: variable 'sw2' set but not used [-Wunused-but-set-variable]
+              sw2,          /* sweep width in f2                    */
+              ^~~
+PR42_ghn_ca_coP.c:104:14: warning: variable 'BigT1' set but not used [-Wunused-but-set-variable]
+              BigT1,        /* delay about 200 us */
+              ^~~~~
+warn  : /vnmr/biopack/psglib/PR42_ghn_ca_coP_TROSY
+PR42_ghn_ca_coP_TROSY.c: In function 'pulsesequence':
+PR42_ghn_ca_coP_TROSY.c:134:14: warning: variable 'gzlvl10' set but not used [-Wunused-but-set-variable]
+              gzlvl10,
+              ^~~~~~~
+PR42_ghn_ca_coP_TROSY.c:103:14: warning: variable 'at' set but not used [-Wunused-but-set-variable]
+              at,
+              ^~
+PR42_ghn_ca_coP_TROSY.c:102:14: warning: variable 'sw2' set but not used [-Wunused-but-set-variable]
+              sw2,          /* sweep width in f2                    */
+              ^~~
+warn  : /vnmr/biopack/psglib/PR42_ghn_co_caP
+PR42_ghn_co_caP.c: In function 'pulsesequence':
+PR42_ghn_co_caP.c:137:14: warning: variable 'gzlvl11' set but not used [-Wunused-but-set-variable]
+              gzlvl11,
+              ^~~~~~~
+PR42_ghn_co_caP.c:112:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,                /* the largest of pwS2 and 2.0*pwN for 1D experiments */
+    ^~~~
+PR42_ghn_co_caP.c:109:4: warning: variable 'pwS4' set but not used [-Wunused-but-set-variable]
+    pwS4,                                             /* length of 90 on CO */
+    ^~~~
+PR42_ghn_co_caP.c:106:4: warning: variable 'phshift' set but not used [-Wunused-but-set-variable]
+    phshift,        /*  phase shift induced on Ca by 180 on CO in middle of t1 */
+    ^~~~~~~
+PR42_ghn_co_caP.c:99:14: warning: variable 'sw2' set but not used [-Wunused-but-set-variable]
+              sw2,          /* sweep width in f2                    */
+              ^~~
+PR42_ghn_co_caP.c:96:14: warning: variable 'BigT1' set but not used [-Wunused-but-set-variable]
+              BigT1,       /* delay to compensate for gradient gt5 */
+              ^~~~~
+PR42_ghn_co_caP.c:93:14: warning: variable 'bigTCa' set but not used [-Wunused-but-set-variable]
+              bigTCa,      /* Ca T period */
+              ^~~~~~
+warn  : /vnmr/biopack/psglib/PR42_ghn_co_caP_TROSY
+PR42_ghn_co_caP_TROSY.c: In function 'pulsesequence':
+PR42_ghn_co_caP_TROSY.c:109:14: warning: variable 'pwS2' set but not used [-Wunused-but-set-variable]
+              pwS2,         /* selective CO 90 */
+              ^~~~
+PR42_ghn_co_caP_TROSY.c:105:7: warning: variable 'sphase2' set but not used [-Wunused-but-set-variable]
+       sphase2,      /* used only for constant t2 period */
+       ^~~~~~~
+PR42_ghn_co_caP_TROSY.c:102:14: warning: variable 'sw2' set but not used [-Wunused-but-set-variable]
+              sw2,          /* sweep width in f2                    */
+              ^~~
+warn  : /vnmr/biopack/psglib/PR42_ghn_coca_cbP
+PR42_ghn_coca_cbP.c: In function 'pulsesequence':
+PR42_ghn_coca_cbP.c:86:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,               /* the larger of pwS2 and 2.0*pwN for 1D experiments */
+    ^~~~
+PR42_ghn_coca_cbP.c:85:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,                                   /* the larger of pwS2 and 2.0*pwN */
+    ^~~
+PR42_ghn_coca_cbP.c:82:4: warning: variable 'phshift' set but not used [-Wunused-but-set-variable]
+    phshift,        /* phase shift induced on Ca by 180 on CO in middle of t1 */
+    ^~~~~~~
+warn  : /vnmr/biopack/psglib/PR42_ghn_coca_cbP_TROSY
+PR42_ghn_coca_cbP_TROSY.c: In function 'pulsesequence':
+PR42_ghn_coca_cbP_TROSY.c:85:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,               /* the largest of pwS2 and 2.0*pwN for 1D experiments */
+    ^~~~
+PR42_ghn_coca_cbP_TROSY.c:84:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,                                   /* the largest of pwS2 and 2.0*pwN */
+    ^~~
+PR42_ghn_coca_cbP_TROSY.c:81:4: warning: variable 'phshift' set but not used [-Wunused-but-set-variable]
+    phshift,        /* phase shift induced on Ca by 180 on CO in middle of t1 */
+    ^~~~~~~
+warn  : /vnmr/biopack/psglib/PR42_ghncacbP
+PR42_ghncacbP.c: In function 'pulsesequence':
+PR42_ghncacbP.c:81:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,              /* the largest of pwS2 and 2.0*pwN for 1D experiments */
+    ^~~~
+PR42_ghncacbP.c:80:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,                                  /* the largest of pwS2 and 2.0*pwN */
+    ^~~
+PR42_ghncacbP.c:78:4: warning: variable 'pwS3' set but not used [-Wunused-but-set-variable]
+    pwS3,
+    ^~~~
+PR42_ghncacbP.c:76:4: warning: variable 'phshift' set but not used [-Wunused-but-set-variable]
+    phshift = getval("phshift"),    /* phase shift on Cab by 180 on CO in t1 */
+    ^~~~~~~
+PR42_ghncacbP.c:70:4: warning: variable 'pwCa180' set but not used [-Wunused-but-set-variable]
+    pwCa180,
+    ^~~~~~~
+warn  : /vnmr/biopack/psglib/PR42_ghncacbP_TROSY
+PR42_ghncacbP_TROSY.c: In function 'pulsesequence':
+PR42_ghncacbP_TROSY.c:81:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,              /* the largest of pwS2 and 2.0*pwN for 1D experiments */
+    ^~~~
+PR42_ghncacbP_TROSY.c:80:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,                                  /* the largest of pwS2 and 2.0*pwN */
+    ^~~
+PR42_ghncacbP_TROSY.c:78:4: warning: variable 'pwS3' set but not used [-Wunused-but-set-variable]
+    pwS3,
+    ^~~~
+PR42_ghncacbP_TROSY.c:76:4: warning: variable 'phshift' set but not used [-Wunused-but-set-variable]
+    phshift = getval("phshift"),    /* phase shift on Cab by 180 on CO in t1 */
+    ^~~~~~~
+PR42_ghncacbP_TROSY.c:70:4: warning: variable 'pwCa180' set but not used [-Wunused-but-set-variable]
+    pwCa180,
+    ^~~~~~~
+warn  : /vnmr/biopack/psglib/PR42_intra_ghncacbP_TROSY
+PR42_intra_ghncacbP_TROSY.c: In function 'pulsesequence':
+PR42_intra_ghncacbP_TROSY.c:92:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,             /* the largest of pwCO180 and 2.0*pwN for 1D experiments */
+    ^~~~
+PR42_intra_ghncacbP_TROSY.c:91:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,                            /* the largest of pwCO180 and 2.0*pwN */
+    ^~~
+PR42_intra_ghncacbP_TROSY.c:88:4: warning: variable 'phshift' set but not used [-Wunused-but-set-variable]
+    phshift,        /*  phase shift induced on Ca by 180 on CO in middle of t1 */
+    ^~~~~~~
+PR42_intra_ghncacbP_TROSY.c:85:4: warning: variable 'pwCa180' set but not used [-Wunused-but-set-variable]
+    pwCa180,
+    ^~~~~~~
+PR42_intra_ghncacbP_TROSY.c:84:4: warning: variable 'pwCa90' set but not used [-Wunused-but-set-variable]
+    pwCa90,                          /* length of square 90 on Ca */
+    ^~~~~~
+warn  : /vnmr/biopack/psglib/PR42_sim_ghn_co_caP
+PR42_sim_ghn_co_caP.c: In function 'pulsesequence':
+PR42_sim_ghn_co_caP.c:118:14: warning: variable 'pwS4' set but not used [-Wunused-but-set-variable]
+              pwS4,         /* length of 180 on CO  */
+              ^~~~
+PR42_sim_ghn_co_caP.c:109:14: warning: variable 'sw2' set but not used [-Wunused-but-set-variable]
+              sw2,          /* sweep width in f2                    */
+              ^~~
+PR42_sim_ghn_co_caP.c:106:14: warning: variable 'BigT1' set but not used [-Wunused-but-set-variable]
+              BigT1,       /* delay to compensate for gradient gt5 */
+              ^~~~~
+warn  : /vnmr/biopack/psglib/PR42_sim_ghn_co_caP_TROSY
+PR42_sim_ghn_co_caP_TROSY.c: In function 'pulsesequence':
+PR42_sim_ghn_co_caP_TROSY.c:117:14: warning: variable 'pwS4' set but not used [-Wunused-but-set-variable]
+              pwS4,         /* length of 180 on CO  */
+              ^~~~
+PR42_sim_ghn_co_caP_TROSY.c:116:14: warning: variable 'pwS3' set but not used [-Wunused-but-set-variable]
+              pwS3,         /* length of 180 on Ca  */
+              ^~~~
+PR42_sim_ghn_co_caP_TROSY.c:108:14: warning: variable 'sw2' set but not used [-Wunused-but-set-variable]
+              sw2,          /* sweep width in f2                    */
+              ^~~
+warn  : /vnmr/biopack/psglib/best_hncaP
+best_hncaP.c: In function 'pulsesequence':
+best_hncaP.c:102:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_hncacbP
+best_hncacbP.c: In function 'pulsesequence':
+best_hncacbP.c:97:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_hncacoP
+best_hncacoP.c: In function 'pulsesequence':
+best_hncacoP.c:99:46: warning: variable 'pwS8' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,pwS8,
+                                              ^~~~
+best_hncacoP.c:99:41: warning: variable 'pwS7' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,pwS8,
+                                         ^~~~
+best_hncacoP.c:99:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,pwS8,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_hncoP
+best_hncoP.c: In function 'pulsesequence':
+best_hncoP.c:102:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_hnco_jccP
+best_hnco_jccP.c: In function 'pulsesequence':
+best_hnco_jccP.c:115:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_hnco_jcohP
+best_hnco_jcohP.c: In function 'pulsesequence':
+best_hnco_jcohP.c:121:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,         /* the largest of pwS2 and 2.0*pwN for 1D experiments */
+    ^~~~
+best_hnco_jcohP.c:120:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,        /* the largest of pwS2 and 2.0*pwN */
+    ^~~
+best_hnco_jcohP.c:118:4: warning: variable 'phshift' set but not used [-Wunused-but-set-variable]
+    phshift,        /*  phase shift induced on CO by 180 on Ca in middle of t1 */
+    ^~~~~~~
+best_hnco_jcohP.c:117:19: warning: variable 'pwS4' set but not used [-Wunused-but-set-variable]
+    pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,        /* length of sinc 90 on CO */
+                   ^~~~
+best_hnco_jcohP.c:117:4: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+    pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,        /* length of sinc 90 on CO */
+    ^~~~
+warn  : /vnmr/biopack/psglib/best_hncocaP
+best_hncocaP.c: In function 'pulsesequence':
+best_hncocaP.c:96:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_hncoca_jchP
+best_hncoca_jchP.c: In function 'pulsesequence':
+best_hncoca_jchP.c:114:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_hncocacbP
+best_hncocacbP.c: In function 'pulsesequence':
+best_hncocacbP.c:104:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_ihncaP
+best_ihncaP.c: In function 'pulsesequence':
+best_ihncaP.c:43:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_ihncacbP
+best_ihncacbP.c: In function 'pulsesequence':
+best_ihncacbP.c:98:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_ihncacoP
+best_ihncacoP.c: In function 'pulsesequence':
+best_ihncacoP.c:102:46: warning: variable 'pwS8' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,pwS8,
+                                              ^~~~
+best_ihncacoP.c:102:41: warning: variable 'pwS7' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,pwS8,
+                                         ^~~~
+best_ihncacoP.c:102:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,pwS8,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_ghNcocaNH
+best_trosy_ghNcocaNH.c: In function 'pulsesequence':
+best_trosy_ghNcocaNH.c:73:11: warning: variable 'shlvl1' set but not used [-Wunused-but-set-variable]
+           shlvl1,
+           ^~~~~~
+best_trosy_ghNcocaNH.c:57:11: warning: variable 'kappa' set but not used [-Wunused-but-set-variable]
+           kappa,
+           ^~~~~
+best_trosy_ghNcocaNH.c:56:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_hbonds
+best_trosy_hbonds.c: In function 'pulsesequence':
+best_trosy_hbonds.c:56:11: warning: variable 'kappa' set but not used [-Wunused-but-set-variable]
+           kappa,
+           ^~~~~
+best_trosy_hbonds.c:55:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_hnCOcaNH
+best_trosy_hnCOcaNH.c: In function 'pulsesequence':
+best_trosy_hnCOcaNH.c:72:11: warning: variable 'shlvl1' set but not used [-Wunused-but-set-variable]
+           shlvl1,
+           ^~~~~~
+best_trosy_hnCOcaNH.c:56:11: warning: variable 'kappa' set but not used [-Wunused-but-set-variable]
+           kappa,
+           ^~~~~
+best_trosy_hnCOcaNH.c:55:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_hnca
+best_trosy_hnca.c: In function 'pulsesequence':
+best_trosy_hnca.c:57:11: warning: variable 'kappa' set but not used [-Wunused-but-set-variable]
+           kappa,
+           ^~~~~
+best_trosy_hnca.c:56:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_hncacb
+best_trosy_hncacb.c: In function 'pulsesequence':
+best_trosy_hncacb.c:57:11: warning: variable 'kappa' set but not used [-Wunused-but-set-variable]
+           kappa,
+           ^~~~~
+best_trosy_hncacb.c:56:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_hnco
+best_trosy_hnco.c: In function 'pulsesequence':
+best_trosy_hnco.c:57:11: warning: variable 'kappa' set but not used [-Wunused-but-set-variable]
+           kappa,
+           ^~~~~
+best_trosy_hnco.c:56:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_hncoca
+best_trosy_hncoca.c: In function 'pulsesequence':
+best_trosy_hncoca.c:57:11: warning: variable 'kappa' set but not used [-Wunused-but-set-variable]
+           kappa,
+           ^~~~~
+best_trosy_hncoca.c:56:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_hncocacb
+best_trosy_hncocacb.c: In function 'pulsesequence':
+best_trosy_hncocacb.c:57:11: warning: variable 'kappa' set but not used [-Wunused-but-set-variable]
+           kappa,
+           ^~~~~
+best_trosy_hncocacb.c:56:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_ihnca
+best_trosy_ihnca.c: In function 'pulsesequence':
+best_trosy_ihnca.c:51:41: warning: variable 'pwS7' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,max,
+                                         ^~~~
+best_trosy_ihnca.c:51:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,max,
+           ^~~~
+warn  : /vnmr/biopack/psglib/best_trosy_ihncacb
+best_trosy_ihncacb.c: In function 'pulsesequence':
+best_trosy_ihncacb.c:52:41: warning: variable 'pwS7' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,max,
+                                         ^~~~
+best_trosy_ihncacb.c:52:11: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+           pwS1,pwS2,pwS3,pwS4,pwS5,pwS6,pwS7,max,
+           ^~~~
+warn  : /vnmr/biopack/psglib/caco
+caco.c: In function 'x_pulsesequence':
+caco.c:668:22: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+                      else DPSprint(1.0/dmf3, "48 dec3rgpulse  1 0 1 1 1.0e-6 %.9f 0.0e-6 %.9f  4 three %d 1.0/dmf3 %.9f \n", (float)(1.0e-6), (float)(0.0e-6), (int)(three), (float)(1.0/dmf3)); DPSprint(0.00, "2 dec3blank  4 1 0 off 0 \n");
+                      ^~~~
+caco.c:668:194: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+                      else DPSprint(1.0/dmf3, "48 dec3rgpulse  1 0 1 1 1.0e-6 %.9f 0.0e-6 %.9f  4 three %d 1.0/dmf3 %.9f \n", (float)(1.0e-6), (float)(0.0e-6), (int)(three), (float)(1.0/dmf3)); DPSprint(0.00, "2 dec3blank  4 1 0 off 0 \n");
+                                                                                                                                                                                                  ^~~~~~~~
+caco.c: In function 't_pulsesequence':
+caco.c:1043:22: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+                      else DPStimer(48,0,0,3,0,0,0,0,(double)1.0/dmf3,(double)1.0e-6,(double)0.0e-6); DPStimer(2,0,0,0);
+                      ^~~~
+caco.c:1043:102: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+                      else DPStimer(48,0,0,3,0,0,0,0,(double)1.0/dmf3,(double)1.0e-6,(double)0.0e-6); DPStimer(2,0,0,0);
+                                                                                                      ^~~~~~~~
+warn  : /vnmr/biopack/psglib/cleanHMBC
+cleanHMBC.c: In function 'pulsesequence':
+cleanHMBC.c:452:3: warning: variable 'tauSC' set but not used [-Wunused-but-set-variable]
+   tauSC,
+   ^~~~~
+cleanHMBC.c:439:12: warning: variable 'EpsilonpwC' set but not used [-Wunused-but-set-variable]
+   Epsilon, EpsilonpwC, gradlen,
+            ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/cyclenoe
+cyclenoe.c: In function 'pulsesequence':
+cyclenoe.c:62:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+   ^~
+cyclenoe.c:62:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+                                  ^~
+cyclenoe.c: In function 'x_pulsesequence':
+cyclenoe.c:193:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+   ^~
+cyclenoe.c:193:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+                                  ^~
+cyclenoe.c: In function 't_pulsesequence':
+cyclenoe.c:334:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+   ^~
+cyclenoe.c:334:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+                                  ^~
+warn  : /vnmr/biopack/psglib/cyclenoef
+cyclenoef.c: In function 'pulsesequence':
+cyclenoef.c:69:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+   ^~
+cyclenoef.c:69:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+                                  ^~
+cyclenoef.c: In function 'x_pulsesequence':
+cyclenoef.c:253:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+   ^~
+cyclenoef.c:253:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+                                  ^~
+cyclenoef.c: In function 't_pulsesequence':
+cyclenoef.c:454:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+   ^~
+cyclenoef.c:454:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+                                  ^~
+warn  : /vnmr/biopack/psglib/dpfgse_satxfer_Troesy
+dpfgse_satxfer_Troesy.c: In function 'pulsesequence':
+dpfgse_satxfer_Troesy.c:147:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (alt_grd[0] == 'y') hlv(ct,v6); mod2(v6,v6);
+    ^~
+dpfgse_satxfer_Troesy.c:147:39: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if (alt_grd[0] == 'y') hlv(ct,v6); mod2(v6,v6);
+                                       ^~~~
+dpfgse_satxfer_Troesy.c: In function 'x_pulsesequence':
+dpfgse_satxfer_Troesy.c:343:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (alt_grd[0] == 'y') DPSprint(0.00, "70 hlv 58 2 0 ct %d v6 %d \n", (int)(ct), (int)(v6)); DPSprint(0.00, "70 mod2 63 2 0 v6 %d v6 %d \n", (int)(v6), (int)(v6));
+    ^~
+dpfgse_satxfer_Troesy.c:343:97: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if (alt_grd[0] == 'y') DPSprint(0.00, "70 hlv 58 2 0 ct %d v6 %d \n", (int)(ct), (int)(v6)); DPSprint(0.00, "70 mod2 63 2 0 v6 %d v6 %d \n", (int)(v6), (int)(v6));
+                                                                                                 ^~~~~~~~
+dpfgse_satxfer_Troesy.c: In function 't_pulsesequence':
+dpfgse_satxfer_Troesy.c:544:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (alt_grd[0] == 'y') DPStimer(70,58,2,0,(int)ct,(int)v6,0,0); DPStimer(70,63,2,0,(int)v6,(int)v6,0,0);
+    ^~
+dpfgse_satxfer_Troesy.c:544:68: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if (alt_grd[0] == 'y') DPStimer(70,58,2,0,(int)ct,(int)v6,0,0); DPStimer(70,63,2,0,(int)v6,(int)v6,0,0);
+                                                                    ^~~~~~~~
+warn  : /vnmr/biopack/psglib/dpfgse_satxfer_tocsy
+dpfgse_satxfer_tocsy.c: In function 'pulsesequence':
+dpfgse_satxfer_tocsy.c:182:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (alt_grd[0] == 'y') hlv(ct,v6); mod2(v6,v6); /* 0011 0011 ..... */
+    ^~
+dpfgse_satxfer_tocsy.c:182:39: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if (alt_grd[0] == 'y') hlv(ct,v6); mod2(v6,v6); /* 0011 0011 ..... */
+                                       ^~~~
+dpfgse_satxfer_tocsy.c: In function 'x_pulsesequence':
+dpfgse_satxfer_tocsy.c:439:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (alt_grd[0] == 'y') DPSprint(0.00, "70 hlv 58 2 0 ct %d v6 %d \n", (int)(ct), (int)(v6)); DPSprint(0.00, "70 mod2 63 2 0 v6 %d v6 %d \n", (int)(v6), (int)(v6));
+    ^~
+dpfgse_satxfer_tocsy.c:439:97: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if (alt_grd[0] == 'y') DPSprint(0.00, "70 hlv 58 2 0 ct %d v6 %d \n", (int)(ct), (int)(v6)); DPSprint(0.00, "70 mod2 63 2 0 v6 %d v6 %d \n", (int)(v6), (int)(v6));
+                                                                                                 ^~~~~~~~
+dpfgse_satxfer_tocsy.c: In function 't_pulsesequence':
+dpfgse_satxfer_tocsy.c:705:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (alt_grd[0] == 'y') DPStimer(70,58,2,0,(int)ct,(int)v6,0,0); DPStimer(70,63,2,0,(int)v6,(int)v6,0,0);
+    ^~
+dpfgse_satxfer_tocsy.c:705:68: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if (alt_grd[0] == 'y') DPStimer(70,58,2,0,(int)ct,(int)v6,0,0); DPStimer(70,63,2,0,(int)v6,(int)v6,0,0);
+                                                                    ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gCLNfhsqc
+gCLNfhsqc.c: In function 'pulsesequence':
+gCLNfhsqc.c:78:27: warning: variable 'gt2' set but not used [-Wunused-but-set-variable]
+   double    tauxh, tau1,  gt2, gt1,
+                           ^~~
+gCLNfhsqc.c:73:13: warning: variable 'phase' set but not used [-Wunused-but-set-variable]
+   int       phase, t1_counter;
+             ^~~~~
+warn  : /vnmr/biopack/psglib/gCLNfhsqcA
+gCLNfhsqcA.c: In function 'pulsesequence':
+gCLNfhsqcA.c:94:27: warning: variable 'gt2' set but not used [-Wunused-but-set-variable]
+   double    tauxh, tau1,  gt2, gt1,
+                           ^~~
+gCLNfhsqcA.c:89:13: warning: variable 'phase' set but not used [-Wunused-but-set-variable]
+   int       phase, t1_counter;
+             ^~~~~
+warn  : /vnmr/biopack/psglib/gCNfilnoesyChsqcA
+gCNfilnoesyChsqcA.c: In function 'pulsesequence':
+gCNfilnoesyChsqcA.c:382:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gCNfilnoesyChsqcA.c:384:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+gCNfilnoesyChsqcA.c:641:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if ((satmode[B]=='n') && (wet[B]=='n'))
+   ^~
+gCNfilnoesyChsqcA.c:644:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      zgradpulse(gzlvl0, gt0);
+      ^~~~~~~~~~
+gCNfilnoesyChsqcA.c:218:14: warning: variable 'gzcal' set but not used [-Wunused-but-set-variable]
+              gzcal,        /* dac to G/cm conversion factor */
+              ^~~~~
+gCNfilnoesyChsqcA.c: In function 'x_pulsesequence':
+gCNfilnoesyChsqcA.c:1813:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gCNfilnoesyChsqcA.c:1815:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+gCNfilnoesyChsqcA.c:2096:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if ((satmode[B]=='n') && (wet[B]=='n'))
+   ^~
+gCNfilnoesyChsqcA.c:2099:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPSprint(gt0, "94 zgradpulse  11 0 3 z gt0 %.9f gzlvl0 %.9f  gradalt  %.9f \n", (float)(gt0), (float)(gzlvl0), (float)gradalt);
+      ^~~~~~~~
+gCNfilnoesyChsqcA.c: In function 't_pulsesequence':
+gCNfilnoesyChsqcA.c:3269:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gCNfilnoesyChsqcA.c:3271:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+gCNfilnoesyChsqcA.c:3552:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if ((satmode[B]=='n') && (wet[B]=='n'))
+   ^~
+gCNfilnoesyChsqcA.c:3555:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPStimer(94,0,0,1,0,0,0,0,(double)gt0);
+      ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gCNfilnoesyChsqcSE
+gCNfilnoesyChsqcSE.c: In function 'pulsesequence':
+gCNfilnoesyChsqcSE.c:196:3: warning: variable 'pwZlw' set but not used [-Wunused-but-set-variable]
+   pwZlw=0.0,   /* largest of pwNlw and 2*pwClw */
+   ^~~~~
+gCNfilnoesyChsqcSE.c: In function 'x_pulsesequence':
+gCNfilnoesyChsqcSE.c:2085:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ni > 0)
+    ^~
+gCNfilnoesyChsqcSE.c:2087:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     {
+     ^
+gCNfilnoesyChsqcSE.c: In function 't_pulsesequence':
+gCNfilnoesyChsqcSE.c:3544:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ni > 0)
+    ^~
+gCNfilnoesyChsqcSE.c:3546:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     {
+     ^
+warn  : /vnmr/biopack/psglib/gCNfilnoesyNfhsqcA
+gCNfilnoesyNfhsqcA.c: In function 'x_pulsesequence':
+gCNfilnoesyNfhsqcA.c:1926:1: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+ else if (CNfil == 2)
+ ^~~~
+gCNfilnoesyNfhsqcA.c:1981:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      if ((C13refoc[A]=='y') && (N15refoc[A]=='y') && (tau1 > pwZlw +2.0*pw/PI +3.0*SAPS_DELAY +2.0*POWER_DELAY +2.0*rof1))
+      ^~
+gCNfilnoesyNfhsqcA.c: In function 't_pulsesequence':
+gCNfilnoesyNfhsqcA.c:3409:1: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+ else if (CNfil == 2)
+ ^~~~
+gCNfilnoesyNfhsqcA.c:3464:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      if ((C13refoc[A]=='y') && (N15refoc[A]=='y') && (tau1 > pwZlw +2.0*pw/PI +3.0*SAPS_DELAY +2.0*POWER_DELAY +2.0*rof1))
+      ^~
+warn  : /vnmr/biopack/psglib/gCfhsqc
+gCfhsqc.c: In function 'pulsesequence':
+gCfhsqc.c:122:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gCfhsqc.c:124:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gCfhsqc.c: In function 'x_pulsesequence':
+gCfhsqc.c:383:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gCfhsqc.c:385:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gCfhsqc.c: In function 't_pulsesequence':
+gCfhsqc.c:653:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gCfhsqc.c:655:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/gCfhsqcA
+gCfhsqcA.c: In function 'pulsesequence':
+gCfhsqcA.c:154:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gCfhsqcA.c:156:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gCfhsqcA.c: In function 'x_pulsesequence':
+gCfhsqcA.c:1221:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gCfhsqcA.c:1223:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gCfhsqcA.c: In function 't_pulsesequence':
+gCfhsqcA.c:2297:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gCfhsqcA.c:2299:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/gChmqc
+gChmqc.c: In function 'pulsesequence':
+gChmqc.c:271:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if( ix == 1)
+   ^~
+gChmqc.c:274:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+  t1_counter = (int) ((d2 - d2_init)*sw1 + 0.5);
+  ^~~~~~~~~~
+gChmqc.c:352:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+gChmqc.c:353:47: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         Wet4(wetpwr,wetshape,wetpw,zero,one); delay(dz);
+                                               ^~~~~
+gChmqc.c: In function 'x_pulsesequence':
+gChmqc.c:609:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  else if (aliph[A] == 'y')
+       ^~
+gChmqc.c:614:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (phase == 2)
+   ^~
+gChmqc.c:706:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+gChmqc.c:707:49: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         x_Wet4(wetpwr,wetshape,wetpw,zero,one); DPSprint(dz, "10 delay  1 0 1 dz %.9f \n", (float)(dz));
+                                                 ^~~~~~~~
+gChmqc.c: In function 't_pulsesequence':
+gChmqc.c:962:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  else if (aliph[A] == 'y')
+       ^~
+gChmqc.c:967:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (phase == 2)
+   ^~
+gChmqc.c:1059:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+gChmqc.c:1060:49: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         t_Wet4(wetpwr,wetshape,wetpw,zero,one); DPStimer(10,0,0,1,0,0,0,0,(double)dz);
+                                                 ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gChmqcnoesyNhsqc
+gChmqcnoesyNhsqc.c: In function 'pulsesequence':
+gChmqcnoesyNhsqc.c:89:12: warning: variable 'ni3' set but not used [-Wunused-but-set-variable]
+  mix, ni2, ni3,
+            ^~~
+gChmqcnoesyNhsqc.c:89:7: warning: variable 'ni2' set but not used [-Wunused-but-set-variable]
+  mix, ni2, ni3,
+       ^~~
+warn  : /vnmr/biopack/psglib/gChmqcnoesy_Cfilt
+gChmqcnoesy_Cfilt.c: In function 'pulsesequence':
+gChmqcnoesy_Cfilt.c:95:14: warning: variable 'gzlvl4' set but not used [-Wunused-but-set-variable]
+              gzlvl4,
+              ^~~~~~
+gChmqcnoesy_Cfilt.c:93:14: warning: variable 'gzlvl2' set but not used [-Wunused-but-set-variable]
+              gzlvl2,
+              ^~~~~~
+gChmqcnoesy_Cfilt.c:85:14: warning: variable 'tauch' set but not used [-Wunused-but-set-variable]
+              tauch,        /* taua/2.0              */
+              ^~~~~
+warn  : /vnmr/biopack/psglib/gChsqcnoesy
+gChsqcnoesy.c: In function 'pulsesequence':
+gChsqcnoesy.c:153:10: warning: variable 'pwNlvl' set but not used [-Wunused-but-set-variable]
+          pwNlvl,  /* high dec2 pwr for 15N hard pulses    */
+          ^~~~~~
+gChsqcnoesy.c:143:10: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+          rf0,   /* full fine power */
+          ^~~
+gChsqcnoesy.c: In function 'x_pulsesequence':
+gChsqcnoesy.c:863:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   { if (dm2[C] == 'y')
+     ^~
+gChsqcnoesy.c:865:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(0.00, "2 decunblank  2 1 0 on 1 \n");
+         ^~~~~~~~
+gChsqcnoesy.c: In function 't_pulsesequence':
+gChsqcnoesy.c:1283:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   { if (dm2[C] == 'y')
+     ^~
+gChsqcnoesy.c:1285:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(2,0,0,0);
+         ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gChsqcnoesyA
+gChsqcnoesyA.c: In function 'pulsesequence':
+gChsqcnoesyA.c:175:10: warning: variable 'pwNlvl' set but not used [-Wunused-but-set-variable]
+          pwNlvl,  /* high dec2 pwr for 15N hard pulses    */
+          ^~~~~~
+gChsqcnoesyA.c:163:10: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+          rf0,   /* full fine power */
+          ^~~
+warn  : /vnmr/biopack/psglib/gChsqctocsy
+gChsqctocsy.c: In function 'pulsesequence':
+gChsqctocsy.c:182:66: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+          gzlvl0, gzlvl1, gzlvl2, gzlvl3, gzlvl4, gzlvl5, gzlvl6, gzlvl7;
+                                                                  ^~~~~~
+gChsqctocsy.c:182:58: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+          gzlvl0, gzlvl1, gzlvl2, gzlvl3, gzlvl4, gzlvl5, gzlvl6, gzlvl7;
+                                                          ^~~~~~
+gChsqctocsy.c:182:18: warning: variable 'gzlvl1' set but not used [-Wunused-but-set-variable]
+          gzlvl0, gzlvl1, gzlvl2, gzlvl3, gzlvl4, gzlvl5, gzlvl6, gzlvl7;
+                  ^~~~~~
+gChsqctocsy.c:176:10: warning: variable 'pwNlvl' set but not used [-Wunused-but-set-variable]
+          pwNlvl,  /* high dec2 pwr for 15N hard pulses    */
+          ^~~~~~
+gChsqctocsy.c:166:10: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+          rf0,   /* full fine power */
+          ^~~
+warn  : /vnmr/biopack/psglib/gChsqctocsyA
+gChsqctocsyA.c: In function 'pulsesequence':
+gChsqctocsyA.c:202:66: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+          gzlvl0, gzlvl1, gzlvl2, gzlvl3, gzlvl4, gzlvl5, gzlvl6, gzlvl7;
+                                                                  ^~~~~~
+gChsqctocsyA.c:202:58: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+          gzlvl0, gzlvl1, gzlvl2, gzlvl3, gzlvl4, gzlvl5, gzlvl6, gzlvl7;
+                                                          ^~~~~~
+gChsqctocsyA.c:202:18: warning: variable 'gzlvl1' set but not used [-Wunused-but-set-variable]
+          gzlvl0, gzlvl1, gzlvl2, gzlvl3, gzlvl4, gzlvl5, gzlvl6, gzlvl7;
+                  ^~~~~~
+gChsqctocsyA.c:194:10: warning: variable 'pwNlvl' set but not used [-Wunused-but-set-variable]
+          pwNlvl,  /* high dec2 pwr for 15N hard pulses    */
+          ^~~~~~
+gChsqctocsyA.c:184:10: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+          rf0,   /* full fine power */
+          ^~~
+warn  : /vnmr/biopack/psglib/gLRCH
+gLRCH.c: In function 'pulsesequence':
+gLRCH.c:303:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+gLRCH.c:306:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+    if(gt1 > 0.2e-6)
+    ^~
+gLRCH.c:103:6: warning: variable 'pwN' set but not used [-Wunused-but-set-variable]
+      pwN,
+      ^~~
+gLRCH.c: In function 'x_pulsesequence':
+gLRCH.c:727:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+gLRCH.c:730:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+    if(gt1 > 0.2e-6)
+    ^~
+gLRCH.c: In function 't_pulsesequence':
+gLRCH.c:1167:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+gLRCH.c:1170:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+    if(gt1 > 0.2e-6)
+    ^~
+warn  : /vnmr/biopack/psglib/gNT1
+gNT1.c: In function 'pulsesequence':
+gNT1.c:198:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNT1.c:200:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNT1.c:74:14: warning: variable 'tau1' set but not used [-Wunused-but-set-variable]
+              tau1,                  /* t1/2  */
+              ^~~~
+gNT1.c: In function 'x_pulsesequence':
+gNT1.c:530:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNT1.c:532:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNT1.c: In function 't_pulsesequence':
+gNT1.c:872:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNT1.c:874:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/gNT2
+gNT2.c: In function 'pulsesequence':
+gNT2.c:193:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNT2.c:195:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNT2.c:62:14: warning: variable 'tau1' set but not used [-Wunused-but-set-variable]
+              tau1,                  /* t1/2  */
+              ^~~~
+gNT2.c: In function 'x_pulsesequence':
+gNT2.c:542:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNT2.c:544:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNT2.c: In function 't_pulsesequence':
+gNT2.c:899:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNT2.c:901:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/gNTSR1
+gNTSR1.c: In function 'pulsesequence':
+gNTSR1.c:61:13: warning: variable 'gsign' set but not used [-Wunused-but-set-variable]
+             gsign,
+             ^~~~~
+warn  : /vnmr/biopack/psglib/gNcpmgex
+gNcpmgex.c: In function 'pulsesequence':
+gNcpmgex.c:145:11: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+           rf0,                     /* maximum fine power when using pwC pulses */
+           ^~~
+warn  : /vnmr/biopack/psglib/gNhmqc
+gNhmqc.c: In function 'pulsesequence':
+gNhmqc.c:225:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if( ix == 1)
+   ^~
+gNhmqc.c:228:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+  t1_counter = (int) ((d2 - d2_init)*sw1 + 0.5);
+  ^~~~~~~~~~
+gNhmqc.c: In function 'x_pulsesequence':
+gNhmqc.c:663:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+gNhmqc.c:666:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPSprint(gt1, "94 zgradpulse  11 0 3 z gt1 %.9f gzlvl1 %.9f  gradalt  %.9f \n", (float)(gt1), (float)(gzlvl1), (float)gradalt);
+         ^~~~~~~~
+gNhmqc.c: In function 't_pulsesequence':
+gNhmqc.c:1024:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+gNhmqc.c:1027:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gt1);
+         ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gNhmqcJ
+gNhmqcJ.c: In function 'pulsesequence':
+gNhmqcJ.c:206:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+gNhmqcJ.c:208:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+gNhmqcJ.c: In function 'x_pulsesequence':
+gNhmqcJ.c:511:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+gNhmqcJ.c:513:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+gNhmqcJ.c: In function 't_pulsesequence':
+gNhmqcJ.c:821:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix==1)
+    ^~
+gNhmqcJ.c:823:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+      ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/gNhmqcnoesyNhsqc
+gNhmqcnoesyNhsqc.c: In function 'pulsesequence':
+gNhmqcnoesyNhsqc.c:69:16: warning: variable 'ni3' set but not used [-Wunused-but-set-variable]
+  int      ni2, ni3, phase, phase2, phase3, icosel,t1_counter, t2_counter, t3_counter;
+                ^~~
+gNhmqcnoesyNhsqc.c:69:11: warning: variable 'ni2' set but not used [-Wunused-but-set-variable]
+  int      ni2, ni3, phase, phase2, phase3, icosel,t1_counter, t2_counter, t3_counter;
+           ^~~
+warn  : /vnmr/biopack/psglib/gNhsqc2
+gNhsqc2.c: In function 'pulsesequence':
+gNhsqc2.c:336:4: warning: variable 'rfst' set but not used [-Wunused-but-set-variable]
+    rfst,                            /* fine power for the stCall pulse */
+    ^~~~
+gNhsqc2.c:335:4: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+    rf0,                       /* maximum fine power when using pwC pulses */
+    ^~~
+warn  : /vnmr/biopack/psglib/gNhsqcHT
+gNhsqcHT.c: In function 'pulsesequence':
+gNhsqcHT.c:70:13: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+             rf0,                /* maximum fine power when using pwC pulses */
+             ^~~
+warn  : /vnmr/biopack/psglib/gNhsqc_IPAP
+gNhsqc_IPAP.c: In function 'pulsesequence':
+gNhsqc_IPAP.c:146:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNhsqc_IPAP.c:148:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNhsqc_IPAP.c:68:4: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+    rf0,                       /* maximum fine power when using pwC pulses */
+    ^~~
+gNhsqc_IPAP.c: In function 'x_pulsesequence':
+gNhsqc_IPAP.c:364:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNhsqc_IPAP.c:366:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNhsqc_IPAP.c: In function 't_pulsesequence':
+gNhsqc_IPAP.c:583:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNhsqc_IPAP.c:585:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/gNhsqc_IPAPA
+gNhsqc_IPAPA.c: In function 'pulsesequence':
+gNhsqc_IPAPA.c:186:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNhsqc_IPAPA.c:188:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNhsqc_IPAPA.c:85:4: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+    rf0,                       /* maximum fine power when using pwC pulses */
+    ^~~
+gNhsqc_IPAPA.c: In function 'x_pulsesequence':
+gNhsqc_IPAPA.c:1221:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNhsqc_IPAPA.c:1223:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNhsqc_IPAPA.c: In function 't_pulsesequence':
+gNhsqc_IPAPA.c:2257:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNhsqc_IPAPA.c:2259:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/gNhsqc_IPAP_gel
+gNhsqc_IPAP_gel.c: In function 'pulsesequence':
+gNhsqc_IPAP_gel.c:162:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNhsqc_IPAP_gel.c:164:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNhsqc_IPAP_gel.c:89:4: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+    rf0,                       /* maximum fine power when using pwC pulses */
+    ^~~
+gNhsqc_IPAP_gel.c: In function 'x_pulsesequence':
+gNhsqc_IPAP_gel.c:383:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNhsqc_IPAP_gel.c:385:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNhsqc_IPAP_gel.c: In function 't_pulsesequence':
+gNhsqc_IPAP_gel.c:605:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNhsqc_IPAP_gel.c:607:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/gNhsqcnoesy
+gNhsqcnoesy.c: In function 'x_pulsesequence':
+gNhsqcnoesy.c:906:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+gNhsqcnoesy.c:909:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 two %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(two), (float)(pw));
+     ^~~~~~~~
+gNhsqcnoesy.c:917:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  if (wet[A] == 'y')
+  ^~
+gNhsqcnoesy.c:919:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 2.0e-6 %.9f rof1 %.9f  1 zero %d pw %.9f \n", (float)(2.0e-6), (float)(rof1), (int)(zero), (float)(pw));
+     ^~~~~~~~
+gNhsqcnoesy.c: In function 't_pulsesequence':
+gNhsqcnoesy.c:1335:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+gNhsqcnoesy.c:1338:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+gNhsqcnoesy.c:1346:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  if (wet[A] == 'y')
+  ^~
+gNhsqcnoesy.c:1348:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)2.0e-6,(double)rof1);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gNhsqcnoesyA
+gNhsqcnoesyA.c: In function 'x_pulsesequence':
+gNhsqcnoesyA.c:1744:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+gNhsqcnoesyA.c:1747:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 two %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(two), (float)(pw));
+     ^~~~~~~~
+gNhsqcnoesyA.c:1755:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  if (wet[A] == 'y')
+  ^~
+gNhsqcnoesyA.c:1757:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 2.0e-6 %.9f rof1 %.9f  1 zero %d pw %.9f \n", (float)(2.0e-6), (float)(rof1), (int)(zero), (float)(pw));
+     ^~~~~~~~
+gNhsqcnoesyA.c: In function 't_pulsesequence':
+gNhsqcnoesyA.c:2986:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+gNhsqcnoesyA.c:2989:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+gNhsqcnoesyA.c:2997:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  if (wet[A] == 'y')
+  ^~
+gNhsqcnoesyA.c:2999:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)2.0e-6,(double)rof1);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gNhsqctocsy
+gNhsqctocsy.c: In function 'x_pulsesequence':
+gNhsqctocsy.c:947:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+  else
+  ^~~~
+gNhsqctocsy.c:950:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 t4 %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(t4), (float)(pw));
+     ^~~~~~~~
+gNhsqctocsy.c: In function 't_pulsesequence':
+gNhsqctocsy.c:1392:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+  else
+  ^~~~
+gNhsqctocsy.c:1395:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gNhsqctocsyA
+gNhsqctocsyA.c: In function 'x_pulsesequence':
+gNhsqctocsyA.c:1798:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+  else
+  ^~~~
+gNhsqctocsyA.c:1801:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 t4 %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(t4), (float)(pw));
+     ^~~~~~~~
+gNhsqctocsyA.c: In function 't_pulsesequence':
+gNhsqctocsyA.c:3059:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+  else
+  ^~~~
+gNhsqctocsyA.c:3062:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gNhsqctocsynoesyNhsqc
+gNhsqctocsynoesyNhsqc.c: In function 'pulsesequence':
+gNhsqctocsynoesyNhsqc.c:145:4: warning: variable 'dof100' set but not used [-Wunused-but-set-variable]
+    dof100,       /* C13 frequency at 100ppm for both aliphatic & aromatic*/
+    ^~~~~~
+warn  : /vnmr/biopack/psglib/gNhsqctocsynoesyNhsqcA
+gNhsqctocsynoesyNhsqcA.c: In function 'pulsesequence':
+gNhsqctocsynoesyNhsqcA.c:161:4: warning: variable 'dof100' set but not used [-Wunused-but-set-variable]
+    dof100,       /* C13 frequency at 100ppm for both aliphatic & aromatic*/
+    ^~~~~~
+warn  : /vnmr/biopack/psglib/gNtrosyS3
+gNtrosyS3.c: In function 'pulsesequence':
+gNtrosyS3.c:247:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNtrosyS3.c:249:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNtrosyS3.c: In function 'x_pulsesequence':
+gNtrosyS3.c:570:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNtrosyS3.c:572:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+gNtrosyS3.c: In function 't_pulsesequence':
+gNtrosyS3.c:891:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+gNtrosyS3.c:893:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/gc_tocsy_nch2A
+gc_tocsy_nch2A.c: In function 'pulsesequence':
+gc_tocsy_nch2A.c:83:29: warning: variable 'ni' set but not used [-Wunused-but-set-variable]
+  int         phase, phase2, ni, ni2, ncyc,
+                             ^~
+warn  : /vnmr/biopack/psglib/gcacb_tocsy_cmhmA
+gcacb_tocsy_cmhmA.c: In function 'pulsesequence':
+gcacb_tocsy_cmhmA.c:501:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhmA.c:503:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         delay(gstab/2.0);
+         ^~~~~
+gcacb_tocsy_cmhmA.c:507:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhmA.c:509:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         delay(gstab/2.0);
+         ^~~~~
+gcacb_tocsy_cmhmA.c: In function 'x_pulsesequence':
+gcacb_tocsy_cmhmA.c:1823:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhmA.c:1825:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPSprint(gstab/2.0, "10 delay  1 0 1 gstab/2.0 %.9f \n", (float)(gstab/2.0));
+         ^~~~~~~~
+gcacb_tocsy_cmhmA.c:1829:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhmA.c:1831:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPSprint(gstab/2.0, "10 delay  1 0 1 gstab/2.0 %.9f \n", (float)(gstab/2.0));
+         ^~~~~~~~
+gcacb_tocsy_cmhmA.c: In function 't_pulsesequence':
+gcacb_tocsy_cmhmA.c:3148:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhmA.c:3150:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPStimer(10,0,0,1,0,0,0,0,(double)gstab/2.0);
+         ^~~~~~~~
+gcacb_tocsy_cmhmA.c:3154:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhmA.c:3156:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPStimer(10,0,0,1,0,0,0,0,(double)gstab/2.0);
+         ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gcacb_tocsy_cmhm_sqA
+gcacb_tocsy_cmhm_sqA.c: In function 'pulsesequence':
+gcacb_tocsy_cmhm_sqA.c:507:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhm_sqA.c:509:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         delay(gstab/2.0);
+         ^~~~~
+gcacb_tocsy_cmhm_sqA.c:513:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhm_sqA.c:515:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         delay(gstab/2.0);
+         ^~~~~
+gcacb_tocsy_cmhm_sqA.c: In function 'x_pulsesequence':
+gcacb_tocsy_cmhm_sqA.c:1830:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhm_sqA.c:1832:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPSprint(gstab/2.0, "10 delay  1 0 1 gstab/2.0 %.9f \n", (float)(gstab/2.0));
+         ^~~~~~~~
+gcacb_tocsy_cmhm_sqA.c:1836:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhm_sqA.c:1838:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPSprint(gstab/2.0, "10 delay  1 0 1 gstab/2.0 %.9f \n", (float)(gstab/2.0));
+         ^~~~~~~~
+gcacb_tocsy_cmhm_sqA.c: In function 't_pulsesequence':
+gcacb_tocsy_cmhm_sqA.c:3156:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhm_sqA.c:3158:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPStimer(10,0,0,1,0,0,0,0,(double)gstab/2.0);
+         ^~~~~~~~
+gcacb_tocsy_cmhm_sqA.c:3162:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gcacb_tocsy_cmhm_sqA.c:3164:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPStimer(10,0,0,1,0,0,0,0,(double)gstab/2.0);
+         ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gh2cnA
+gh2cnA.c: In function 'pulsesequence':
+gh2cnA.c:107:29: warning: variable 'ni' set but not used [-Wunused-but-set-variable]
+  int         phase, phase2, ni, ni2,
+                             ^~
+warn  : /vnmr/biopack/psglib/ghca_co
+ghca_co.c: In function 'pulsesequence':
+ghca_co.c:127:5: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+     gzlvl7,
+     ^~~~~~
+ghca_co.c:118:5: warning: variable 'gt7' set but not used [-Wunused-but-set-variable]
+     gt7,
+     ^~~
+warn  : /vnmr/biopack/psglib/ghca_coA
+ghca_coA.c: In function 'pulsesequence':
+ghca_coA.c:145:5: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+     gzlvl7,
+     ^~~~~~
+ghca_coA.c:136:5: warning: variable 'gt7' set but not used [-Wunused-but-set-variable]
+     gt7,
+     ^~~
+warn  : /vnmr/biopack/psglib/ghca_co_canh
+ghca_co_canh.c: In function 'pulsesequence':
+ghca_co_canh.c:128:5: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+     gzlvl7,
+     ^~~~~~
+ghca_co_canh.c:119:5: warning: variable 'gt7' set but not used [-Wunused-but-set-variable]
+     gt7,
+     ^~~
+warn  : /vnmr/biopack/psglib/ghca_co_canhA
+ghca_co_canhA.c: In function 'pulsesequence':
+ghca_co_canhA.c:142:5: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+     gzlvl7,
+     ^~~~~~
+ghca_co_canhA.c:133:5: warning: variable 'gt7' set but not used [-Wunused-but-set-variable]
+     gt7,
+     ^~~
+warn  : /vnmr/biopack/psglib/ghca_co_n
+ghca_co_n.c: In function 'pulsesequence':
+ghca_co_n.c:128:5: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+     gzlvl7,
+     ^~~~~~
+ghca_co_n.c:119:5: warning: variable 'gt7' set but not used [-Wunused-but-set-variable]
+     gt7,
+     ^~~
+warn  : /vnmr/biopack/psglib/ghca_co_nA
+ghca_co_nA.c: In function 'pulsesequence':
+ghca_co_nA.c:146:5: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+     gzlvl7,
+     ^~~~~~
+ghca_co_nA.c:137:5: warning: variable 'gt7' set but not used [-Wunused-but-set-variable]
+     gt7,
+     ^~~
+warn  : /vnmr/biopack/psglib/ghcch_tocsy
+ghcch_tocsy.c: In function 'x_pulsesequence':
+ghcch_tocsy.c:1069:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if ((STUD[A]=='n') && (dm[C] == 'y'))
+    ^~
+ghcch_tocsy.c:1071:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if ( dm3[B] == 'y' )
+         ^~
+ghcch_tocsy.c: In function 't_pulsesequence':
+ghcch_tocsy.c:1563:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if ((STUD[A]=='n') && (dm[C] == 'y'))
+    ^~
+ghcch_tocsy.c:1565:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if ( dm3[B] == 'y' )
+         ^~
+warn  : /vnmr/biopack/psglib/ghcch_tocsyA
+ghcch_tocsyA.c: In function 'x_pulsesequence':
+ghcch_tocsyA.c:1952:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if ((STUD[A]=='n') && (dm[C] == 'y'))
+    ^~
+ghcch_tocsyA.c:1954:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if ( dm3[B] == 'y' )
+         ^~
+ghcch_tocsyA.c: In function 't_pulsesequence':
+ghcch_tocsyA.c:3280:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if ((STUD[A]=='n') && (dm[C] == 'y'))
+    ^~
+ghcch_tocsyA.c:3282:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if ( dm3[B] == 'y' )
+         ^~
+warn  : /vnmr/biopack/psglib/ghcch_tocsy_cmhm2
+ghcch_tocsy_cmhm2.c: In function 'pulsesequence':
+ghcch_tocsy_cmhm2.c:72:6: warning: variable 't3_counter' set but not used [-Wunused-but-set-variable]
+      t3_counter,    /* used for states tppi in t3, not yet set */
+      ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/ghcch_tocsy_cmhm3
+ghcch_tocsy_cmhm3.c: In function 'pulsesequence':
+ghcch_tocsy_cmhm3.c:100:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,       /* the largest of pwC10 and 2.0*pwN */
+    ^~~
+ghcch_tocsy_cmhm3.c:72:6: warning: variable 't3_counter' set but not used [-Wunused-but-set-variable]
+      t3_counter,    /* used for states tppi in t3, not yet set */
+      ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/ghcch_tocsy_cmhm4
+ghcch_tocsy_cmhm4.c: In function 'pulsesequence':
+ghcch_tocsy_cmhm4.c:139:21: warning: variable 'cores' set but not used [-Wunused-but-set-variable]
+         pwco,copwr, cores,codmf;
+                     ^~~~~
+ghcch_tocsy_cmhm4.c:139:14: warning: variable 'copwr' set but not used [-Wunused-but-set-variable]
+         pwco,copwr, cores,codmf;
+              ^~~~~
+ghcch_tocsy_cmhm4.c:139:9: warning: variable 'pwco' set but not used [-Wunused-but-set-variable]
+         pwco,copwr, cores,codmf;
+         ^~~~
+ghcch_tocsy_cmhm4.c:75:6: warning: variable 't3_counter' set but not used [-Wunused-but-set-variable]
+      t3_counter,    /* used for states tppi in t3, not yet set */
+      ^~~~~~~~~~
+ghcch_tocsy_cmhm4.c:74:13: warning: variable 't2_counter' set but not used [-Wunused-but-set-variable]
+             t2_counter,             /* used for states tppi in t2 */
+             ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/ghn_Jcoca_2DS3
+ghn_Jcoca_2DS3.c: In function 'pulsesequence':
+ghn_Jcoca_2DS3.c:248:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghn_Jcoca_2DS3.c:250:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghn_Jcoca_2DS3.c:106:14: warning: variable 'dofca' set but not used [-Wunused-but-set-variable]
+              dofca,
+              ^~~~~
+ghn_Jcoca_2DS3.c:83:58: warning: variable 'taucacb' set but not used [-Wunused-but-set-variable]
+              tauhn,taunco,taucoca,taunca,tauhaca,taucaha,taucacb,
+                                                          ^~~~~~~
+ghn_Jcoca_2DS3.c:83:50: warning: variable 'taucaha' set but not used [-Wunused-but-set-variable]
+              tauhn,taunco,taucoca,taunca,tauhaca,taucaha,taucacb,
+                                                  ^~~~~~~
+ghn_Jcoca_2DS3.c:83:42: warning: variable 'tauhaca' set but not used [-Wunused-but-set-variable]
+              tauhn,taunco,taucoca,taunca,tauhaca,taucaha,taucacb,
+                                          ^~~~~~~
+ghn_Jcoca_2DS3.c:83:35: warning: variable 'taunca' set but not used [-Wunused-but-set-variable]
+              tauhn,taunco,taucoca,taunca,tauhaca,taucaha,taucacb,
+                                   ^~~~~~
+ghn_Jcoca_2DS3.c: In function 'x_pulsesequence':
+ghn_Jcoca_2DS3.c:749:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghn_Jcoca_2DS3.c:751:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghn_Jcoca_2DS3.c: In function 't_pulsesequence':
+ghn_Jcoca_2DS3.c:1253:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghn_Jcoca_2DS3.c:1255:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/ghn_Jnca_2DS3
+ghn_Jnca_2DS3.c: In function 'pulsesequence':
+ghn_Jnca_2DS3.c:230:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghn_Jnca_2DS3.c:232:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghn_Jnca_2DS3.c:73:58: warning: variable 'taucacb' set but not used [-Wunused-but-set-variable]
+              tauhn,taunco,taucoca,taunca,tauhaca,taucaha,taucacb,
+                                                          ^~~~~~~
+ghn_Jnca_2DS3.c:73:50: warning: variable 'taucaha' set but not used [-Wunused-but-set-variable]
+              tauhn,taunco,taucoca,taunca,tauhaca,taucaha,taucacb,
+                                                  ^~~~~~~
+ghn_Jnca_2DS3.c:73:42: warning: variable 'tauhaca' set but not used [-Wunused-but-set-variable]
+              tauhn,taunco,taucoca,taunca,tauhaca,taucaha,taucacb,
+                                          ^~~~~~~
+ghn_Jnca_2DS3.c:73:35: warning: variable 'taunca' set but not used [-Wunused-but-set-variable]
+              tauhn,taunco,taucoca,taunca,tauhaca,taucaha,taucacb,
+                                   ^~~~~~
+ghn_Jnca_2DS3.c: In function 'x_pulsesequence':
+ghn_Jnca_2DS3.c:692:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghn_Jnca_2DS3.c:694:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghn_Jnca_2DS3.c: In function 't_pulsesequence':
+ghn_Jnca_2DS3.c:1158:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghn_Jnca_2DS3.c:1160:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/ghn_Jnco_2DS3
+ghn_Jnco_2DS3.c: In function 'pulsesequence':
+ghn_Jnco_2DS3.c:240:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+ghn_Jnco_2DS3.c:242:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghn_Jnco_2DS3.c:101:14: warning: variable 'dofca' set but not used [-Wunused-but-set-variable]
+              dofca,
+              ^~~~~
+ghn_Jnco_2DS3.c: In function 'x_pulsesequence':
+ghn_Jnco_2DS3.c:659:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+ghn_Jnco_2DS3.c:661:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghn_Jnco_2DS3.c: In function 't_pulsesequence':
+ghn_Jnco_2DS3.c:1080:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+ghn_Jnco_2DS3.c:1082:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/ghn_cacbCTP
+ghn_cacbCTP.c: In function 'pulsesequence':
+ghn_cacbCTP.c:200:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,         /* the largest of pwS2 and 2.0*pwN for 1D experiments */
+    ^~~~
+ghn_cacbCTP.c:199:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,        /* the largest of pwS2 and 2.0*pwN */
+    ^~~
+ghn_cacbCTP.c:196:4: warning: variable 'phshift' set but not used [-Wunused-but-set-variable]
+    phshift,        /* phase shift induced on Cab by 180 on CO in middle of t1 */
+    ^~~~~~~
+ghn_cacbCTP.c:195:4: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+    pwS1,     /* length of square 90 on Cab */
+    ^~~~
+warn  : /vnmr/biopack/psglib/ghn_co_hb
+ghn_co_hb.c: In function 'pulsesequence':
+ghn_co_hb.c:116:5: warning: variable 'gzlvl10' set but not used [-Wunused-but-set-variable]
+     gzlvl10;
+     ^~~~~~~
+ghn_co_hb.c:114:5: warning: variable 'gzlvl8' set but not used [-Wunused-but-set-variable]
+     gzlvl8,
+     ^~~~~~
+ghn_co_hb.c:105:5: warning: variable 'gt10' set but not used [-Wunused-but-set-variable]
+     gt10,
+     ^~~~
+warn  : /vnmr/biopack/psglib/ghn_co_hbA
+ghn_co_hbA.c: In function 'pulsesequence':
+ghn_co_hbA.c:134:5: warning: variable 'gzlvl10' set but not used [-Wunused-but-set-variable]
+     gzlvl10;
+     ^~~~~~~
+ghn_co_hbA.c:132:5: warning: variable 'gzlvl8' set but not used [-Wunused-but-set-variable]
+     gzlvl8,
+     ^~~~~~
+ghn_co_hbA.c:123:5: warning: variable 'gt10' set but not used [-Wunused-but-set-variable]
+     gt10,
+     ^~~~
+warn  : /vnmr/biopack/psglib/ghn_coca_cb
+ghn_coca_cb.c: In function 'pulsesequence':
+ghn_coca_cb.c:178:6: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+      rf0,               /* maximum fine power when using pwC pulses */
+      ^~~
+warn  : /vnmr/biopack/psglib/ghn_coco
+ghn_coco.c: In function 'pulsesequence':
+ghn_coco.c:209:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,        /* the largest of pwC3a and 2.0*pwN for 1D experiments */
+    ^~~~
+ghn_coco.c:208:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,        /* the largest of pwC3 and 2.0*pwN */
+    ^~~
+ghn_coco.c:207:4: warning: variable 'phshift3' set but not used [-Wunused-but-set-variable]
+    phshift3,             /* phase shift induced on CO by pwC3 ("offC3") pulse */
+    ^~~~~~~~
+warn  : /vnmr/biopack/psglib/ghn_cocoA
+ghn_cocoA.c: In function 'pulsesequence':
+ghn_cocoA.c:222:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,        /* the largest of pwC3a and 2.0*pwN for 1D experiments */
+    ^~~~
+ghn_cocoA.c:221:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,        /* the largest of pwC3 and 2.0*pwN */
+    ^~~
+ghn_cocoA.c:220:4: warning: variable 'phshift3' set but not used [-Wunused-but-set-variable]
+    phshift3,             /* phase shift induced on CO by pwC3 ("offC3") pulse */
+    ^~~~~~~~
+warn  : /vnmr/biopack/psglib/ghnca_Jnha_3D
+ghnca_Jnha_3D.c: In function 'pulsesequence':
+ghnca_Jnha_3D.c:93:39: warning: variable 'taucacb' set but not used [-Wunused-but-set-variable]
+              jcacb = getval("jcacb"), taucacb,
+                                       ^~~~~~~
+ghnca_Jnha_3D.c:92:39: warning: variable 'taucaha' set but not used [-Wunused-but-set-variable]
+              jcaha = getval("jcaha"), taucaha,
+                                       ^~~~~~~
+ghnca_Jnha_3D.c:91:39: warning: variable 'tauhaca' set but not used [-Wunused-but-set-variable]
+              jhaca = getval("jhaca"), tauhaca,
+                                       ^~~~~~~
+ghnca_Jnha_3D.c:89:39: warning: variable 'taucoca' set but not used [-Wunused-but-set-variable]
+              jcoca = getval("jcoca"), taucoca,
+                                       ^~~~~~~
+ghnca_Jnha_3D.c:88:37: warning: variable 'taunco' set but not used [-Wunused-but-set-variable]
+              jnco = getval("jnco"), taunco,
+                                     ^~~~~~
+warn  : /vnmr/biopack/psglib/ghnca_trosy_3DA
+ghnca_trosy_3DA.c: In function 'pulsesequence':
+ghnca_trosy_3DA.c:353:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (shared_CT[A] == 'n')
+   ^~
+ghnca_trosy_3DA.c:362:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if(fCT[A] == 'y')
+    ^~
+ghnca_trosy_3DA.c:362:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+ghnca_trosy_3DA.c:379:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y' ))
+     ^~
+ghnca_trosy_3DA.c:190:14: warning: variable 'at' set but not used [-Wunused-but-set-variable]
+              at,
+              ^~
+ghnca_trosy_3DA.c: In function 'x_pulsesequence':
+ghnca_trosy_3DA.c:2045:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (shared_CT[A] == 'n')
+   ^~
+ghnca_trosy_3DA.c:2055:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if(fCT[A] == 'y')
+    ^~
+ghnca_trosy_3DA.c: In function 't_pulsesequence':
+ghnca_trosy_3DA.c:3763:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (shared_CT[A] == 'n')
+   ^~
+ghnca_trosy_3DA.c:3773:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if(fCT[A] == 'y')
+    ^~
+warn  : /vnmr/biopack/psglib/ghncacb_intraP
+ghncacb_intraP.c: In function 'pulsesequence':
+ghncacb_intraP.c:91:4: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+    pwS1,      /* length of square 90 on Ca */
+    ^~~~
+warn  : /vnmr/biopack/psglib/ghncacb_trosy_3DA
+ghncacb_trosy_3DA.c: In function 'pulsesequence':
+ghncacb_trosy_3DA.c:403:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(fCT[A] == 'y')
+    ^~
+ghncacb_trosy_3DA.c:418:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y'))
+     ^~
+ghncacb_trosy_3DA.c:252:14: warning: variable 'gzlvl8' set but not used [-Wunused-but-set-variable]
+              gzlvl8,
+              ^~~~~~
+ghncacb_trosy_3DA.c: In function 'x_pulsesequence':
+ghncacb_trosy_3DA.c:2241:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(fCT[A] == 'y')
+    ^~
+ghncacb_trosy_3DA.c:2257:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y'))
+     ^~
+ghncacb_trosy_3DA.c: In function 't_pulsesequence':
+ghncacb_trosy_3DA.c:4101:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(fCT[A] == 'y')
+    ^~
+ghncacb_trosy_3DA.c:4117:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y'))
+     ^~
+warn  : /vnmr/biopack/psglib/ghncaco_trosy_3DA
+ghncaco_trosy_3DA.c: In function 'pulsesequence':
+ghncaco_trosy_3DA.c:440:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if(f1180[A] == 'n')
+     ^~
+ghncaco_trosy_3DA.c:446:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if(tau1 < 0.2e-6) tau1 = 0.2e-6;
+         ^~
+ghncaco_trosy_3DA.c:157:14: warning: variable 'at' set but not used [-Wunused-but-set-variable]
+              at,
+              ^~
+ghncaco_trosy_3DA.c: In function 'x_pulsesequence':
+ghncaco_trosy_3DA.c:2163:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if(f1180[A] == 'n')
+     ^~
+ghncaco_trosy_3DA.c:2169:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if(tau1 < 0.2e-6) tau1 = 0.2e-6;
+         ^~
+ghncaco_trosy_3DA.c: In function 't_pulsesequence':
+ghncaco_trosy_3DA.c:3875:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if(f1180[A] == 'n')
+     ^~
+ghncaco_trosy_3DA.c:3881:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if(tau1 < 0.2e-6) tau1 = 0.2e-6;
+         ^~
+warn  : /vnmr/biopack/psglib/ghncaco_trosy_4DA
+ghncaco_trosy_4DA.c: In function 'pulsesequence':
+ghncaco_trosy_4DA.c:531:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if(f2180[A] == 'n')
+     ^~
+ghncaco_trosy_4DA.c:535:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if(tau2 < 0.2e-6) tau2 = 0.2e-6;
+         ^~
+ghncaco_trosy_4DA.c:194:14: warning: variable 'at' set but not used [-Wunused-but-set-variable]
+              at,
+              ^~
+warn  : /vnmr/biopack/psglib/ghncn
+ghncn.c: In function 'pulsesequence':
+ghncn.c:157:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,                /* the larger of pwC9a and 2.0*pwN for 1D experiments */
+    ^~~~
+ghncn.c:156:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,        /* the largest of pwC9 and 2.0*pwN */
+    ^~~
+ghncn.c:155:4: warning: variable 'phshift9' set but not used [-Wunused-but-set-variable]
+    phshift9,             /* phase shift induced on Ca by pwC9 ("offC9") pulse */
+    ^~~~~~~~
+warn  : /vnmr/biopack/psglib/ghncnA
+ghncnA.c: In function 'pulsesequence':
+ghncnA.c:168:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,                /* the larger of pwC9a and 2.0*pwN for 1D experiments */
+    ^~~~
+ghncnA.c:167:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,        /* the largest of pwC9 and 2.0*pwN */
+    ^~~
+ghncnA.c:166:4: warning: variable 'phshift9' set but not used [-Wunused-but-set-variable]
+    phshift9,             /* phase shift induced on Ca by pwC9 ("offC9") pulse */
+    ^~~~~~~~
+warn  : /vnmr/biopack/psglib/ghnco_DNCO_trosyA
+ghnco_DNCO_trosyA.c: In function 'pulsesequence':
+ghnco_DNCO_trosyA.c:174:14: warning: variable 'gzlvl8' set but not used [-Wunused-but-set-variable]
+              gzlvl8;
+              ^~~~~~
+ghnco_DNCO_trosyA.c:166:14: warning: variable 'gzlvl0' set but not used [-Wunused-but-set-variable]
+              gzlvl0,
+              ^~~~~~
+ghnco_DNCO_trosyA.c:136:14: warning: variable 'BigT1' set but not used [-Wunused-but-set-variable]
+              BigT1,        /* delay to compensate for gradient */
+              ^~~~~
+ghnco_DNCO_trosyA.c:129:14: warning: variable 'compN' set but not used [-Wunused-but-set-variable]
+              compN,
+              ^~~~~
+ghnco_DNCO_trosyA.c:122:29: warning: variable 'ni2' set but not used [-Wunused-but-set-variable]
+  int         phase, phase2, ni2, icosel, /* icosel changes sign with gds  */
+                             ^~~
+warn  : /vnmr/biopack/psglib/ghnco_Jcoca_3DS3
+ghnco_Jcoca_3DS3.c: In function 'pulsesequence':
+ghnco_Jcoca_3DS3.c:265:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghnco_Jcoca_3DS3.c:267:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghnco_Jcoca_3DS3.c:278:10: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+          if (ix == 1)
+          ^~
+ghnco_Jcoca_3DS3.c:280:13: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+             t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+             ^~~~~~~~~~
+ghnco_Jcoca_3DS3.c:93:30: warning: variable 'taucacb' set but not used [-Wunused-but-set-variable]
+              tauhaca,taucaha,taucacb,
+                              ^~~~~~~
+ghnco_Jcoca_3DS3.c:93:22: warning: variable 'taucaha' set but not used [-Wunused-but-set-variable]
+              tauhaca,taucaha,taucacb,
+                      ^~~~~~~
+ghnco_Jcoca_3DS3.c:93:14: warning: variable 'tauhaca' set but not used [-Wunused-but-set-variable]
+              tauhaca,taucaha,taucacb,
+              ^~~~~~~
+ghnco_Jcoca_3DS3.c:92:34: warning: variable 'taunca' set but not used [-Wunused-but-set-variable]
+       kappa,tauhn,taunco,taucoca,taunca,
+                                  ^~~~~~
+ghnco_Jcoca_3DS3.c: In function 'x_pulsesequence':
+ghnco_Jcoca_3DS3.c:790:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghnco_Jcoca_3DS3.c:792:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghnco_Jcoca_3DS3.c:804:10: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+          if (ix == 1)
+          ^~
+ghnco_Jcoca_3DS3.c:806:13: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+             t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+             ^~~~~~~~~~
+ghnco_Jcoca_3DS3.c: In function 't_pulsesequence':
+ghnco_Jcoca_3DS3.c:1319:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghnco_Jcoca_3DS3.c:1321:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghnco_Jcoca_3DS3.c:1333:10: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+          if (ix == 1)
+          ^~
+ghnco_Jcoca_3DS3.c:1335:13: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+             t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+             ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/ghnco_Jnca_3DS3
+ghnco_Jnca_3DS3.c: In function 'pulsesequence':
+ghnco_Jnca_3DS3.c:288:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghnco_Jnca_3DS3.c:290:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghnco_Jnca_3DS3.c:124:38: warning: variable 'taucacb' set but not used [-Wunused-but-set-variable]
+              jcacb = getval("jcacb"),taucacb,
+                                      ^~~~~~~
+ghnco_Jnca_3DS3.c:123:38: warning: variable 'taucaha' set but not used [-Wunused-but-set-variable]
+              jcaha = getval("jcaha"),taucaha,
+                                      ^~~~~~~
+ghnco_Jnca_3DS3.c:122:38: warning: variable 'tauhaca' set but not used [-Wunused-but-set-variable]
+              jhaca = getval("jhaca"),tauhaca,
+                                      ^~~~~~~
+ghnco_Jnca_3DS3.c:121:36: warning: variable 'taunca' set but not used [-Wunused-but-set-variable]
+              jnca = getval("jnca"),taunca,
+                                    ^~~~~~
+ghnco_Jnca_3DS3.c: In function 'x_pulsesequence':
+ghnco_Jnca_3DS3.c:804:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghnco_Jnca_3DS3.c:806:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghnco_Jnca_3DS3.c: In function 't_pulsesequence':
+ghnco_Jnca_3DS3.c:1325:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghnco_Jnca_3DS3.c:1327:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/ghnco_Jnco_3DS3
+ghnco_Jnco_3DS3.c: In function 'pulsesequence':
+ghnco_Jnco_3DS3.c:268:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghnco_Jnco_3DS3.c:270:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghnco_Jnco_3DS3.c:278:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if(ix==1)
+     ^~
+ghnco_Jnco_3DS3.c:280:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+      ^~~~~~~~~~
+ghnco_Jnco_3DS3.c:98:39: warning: variable 'taucacb' set but not used [-Wunused-but-set-variable]
+              jcacb = getval("jcacb"), taucacb,
+                                       ^~~~~~~
+ghnco_Jnco_3DS3.c:97:39: warning: variable 'taucaha' set but not used [-Wunused-but-set-variable]
+              jcaha = getval("jcaha"), taucaha,
+                                       ^~~~~~~
+ghnco_Jnco_3DS3.c:96:39: warning: variable 'tauhaca' set but not used [-Wunused-but-set-variable]
+              jhaca = getval("jhaca"), tauhaca,
+                                       ^~~~~~~
+ghnco_Jnco_3DS3.c:95:37: warning: variable 'taunca' set but not used [-Wunused-but-set-variable]
+              jnca = getval("jnca"), taunca,
+                                     ^~~~~~
+ghnco_Jnco_3DS3.c:94:39: warning: variable 'taucoca' set but not used [-Wunused-but-set-variable]
+              jcoca = getval("jcoca"), taucoca,
+                                       ^~~~~~~
+ghnco_Jnco_3DS3.c: In function 'x_pulsesequence':
+ghnco_Jnco_3DS3.c:811:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghnco_Jnco_3DS3.c:813:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghnco_Jnco_3DS3.c:822:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if(ix==1)
+     ^~
+ghnco_Jnco_3DS3.c:824:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+      ^~~~~~~~~~
+ghnco_Jnco_3DS3.c: In function 't_pulsesequence':
+ghnco_Jnco_3DS3.c:1359:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (ix == 1)
+    ^~
+ghnco_Jnco_3DS3.c:1361:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+ghnco_Jnco_3DS3.c:1370:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if(ix==1)
+     ^~
+ghnco_Jnco_3DS3.c:1372:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      t2_counter = (int) ( (d3-d3_init)*sw2 + 0.5);
+      ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/ghnco_trosy_3DA
+ghnco_trosy_3DA.c: In function 'pulsesequence':
+ghnco_trosy_3DA.c:292:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(shared_CT[A] == 'n')
+    ^~
+ghnco_trosy_3DA.c:299:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y'))
+     ^~
+ghnco_trosy_3DA.c:193:14: warning: variable 'gzlvl8' set but not used [-Wunused-but-set-variable]
+              gzlvl8;
+              ^~~~~~
+ghnco_trosy_3DA.c:185:14: warning: variable 'gzlvl0' set but not used [-Wunused-but-set-variable]
+              gzlvl0,
+              ^~~~~~
+ghnco_trosy_3DA.c: In function 'x_pulsesequence':
+ghnco_trosy_3DA.c:1770:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(shared_CT[A] == 'n')
+    ^~
+ghnco_trosy_3DA.c:1778:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y'))
+     ^~
+ghnco_trosy_3DA.c: In function 't_pulsesequence':
+ghnco_trosy_3DA.c:3268:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(shared_CT[A] == 'n')
+    ^~
+ghnco_trosy_3DA.c:3276:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y'))
+     ^~
+warn  : /vnmr/biopack/psglib/ghncoca_seq_trosy_3DA
+ghncoca_seq_trosy_3DA.c: In function 'pulsesequence':
+ghncoca_seq_trosy_3DA.c:234:14: warning: variable 'gzlvl8' set but not used [-Wunused-but-set-variable]
+              gzlvl8,
+              ^~~~~~
+ghncoca_seq_trosy_3DA.c:184:14: warning: variable 'at' set but not used [-Wunused-but-set-variable]
+              at,
+              ^~
+ghncoca_seq_trosy_3DA.c:181:14: warning: variable 'dresD' set but not used [-Wunused-but-set-variable]
+              dresD,        /* dres for the deuterium decoupling */
+              ^~~~~
+warn  : /vnmr/biopack/psglib/ghncoca_sim_trosy_4DA
+ghncoca_sim_trosy_4DA.c: In function 'pulsesequence':
+ghncoca_sim_trosy_4DA.c:397:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+ghncoca_sim_trosy_4DA.c:401:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if(tau1 < 0.2e-6) {
+         ^~
+ghncoca_sim_trosy_4DA.c:412:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+ghncoca_sim_trosy_4DA.c:416:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if(tau1 < 0.2e-6) tau1 = 0.4e-6;
+         ^~
+ghncoca_sim_trosy_4DA.c: In function 'x_pulsesequence':
+ghncoca_sim_trosy_4DA.c:1896:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+ghncoca_sim_trosy_4DA.c:1900:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if(tau1 < 0.2e-6) {
+         ^~
+ghncoca_sim_trosy_4DA.c:1913:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+ghncoca_sim_trosy_4DA.c:1917:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if(tau1 < 0.2e-6) tau1 = 0.4e-6;
+         ^~
+ghncoca_sim_trosy_4DA.c: In function 't_pulsesequence':
+ghncoca_sim_trosy_4DA.c:3411:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+ghncoca_sim_trosy_4DA.c:3415:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if(tau1 < 0.2e-6) {
+         ^~
+ghncoca_sim_trosy_4DA.c:3428:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+ghncoca_sim_trosy_4DA.c:3432:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if(tau1 < 0.2e-6) tau1 = 0.4e-6;
+         ^~
+warn  : /vnmr/biopack/psglib/ghncocacb_trosy_3DA
+ghncocacb_trosy_3DA.c: In function 'pulsesequence':
+ghncocacb_trosy_3DA.c:487:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(fCT[A] == 'y')
+    ^~
+ghncocacb_trosy_3DA.c:502:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y'))
+     ^~
+ghncocacb_trosy_3DA.c:307:14: warning: variable 'gzlvl8' set but not used [-Wunused-but-set-variable]
+              gzlvl8,
+              ^~~~~~
+ghncocacb_trosy_3DA.c: In function 'x_pulsesequence':
+ghncocacb_trosy_3DA.c:2509:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(fCT[A] == 'y')
+    ^~
+ghncocacb_trosy_3DA.c:2525:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y'))
+     ^~
+ghncocacb_trosy_3DA.c: In function 't_pulsesequence':
+ghncocacb_trosy_3DA.c:4531:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(fCT[A] == 'y')
+    ^~
+ghncocacb_trosy_3DA.c:4547:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if((dm[A] == 'y' || dm[B] == 'y' || dm[C] == 'y'))
+     ^~
+warn  : /vnmr/biopack/psglib/ghnha
+ghnha.c: In function 'pulsesequence':
+ghnha.c:170:13: warning: variable 'gzlvl4' set but not used [-Wunused-but-set-variable]
+             gzlvl4,
+             ^~~~~~
+ghnha.c:163:13: warning: variable 'gt4' set but not used [-Wunused-but-set-variable]
+             gt4,
+             ^~~
+warn  : /vnmr/biopack/psglib/ghnn
+ghnn.c: In function 'pulsesequence':
+ghnn.c:168:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,                /* the larger of pwC9a and 2.0*pwN for 1D experiments */
+    ^~~~
+ghnn.c:167:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,        /* the largest of pwC9 and 2.0*pwN */
+    ^~~
+ghnn.c:166:4: warning: variable 'phshift9' set but not used [-Wunused-but-set-variable]
+    phshift9,             /* phase shift induced on Ca by pwC9 ("offC9") pulse */
+    ^~~~~~~~
+warn  : /vnmr/biopack/psglib/ghnnA
+ghnnA.c: In function 'pulsesequence':
+ghnnA.c:180:4: warning: variable 'pwZ1' set but not used [-Wunused-but-set-variable]
+    pwZ1,                /* the larger of pwC9a and 2.0*pwN for 1D experiments */
+    ^~~~
+ghnnA.c:179:4: warning: variable 'pwZ' set but not used [-Wunused-but-set-variable]
+    pwZ,        /* the largest of pwC9 and 2.0*pwN */
+    ^~~
+ghnnA.c:178:4: warning: variable 'phshift9' set but not used [-Wunused-but-set-variable]
+    phshift9,             /* phase shift induced on Ca by pwC9 ("offC9") pulse */
+    ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gihca_nco_cah
+gihca_nco_cah.c: In function 'pulsesequence':
+gihca_nco_cah.c:136:5: warning: variable 'gzlvl8' set but not used [-Wunused-but-set-variable]
+     gzlvl8,
+     ^~~~~~
+gihca_nco_cah.c:127:5: warning: variable 'gt8' set but not used [-Wunused-but-set-variable]
+     gt8,
+     ^~~
+warn  : /vnmr/biopack/psglib/gmacosy
+gmacosy.c: In function 'pulsesequence':
+gmacosy.c:51:28: warning: variable 'phi' set but not used [-Wunused-but-set-variable]
+   gt1,gt2,qlvl,gstab,theta,phi,
+                            ^~~
+gmacosy.c:51:22: warning: variable 'theta' set but not used [-Wunused-but-set-variable]
+   gt1,gt2,qlvl,gstab,theta,phi,
+                      ^~~~~
+gmacosy.c:51:3: warning: variable 'gt1' set but not used [-Wunused-but-set-variable]
+   gt1,gt2,qlvl,gstab,theta,phi,
+   ^~~
+gmacosy.c:50:34: warning: variable 'gzlvl2a' set but not used [-Wunused-but-set-variable]
+         double nsw,gzlvl1,gzlvl2,gzlvl2a,
+                                  ^~~~~~~
+gmacosy.c:50:20: warning: variable 'gzlvl1' set but not used [-Wunused-but-set-variable]
+         double nsw,gzlvl1,gzlvl2,gzlvl2a,
+                    ^~~~~~
+warn  : /vnmr/biopack/psglib/gnoesyCNhsqc
+gnoesyCNhsqc.c: In function 'pulsesequence':
+gnoesyCNhsqc.c:208:14: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+              gzlvl7;
+              ^~~~~~
+gnoesyCNhsqc.c:207:14: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+              gzlvl6,
+              ^~~~~~
+gnoesyCNhsqc.c:176:13: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+             rf0,                        /* full fine power */
+             ^~~
+warn  : /vnmr/biopack/psglib/gnoesyCNhsqcA
+gnoesyCNhsqcA.c: In function 'pulsesequence':
+gnoesyCNhsqcA.c:224:14: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+              gzlvl7;
+              ^~~~~~
+gnoesyCNhsqcA.c:223:14: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+              gzlvl6,
+              ^~~~~~
+gnoesyCNhsqcA.c:191:13: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+             rf0,                        /* full fine power */
+             ^~~
+warn  : /vnmr/biopack/psglib/gnoesyChsqc
+gnoesyChsqc.c: In function 'pulsesequence':
+gnoesyChsqc.c:230:14: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+              gzlvl7;
+              ^~~~~~
+gnoesyChsqc.c:229:14: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+              gzlvl6,
+              ^~~~~~
+gnoesyChsqc.c:194:13: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+             rf0,                        /* full fine power */
+             ^~~
+warn  : /vnmr/biopack/psglib/gnoesyChsqcSE
+gnoesyChsqcSE.c: In function 'pulsesequence':
+gnoesyChsqcSE.c:158:3: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+   rf0,    /* full fine power */
+   ^~~
+warn  : /vnmr/biopack/psglib/gnoesyChsqc_wg
+gnoesyChsqc_wg.c: In function 'pulsesequence':
+gnoesyChsqc_wg.c:181:14: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+              gzlvl7;
+              ^~~~~~
+gnoesyChsqc_wg.c:180:14: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+              gzlvl6,
+              ^~~~~~
+gnoesyChsqc_wg.c:140:13: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+             rf0,                        /* full fine power */
+             ^~~
+warn  : /vnmr/biopack/psglib/gnoesyNhsqc
+gnoesyNhsqc.c: In function 'pulsesequence':
+gnoesyNhsqc.c:172:4: warning: variable 'rfst' set but not used [-Wunused-but-set-variable]
+    rfst,                            /* fine power for the stCall pulse */
+    ^~~~
+warn  : /vnmr/biopack/psglib/gnoesyNhsqcA
+gnoesyNhsqcA.c: In function 'x_pulsesequence':
+gnoesyNhsqcA.c:1662:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+        ^~
+gnoesyNhsqcA.c:1665:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 zero %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(zero), (float)(pw));
+     ^~~~~~~~
+gnoesyNhsqcA.c: In function 't_pulsesequence':
+gnoesyNhsqcA.c:2922:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+        ^~
+gnoesyNhsqcA.c:2925:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/groesyChsqcSM
+groesyChsqcSM.c: In function 'pulsesequence':
+groesyChsqcSM.c:254:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if( gzlvl3*gzlvl4 > 0.0 )
+    ^~
+groesyChsqcSM.c:259:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (phase2 == 1)  {tsadd(t5,2,4);  icosel = +1;}
+     ^~
+groesyChsqcSM.c: In function 'x_pulsesequence':
+groesyChsqcSM.c:1489:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if( gzlvl3*gzlvl4 > 0.0 )
+    ^~
+groesyChsqcSM.c:1494:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (phase2 == 1) {DPSprint(0.00, "96 tsadd 51 3 0 t5 %d 2 %d 4 %d \n", (int)(t5), (int)(2), (int)(4)); icosel = +1;}
+     ^~
+groesyChsqcSM.c: In function 't_pulsesequence':
+groesyChsqcSM.c:2737:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if( gzlvl3*gzlvl4 > 0.0 )
+    ^~
+groesyChsqcSM.c:2742:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (phase2 == 1) {DPStimer(96,51,3,0,(int)t5,(int)2,(int)4,0); icosel = +1;}
+     ^~
+warn  : /vnmr/biopack/psglib/groesyNhsqcSM
+groesyNhsqcSM.c: In function 'x_pulsesequence':
+groesyNhsqcSM.c:1611:9: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+         ^~
+groesyNhsqcSM.c:1614:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 t4 %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(t4), (float)(pw));
+     ^~~~~~~~
+groesyNhsqcSM.c: In function 't_pulsesequence':
+groesyNhsqcSM.c:2836:9: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+         ^~
+groesyNhsqcSM.c:2839:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gtocsyChsqc
+gtocsyChsqc.c: In function 'pulsesequence':
+gtocsyChsqc.c:348:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gtocsyChsqc.c:350:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+gtocsyChsqc.c:203:14: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+              gzlvl7;
+              ^~~~~~
+gtocsyChsqc.c:202:14: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+              gzlvl6,
+              ^~~~~~
+gtocsyChsqc.c:197:14: warning: variable 'gzlvl1' set but not used [-Wunused-but-set-variable]
+              gzlvl1,
+              ^~~~~~
+gtocsyChsqc.c:177:14: warning: variable 'pwNlvl' set but not used [-Wunused-but-set-variable]
+              pwNlvl,       /* high dec2 pwr for 15N hard pulses    */
+              ^~~~~~
+gtocsyChsqc.c:167:13: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+             rf0,                        /* full fine power */
+             ^~~
+gtocsyChsqc.c: In function 'x_pulsesequence':
+gtocsyChsqc.c:797:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gtocsyChsqc.c:799:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+gtocsyChsqc.c: In function 't_pulsesequence':
+gtocsyChsqc.c:1258:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gtocsyChsqc.c:1260:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+warn  : /vnmr/biopack/psglib/gtocsyChsqcA
+gtocsyChsqcA.c: In function 'pulsesequence':
+gtocsyChsqcA.c:404:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gtocsyChsqcA.c:406:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+gtocsyChsqcA.c:240:14: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+              gzlvl7;
+              ^~~~~~
+gtocsyChsqcA.c:239:14: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+              gzlvl6,
+              ^~~~~~
+gtocsyChsqcA.c:234:14: warning: variable 'gzlvl1' set but not used [-Wunused-but-set-variable]
+              gzlvl1,
+              ^~~~~~
+gtocsyChsqcA.c:214:14: warning: variable 'pwNlvl' set but not used [-Wunused-but-set-variable]
+              pwNlvl,       /* high dec2 pwr for 15N hard pulses    */
+              ^~~~~~
+gtocsyChsqcA.c: In function 'x_pulsesequence':
+gtocsyChsqcA.c:1739:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gtocsyChsqcA.c:1741:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+gtocsyChsqcA.c: In function 't_pulsesequence':
+gtocsyChsqcA.c:3093:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+gtocsyChsqcA.c:3095:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+warn  : /vnmr/biopack/psglib/gtocsyChsqcSE
+gtocsyChsqcSE.c: In function 'pulsesequence':
+gtocsyChsqcSE.c:324:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if( gzlvl3*gzlvl4 > 0.0 )
+    ^~
+gtocsyChsqcSE.c:329:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (phase2 == 1)  {tsadd(t5,2,4);  icosel = +1;}
+     ^~
+gtocsyChsqcSE.c:182:3: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+   rf0,    /* full fine power */
+   ^~~
+gtocsyChsqcSE.c: In function 'x_pulsesequence':
+gtocsyChsqcSE.c:873:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if( gzlvl3*gzlvl4 > 0.0 )
+    ^~
+gtocsyChsqcSE.c:878:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (phase2 == 1) {DPSprint(0.00, "96 tsadd 51 3 0 t5 %d 2 %d 4 %d \n", (int)(t5), (int)(2), (int)(4)); icosel = +1;}
+     ^~
+gtocsyChsqcSE.c: In function 't_pulsesequence':
+gtocsyChsqcSE.c:1437:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if( gzlvl3*gzlvl4 > 0.0 )
+    ^~
+gtocsyChsqcSE.c:1442:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (phase2 == 1) {DPStimer(96,51,3,0,(int)t5,(int)2,(int)4,0); icosel = +1;}
+     ^~
+warn  : /vnmr/biopack/psglib/gtocsyChsqcSM
+gtocsyChsqcSM.c: In function 'pulsesequence':
+gtocsyChsqcSM.c:293:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if( gzlvl3*gzlvl4 > 0.0 )
+    ^~
+gtocsyChsqcSM.c:298:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (phase2 == 1)  {tsadd(t5,2,4);  icosel = +1;}
+     ^~
+gtocsyChsqcSM.c: In function 'x_pulsesequence':
+gtocsyChsqcSM.c:1578:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if( gzlvl3*gzlvl4 > 0.0 )
+    ^~
+gtocsyChsqcSM.c:1583:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (phase2 == 1) {DPSprint(0.00, "96 tsadd 51 3 0 t5 %d 2 %d 4 %d \n", (int)(t5), (int)(2), (int)(4)); icosel = +1;}
+     ^~
+gtocsyChsqcSM.c: In function 't_pulsesequence':
+gtocsyChsqcSM.c:2879:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if( gzlvl3*gzlvl4 > 0.0 )
+    ^~
+gtocsyChsqcSM.c:2884:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (phase2 == 1) {DPStimer(96,51,3,0,(int)t5,(int)2,(int)4,0); icosel = +1;}
+     ^~
+warn  : /vnmr/biopack/psglib/gtocsyNhsqcA
+gtocsyNhsqcA.c: In function 'x_pulsesequence':
+gtocsyNhsqcA.c:1739:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+        ^~
+gtocsyNhsqcA.c:1742:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 t4 %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(t4), (float)(pw));
+     ^~~~~~~~
+gtocsyNhsqcA.c: In function 't_pulsesequence':
+gtocsyNhsqcA.c:3032:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+        ^~
+gtocsyNhsqcA.c:3035:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/gtocsyNhsqcSM
+gtocsyNhsqcSM.c: In function 'x_pulsesequence':
+gtocsyNhsqcSM.c:1699:9: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+         ^~
+gtocsyNhsqcSM.c:1702:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 t4 %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(t4), (float)(pw));
+     ^~~~~~~~
+gtocsyNhsqcSM.c: In function 't_pulsesequence':
+gtocsyNhsqcSM.c:2973:9: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+         ^~
+gtocsyNhsqcSM.c:2976:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/hNCAnH_A
+hNCAnH_A.c: In function 'x_pulsesequence':
+hNCAnH_A.c:1375:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if (tpwrsf_d<4095.0)
+     ^~
+hNCAnH_A.c:1381:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         settable(t1,1,phi1);
+         ^~~~~~~~
+hNCAnH_A.c:1613:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+hNCAnH_A.c:1615:12: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+            DPSprint(0.00, "2 dec3blank  4 1 0 off 0 \n");
+            ^~~~~~~~
+hNCAnH_A.c: In function 't_pulsesequence':
+hNCAnH_A.c:2555:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if (tpwrsf_d<4095.0)
+     ^~
+hNCAnH_A.c:2561:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         settable(t1,1,phi1);
+         ^~~~~~~~
+hNCAnH_A.c:2793:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+hNCAnH_A.c:2795:12: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+            DPStimer(2,0,0,0);
+            ^~~~~~~~
+warn  : /vnmr/biopack/psglib/hadamac
+hadamac.c: In function 'pulsesequence':
+hadamac.c:104:33: warning: variable 'pwS6' set but not used [-Wunused-but-set-variable]
+    pwS1, pwS2, pwS3, pwS4, pwS5,pwS6,pwS7,
+                                 ^~~~
+hadamac.c:104:4: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+    pwS1, pwS2, pwS3, pwS4, pwS5,pwS6,pwS7,
+    ^~~~
+hadamac.c:91:12: warning: variable 'shpw2' set but not used [-Wunused-but-set-variable]
+      shpw1,shpw2,                      /*  t1 delay */
+            ^~~~~
+hadamac.c:81:6: warning: variable 'ala_flg' set but not used [-Wunused-but-set-variable]
+      ala_flg[MAXSTR],
+      ^~~~~~~
+warn  : /vnmr/biopack/psglib/hmcmcbcaA
+hmcmcbcaA.c: In function 'pulsesequence':
+hmcmcbcaA.c:64:29: warning: variable 'ni' set but not used [-Wunused-but-set-variable]
+  int         phase, phase2, ni, ni2,
+                             ^~
+warn  : /vnmr/biopack/psglib/hmcmcgcbcaA
+hmcmcgcbcaA.c: In function 'pulsesequence':
+hmcmcgcbcaA.c:74:29: warning: variable 'ni' set but not used [-Wunused-but-set-variable]
+  int         phase, phase2, ni, ni2,
+                             ^~
+warn  : /vnmr/biopack/psglib/hmcmcgcbcacoA
+hmcmcgcbcacoA.c: In function 'pulsesequence':
+hmcmcgcbcacoA.c:80:29: warning: variable 'ni' set but not used [-Wunused-but-set-variable]
+  int         phase, phase2, ni, ni2,
+                             ^~
+warn  : /vnmr/biopack/psglib/hmcmcgcbcaco_valA
+hmcmcgcbcaco_valA.c: In function 'pulsesequence':
+hmcmcgcbcaco_valA.c:120:14: warning: variable 'pwrb_co' set but not used [-Wunused-but-set-variable]
+              pwrb_co,
+              ^~~~~~~
+hmcmcgcbcaco_valA.c:72:29: warning: variable 'ni' set but not used [-Wunused-but-set-variable]
+  int         phase, phase2, ni, ni2,
+                             ^~
+warn  : /vnmr/biopack/psglib/ihadamacP
+ihadamacP.c: In function 'pulsesequence':
+ihadamacP.c:99:4: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+    pwS1, pwS2, pwS3, pwS4, pwS5,pwS6,pwS7,pwS8,
+    ^~~~
+warn  : /vnmr/biopack/psglib/ihca_co_nhP
+ihca_co_nhP.c: In function 'pulsesequence':
+ihca_co_nhP.c:165:4: warning: variable 'pwS2' set but not used [-Wunused-but-set-variable]
+    pwS2,     /* length of square 180 on Ca */
+
+    ^~~~
+ihca_co_nhP.c:164:4: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+    pwS1,     /* length of square 90 on Cab */
+
+    ^~~~
+warn  : /vnmr/biopack/psglib/noesyCA
+noesyCA.c: In function 'pulsesequence':
+noesyCA.c:179:14: warning: variable 'dly_wt' set but not used [-Wunused-but-set-variable]
+              dly_wt,
+              ^~~~~~
+noesyCA.c:166:14: warning: variable 'ni2' set but not used [-Wunused-but-set-variable]
+              ni2,
+              ^~~
+warn  : /vnmr/biopack/psglib/noesyCA_500
+noesyCA_500.c: In function 'pulsesequence':
+noesyCA_500.c:203:14: warning: variable 'dly_wt' set but not used [-Wunused-but-set-variable]
+              dly_wt,
+              ^~~~~~
+noesyCA_500.c:190:14: warning: variable 'ni2' set but not used [-Wunused-but-set-variable]
+              ni2,
+              ^~~
+warn  : /vnmr/biopack/psglib/noesyCA_600
+noesyCA_600.c: In function 'pulsesequence':
+noesyCA_600.c:203:14: warning: variable 'dly_wt' set but not used [-Wunused-but-set-variable]
+              dly_wt,
+              ^~~~~~
+noesyCA_600.c:190:14: warning: variable 'ni2' set but not used [-Wunused-but-set-variable]
+              ni2,
+              ^~~
+warn  : /vnmr/biopack/psglib/noesyCA_700
+noesyCA_700.c: In function 'pulsesequence':
+noesyCA_700.c:207:14: warning: variable 'dly_wt' set but not used [-Wunused-but-set-variable]
+              dly_wt,
+              ^~~~~~
+noesyCA_700.c:194:14: warning: variable 'ni2' set but not used [-Wunused-but-set-variable]
+              ni2,
+              ^~~
+warn  : /vnmr/biopack/psglib/noesyCA_750
+noesyCA_750.c: In function 'pulsesequence':
+noesyCA_750.c:203:14: warning: variable 'dly_wt' set but not used [-Wunused-but-set-variable]
+              dly_wt,
+              ^~~~~~
+noesyCA_750.c:190:14: warning: variable 'ni2' set but not used [-Wunused-but-set-variable]
+              ni2,
+              ^~~
+warn  : /vnmr/biopack/psglib/noesyCA_800
+noesyCA_800.c: In function 'pulsesequence':
+noesyCA_800.c:203:14: warning: variable 'dly_wt' set but not used [-Wunused-but-set-variable]
+              dly_wt,
+              ^~~~~~
+noesyCA_800.c:190:14: warning: variable 'ni2' set but not used [-Wunused-but-set-variable]
+              ni2,
+              ^~~
+warn  : /vnmr/biopack/psglib/qwnoesy
+qwnoesy.c: In function 'pulsesequence':
+qwnoesy.c:144:41: warning: variable 'gtw1' set but not used [-Wunused-but-set-variable]
+                    mix,pwwet,pwwet1,gtw,gtw1,gswet,gswet1;
+                                         ^~~~
+qwnoesy.c:143:47: warning: variable 'compN' set but not used [-Wunused-but-set-variable]
+                    pwC,pwClvl,jch,compH,compC,compN,
+                                               ^~~~~
+qwnoesy.c:143:35: warning: variable 'compH' set but not used [-Wunused-but-set-variable]
+                    pwC,pwClvl,jch,compH,compC,compN,
+                                   ^~~~~
+qwnoesy.c:140:20: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+                    rf0,                       /* maximum fine power when using pwC pulses */
+                    ^~~
+warn  : /vnmr/biopack/psglib/qwnoesyA
+qwnoesyA.c: In function 'pulsesequence':
+qwnoesyA.c:167:37: warning: variable 'gtw1' set but not used [-Wunused-but-set-variable]
+                mix,pwwet,pwwet1,gtw,gtw1,gswet,gswet1;
+                                     ^~~~
+qwnoesyA.c:166:43: warning: variable 'compN' set but not used [-Wunused-but-set-variable]
+                pwC,pwClvl,jch,compH,compC,compN,
+                                           ^~~~~
+qwnoesyA.c:166:31: warning: variable 'compH' set but not used [-Wunused-but-set-variable]
+                pwC,pwClvl,jch,compH,compC,compN,
+                               ^~~~~
+qwnoesyA.c:161:16: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+                rf0,                       /* maximum fine power when using pwC pulses */
+                ^~~
+warn  : /vnmr/biopack/psglib/rna_CTgChmqc
+rna_CTgChmqc.c: In function 'pulsesequence':
+rna_CTgChmqc.c:415:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_CTgChmqc.c:416:46: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        Wet4(wetpwr,wetshape,wetpw,zero,one); delay(dz);
+                                              ^~~~~
+rna_CTgChmqc.c: In function 'x_pulsesequence':
+rna_CTgChmqc.c:873:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_CTgChmqc.c:874:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        x_Wet4(wetpwr,wetshape,wetpw,zero,one); DPSprint(dz, "10 delay  1 0 1 dz %.9f \n", (float)(dz));
+                                                ^~~~~~~~
+rna_CTgChmqc.c: In function 't_pulsesequence':
+rna_CTgChmqc.c:1335:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_CTgChmqc.c:1336:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        t_Wet4(wetpwr,wetshape,wetpw,zero,one); DPStimer(10,0,0,1,0,0,0,0,(double)dz);
+                                                ^~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_CTgChmqcA
+rna_CTgChmqcA.c: In function 'pulsesequence':
+rna_CTgChmqcA.c:445:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_CTgChmqcA.c:446:46: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        Wet4(wetpwr,wetshape,wetpw,zero,one); delay(dz);
+                                              ^~~~~
+rna_CTgChmqcA.c: In function 'x_pulsesequence':
+rna_CTgChmqcA.c:1715:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_CTgChmqcA.c:1716:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        x_Wet4(wetpwr,wetshape,wetpw,zero,one); DPSprint(dz, "10 delay  1 0 1 dz %.9f \n", (float)(dz));
+                                                ^~~~~~~~
+rna_CTgChmqcA.c: In function 't_pulsesequence':
+rna_CTgChmqcA.c:2989:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_CTgChmqcA.c:2990:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        t_Wet4(wetpwr,wetshape,wetpw,zero,one); DPStimer(10,0,0,1,0,0,0,0,(double)dz);
+                                                ^~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_CUhnccch_CCdec
+rna_CUhnccch_CCdec.c: In function 'pulsesequence':
+rna_CUhnccch_CCdec.c:137:2: warning: variable 'dof_123' set but not used [-Wunused-but-set-variable]
+  dof_123,     /* dof shifted to 122.5 ppm for C4-C5-C6 transfer and DEC1 */
+  ^~~~~~~
+rna_CUhnccch_CCdec.c:136:2: warning: variable 'dof_133' set but not used [-Wunused-but-set-variable]
+  dof_133,     /* dof shifted to 132.5 ppm for C4-C5-C6 transfer and DEC1 */
+  ^~~~~~~
+rna_CUhnccch_CCdec.c:134:2: warning: variable 'dof_130' set but not used [-Wunused-but-set-variable]
+  dof_130,     /* dof shifted to 130 ppm for C4-C5-C6 transfer and DEC1 */
+  ^~~~~~~
+rna_CUhnccch_CCdec.c:133:2: warning: variable 'dof_120' set but not used [-Wunused-but-set-variable]
+  dof_120,     /* dof shifted to 120 ppm for C4-C5-C6 transfer and DEC1 */
+  ^~~~~~~
+rna_CUhnccch_CCdec.c:131:2: warning: variable 'dof_153' set but not used [-Wunused-but-set-variable]
+  dof_153,     /* dof shifted to 153 ppm for C4-C5-C6 transfer and DEC1 */
+  ^~~~~~~
+rna_CUhnccch_CCdec.c:129:2: warning: variable 'dof_140' set but not used [-Wunused-but-set-variable]
+  dof_140,     /* dof shifted to 140 ppm for C4-C5-C6 transfer and DEC1 */
+  ^~~~~~~
+rna_CUhnccch_CCdec.c:128:2: warning: variable 'dof_169' set but not used [-Wunused-but-set-variable]
+  dof_169,   /* dof shifted to 169 ppm for N3-C4 transfer */
+  ^~~~~~~
+rna_CUhnccch_CCdec.c:126:9: warning: variable 'tof_125' set but not used [-Wunused-but-set-variable]
+         tof_125,                   /* tof shifted to 12 ppm for H3-N3 transfer */
+         ^~~~~~~
+rna_CUhnccch_CCdec.c:124:9: warning: variable 'tof_75' set but not used [-Wunused-but-set-variable]
+         tof_75,                  /* tof shifted to 7.5 ppm for H4-N4 transfer */
+         ^~~~~~
+warn  : /vnmr/biopack/psglib/rna_HCN
+rna_HCN.c: In function 'x_pulsesequence':
+rna_HCN.c:1205:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+rna_HCN.c:1208:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if (TROSY[A] == 'y')
+         ^~
+rna_HCN.c: In function 't_pulsesequence':
+rna_HCN.c:1948:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+rna_HCN.c:1951:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if (TROSY[A] == 'y')
+         ^~
+warn  : /vnmr/biopack/psglib/rna_HPcosyHCP
+rna_HPcosyHCP.c: In function 'pulsesequence':
+rna_HPcosyHCP.c:112:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+rna_HPcosyHCP.c:114:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     rcvroff();
+     ^~~~~~~
+rna_HPcosyHCP.c: In function 'x_pulsesequence':
+rna_HPcosyHCP.c:209:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+rna_HPcosyHCP.c:211:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPSprint(0.00, "53 rcvroff  1 2 0 off 0 1 1 \n");
+     ^~~~~~~~
+rna_HPcosyHCP.c: In function 't_pulsesequence':
+rna_HPcosyHCP.c:304:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+rna_HPcosyHCP.c:306:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     DPStimer(53,0,0,0);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_WGgNtrosy
+rna_WGgNtrosy.c: In function 'x_pulsesequence':
+rna_WGgNtrosy.c:484:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+  else
+  ^~~~
+rna_WGgNtrosy.c:486:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+   settable(t4, 8, phi4);
+   ^~~~~~~~
+rna_WGgNtrosy.c: In function 't_pulsesequence':
+rna_WGgNtrosy.c:793:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+  else
+  ^~~~
+rna_WGgNtrosy.c:795:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+   settable(t4, 8, phi4);
+   ^~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_WGnoesy
+rna_WGnoesy.c: In function 'pulsesequence':
+rna_WGnoesy.c:34:20: warning: variable 'ss' set but not used [-Wunused-but-set-variable]
+                    ss,
+                    ^~
+warn  : /vnmr/biopack/psglib/rna_cchcosy_CCdec
+rna_cchcosy_CCdec.c: In function 'pulsesequence':
+rna_cchcosy_CCdec.c:68:13: warning: variable 't2_counter' set but not used [-Wunused-but-set-variable]
+             t2_counter;            /* used for states tppi in t2 */
+             ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_cchtocsy_CCdec
+rna_cchtocsy_CCdec.c: In function 'pulsesequence':
+rna_cchtocsy_CCdec.c:93:9: warning: variable 'p_d' set but not used [-Wunused-but-set-variable]
+         p_d,                 /* 50 degree pulse for DIPSI-3 at rfdC */
+         ^~~
+rna_cchtocsy_CCdec.c:87:9: warning: variable 'tof_12' set but not used [-Wunused-but-set-variable]
+         tof_12,                   /* tof shifted to 12 ppm for H3-N3 transfer */
+         ^~~~~~
+rna_cchtocsy_CCdec.c:86:9: warning: variable 'tof_75' set but not used [-Wunused-but-set-variable]
+         tof_75,                  /* tof shifted to 7.5 ppm for H4-N4 transfer */
+         ^~~~~~
+warn  : /vnmr/biopack/psglib/rna_fHNNcosyA
+rna_fHNNcosyA.c: In function 'x_pulsesequence':
+rna_fHNNcosyA.c:1658:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else DPSprint(0.00, "60 obspower  1 0 1 tpwrs %.9f \n", (float)(tpwrs));
+       ^~~~
+rna_fHNNcosyA.c:1659:12: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+            DPSprint(pwHs, "77 shaped_pulse  1 1 1 1 0.0 %.9f 0.0 %.9f  1  ?%s t7 %d pwHs %.9f \n", (float)(0.0), (float)(0.0), "H2Osinc", (int)(t7), (float)(pwHs));
+            ^~~~~~~~
+rna_fHNNcosyA.c: In function 't_pulsesequence':
+rna_fHNNcosyA.c:2830:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else DPStimer(60,0,0,0);
+       ^~~~
+rna_fHNNcosyA.c:2831:12: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+            DPStimer(77,0,0,3,0,0,0,0,(double)pwHs,(double)0.0,(double)0.0);
+            ^~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_gChmqc
+rna_gChmqc.c: In function 'pulsesequence':
+rna_gChmqc.c:299:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if( ix == 1)
+   ^~
+rna_gChmqc.c:302:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+  t1_counter = (int) ((d2 - d2_init)*sw1 + 0.5);
+  ^~~~~~~~~~
+rna_gChmqc.c:390:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_gChmqc.c:391:47: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         Wet4(wetpwr,wetshape,wetpw,zero,one); delay(dz);
+                                               ^~~~~
+rna_gChmqc.c: In function 'x_pulsesequence':
+rna_gChmqc.c:727:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+  else
+  ^~~~
+rna_gChmqc.c:732:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+   if (phase == 2)
+   ^~
+rna_gChmqc.c:836:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_gChmqc.c:837:49: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         x_Wet4(wetpwr,wetshape,wetpw,zero,one); DPSprint(dz, "10 delay  1 0 1 dz %.9f \n", (float)(dz));
+                                                 ^~~~~~~~
+rna_gChmqc.c: In function 't_pulsesequence':
+rna_gChmqc.c:1183:2: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+  else
+  ^~~~
+rna_gChmqc.c:1188:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+   if (phase == 2)
+   ^~
+rna_gChmqc.c:1292:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_gChmqc.c:1293:49: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         t_Wet4(wetpwr,wetshape,wetpw,zero,one); DPStimer(10,0,0,1,0,0,0,0,(double)dz);
+                                                 ^~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_gChsqc
+rna_gChsqc.c: In function 'pulsesequence':
+rna_gChsqc.c:631:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  if  ((T1rho[A]=='n') || (T2[A]=='n'))
+  ^~
+rna_gChsqc.c:634:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         rcvroff();
+         ^~~~~~~
+warn  : /vnmr/biopack/psglib/rna_gChsqcA
+rna_gChsqcA.c: In function 'pulsesequence':
+rna_gChsqcA.c:644:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  if  ((T1rho[A]=='n') || (T2[A]=='n'))
+  ^~
+rna_gChsqcA.c:647:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         rcvroff();
+         ^~~~~~~
+warn  : /vnmr/biopack/psglib/rna_gChsqc_CCdec
+rna_gChsqc_CCdec.c: In function 'pulsesequence':
+rna_gChsqc_CCdec.c:667:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  if  ((T1rho[A]=='n') || (T2[A]=='n'))
+  ^~
+rna_gChsqc_CCdec.c:670:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         rcvroff();
+         ^~~~~~~
+warn  : /vnmr/biopack/psglib/rna_gNhmqc
+rna_gNhmqc.c: In function 'pulsesequence':
+rna_gNhmqc.c:261:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if( ix == 1)
+   ^~
+rna_gNhmqc.c:264:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+  t1_counter = (int) ((d2 - d2_init)*sw1 + 0.5);
+  ^~~~~~~~~~
+rna_gNhmqc.c: In function 'x_pulsesequence':
+rna_gNhmqc.c:630:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  else if (amino[A] == 'y')
+       ^~
+rna_gNhmqc.c:635:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (phase == 2)
+   ^~
+rna_gNhmqc.c:734:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+rna_gNhmqc.c:737:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPSprint(gt1, "94 zgradpulse  11 0 3 z gt1 %.9f gzlvl1 %.9f  gradalt  %.9f \n", (float)(gt1), (float)(gzlvl1), (float)gradalt);
+         ^~~~~~~~
+rna_gNhmqc.c: In function 't_pulsesequence':
+rna_gNhmqc.c:1022:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+  else if (amino[A] == 'y')
+       ^~
+rna_gNhmqc.c:1027:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (phase == 2)
+   ^~
+rna_gNhmqc.c:1126:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+   else
+   ^~~~
+rna_gNhmqc.c:1129:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gt1);
+         ^~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_gnoesyChsqc
+rna_gnoesyChsqc.c: In function 'pulsesequence':
+rna_gnoesyChsqc.c:363:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_gnoesyChsqc.c:365:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+rna_gnoesyChsqc.c:213:14: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+              gzlvl7;
+              ^~~~~~
+rna_gnoesyChsqc.c:212:14: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+              gzlvl6,
+              ^~~~~~
+rna_gnoesyChsqc.c:192:14: warning: variable 'pwNlvl' set but not used [-Wunused-but-set-variable]
+              pwNlvl,       /* high dec2 pwr for 15N hard pulses    */
+              ^~~~~~
+rna_gnoesyChsqc.c:182:13: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+             rf0,                        /* full fine power */
+             ^~~
+rna_gnoesyChsqc.c: In function 'x_pulsesequence':
+rna_gnoesyChsqc.c:845:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_gnoesyChsqc.c:847:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+rna_gnoesyChsqc.c: In function 't_pulsesequence':
+rna_gnoesyChsqc.c:1343:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_gnoesyChsqc.c:1345:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+warn  : /vnmr/biopack/psglib/rna_gnoesyChsqcA
+rna_gnoesyChsqcA.c: In function 'pulsesequence':
+rna_gnoesyChsqcA.c:376:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_gnoesyChsqcA.c:378:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+rna_gnoesyChsqcA.c:226:14: warning: variable 'gzlvl7' set but not used [-Wunused-but-set-variable]
+              gzlvl7;
+              ^~~~~~
+rna_gnoesyChsqcA.c:225:14: warning: variable 'gzlvl6' set but not used [-Wunused-but-set-variable]
+              gzlvl6,
+              ^~~~~~
+rna_gnoesyChsqcA.c:205:14: warning: variable 'pwNlvl' set but not used [-Wunused-but-set-variable]
+              pwNlvl,       /* high dec2 pwr for 15N hard pulses    */
+              ^~~~~~
+rna_gnoesyChsqcA.c:195:13: warning: variable 'rf0' set but not used [-Wunused-but-set-variable]
+             rf0,                        /* full fine power */
+             ^~~
+rna_gnoesyChsqcA.c: In function 'x_pulsesequence':
+rna_gnoesyChsqcA.c:1664:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_gnoesyChsqcA.c:1666:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+rna_gnoesyChsqcA.c: In function 't_pulsesequence':
+rna_gnoesyChsqcA.c:2974:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_gnoesyChsqcA.c:2976:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+warn  : /vnmr/biopack/psglib/rna_gnoesyChsqc_CCdec
+rna_gnoesyChsqc_CCdec.c: In function 'pulsesequence':
+rna_gnoesyChsqc_CCdec.c:336:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_gnoesyChsqc_CCdec.c:338:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+rna_gnoesyChsqc_CCdec.c:364:1: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+ if (Both[A]=='y')
+ ^~
+rna_gnoesyChsqc_CCdec.c:367:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    tofa=tof+(1.32*sfrq); /*1.72 or 1.62 first noesy was ribose to base*/
+    ^~~~
+rna_gnoesyChsqc_CCdec.c: In function 'x_pulsesequence':
+rna_gnoesyChsqc_CCdec.c:898:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_gnoesyChsqc_CCdec.c:900:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+rna_gnoesyChsqc_CCdec.c:928:1: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+ if (Both[A]=='y')
+ ^~
+rna_gnoesyChsqc_CCdec.c:931:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    tofa=tof+(1.32*sfrq);
+    ^~~~
+rna_gnoesyChsqc_CCdec.c: In function 't_pulsesequence':
+rna_gnoesyChsqc_CCdec.c:1478:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_gnoesyChsqc_CCdec.c:1480:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      tau2 = tau2/2.0;
+      ^~~~
+rna_gnoesyChsqc_CCdec.c:1508:1: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+ if (Both[A]=='y')
+ ^~
+rna_gnoesyChsqc_CCdec.c:1511:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    tofa=tof+(1.32*sfrq);
+    ^~~~
+warn  : /vnmr/biopack/psglib/rna_gnoesyNhsqc
+rna_gnoesyNhsqc.c: In function 'x_pulsesequence':
+rna_gnoesyNhsqc.c:779:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+        ^~
+rna_gnoesyNhsqc.c:781:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 zero %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(zero), (float)(pw));
+     ^~~~~~~~
+rna_gnoesyNhsqc.c: In function 't_pulsesequence':
+rna_gnoesyNhsqc.c:1202:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+        ^~
+rna_gnoesyNhsqc.c:1204:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_gnoesyNhsqcA
+rna_gnoesyNhsqcA.c: In function 'x_pulsesequence':
+rna_gnoesyNhsqcA.c:1605:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+        ^~
+rna_gnoesyNhsqcA.c:1608:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPSprint(pw, "48 rgpulse  1 0 1 1 0.0 %.9f 0.0 %.9f  1 zero %d pw %.9f \n", (float)(0.0), (float)(0.0), (int)(zero), (float)(pw));
+     ^~~~~~~~
+rna_gnoesyNhsqcA.c: In function 't_pulsesequence':
+rna_gnoesyNhsqcA.c:2838:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   else if (tau1 > (0.64*pw + 0.5*SAPS_DELAY))
+        ^~
+rna_gnoesyNhsqcA.c:2841:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)0.0,(double)0.0);
+     ^~~~~~~~
+warn  : /vnmr/biopack/psglib/rna_hmqc_tocsy
+rna_hmqc_tocsy.c: In function 'pulsesequence':
+rna_hmqc_tocsy.c:211:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+rna_hmqc_tocsy.c:215:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     if (iphase == 2)
+     ^~
+rna_hmqc_tocsy.c: In function 'x_pulsesequence':
+rna_hmqc_tocsy.c:459:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+rna_hmqc_tocsy.c:463:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     if (iphase == 2)
+     ^~
+rna_hmqc_tocsy.c: In function 't_pulsesequence':
+rna_hmqc_tocsy.c:711:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+rna_hmqc_tocsy.c:715:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     if (iphase == 2)
+     ^~
+warn  : /vnmr/biopack/psglib/rna_mqHCN
+rna_mqHCN.c: In function 'pulsesequence':
+rna_mqHCN.c:119:6: warning: variable 'icosel' set but not used [-Wunused-but-set-variable]
+      icosel,
+      ^~~~~~
+warn  : /vnmr/biopack/psglib/rna_mqHCNA
+rna_mqHCNA.c: In function 'pulsesequence':
+rna_mqHCNA.c:116:6: warning: variable 'icosel' set but not used [-Wunused-but-set-variable]
+      icosel,
+      ^~~~~~
+warn  : /vnmr/biopack/psglib/rna_water
+rna_water.c: In function 'pulsesequence':
+rna_water.c:630:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+rna_water.c:631:41: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      Wet4(wetpwr,wetshape,wetpw,t1,t2); delay(dz);
+                                         ^~~~~
+warn  : /vnmr/biopack/psglib/rna_wetnoesy
+rna_wetnoesy.c: In function 'pulsesequence':
+rna_wetnoesy.c:117:41: warning: variable 'gtw1' set but not used [-Wunused-but-set-variable]
+                    mix,wetpw,wetpw1,gtw,gtw1,gswet,gswet1;
+                                         ^~~~
+rna_wetnoesy.c:116:51: warning: variable 'gt1' set but not used [-Wunused-but-set-variable]
+                    corr1,corr,gstab,gzlvl1,gzlvl2,gt1,gt2,
+                                                   ^~~
+warn  : /vnmr/biopack/psglib/rna_wroesy
+rna_wroesy.c: In function 'pulsesequence':
+rna_wroesy.c:120:26: warning: variable 'gtw' set but not used [-Wunused-but-set-variable]
+                    wetpw,gtw,gswet;
+                          ^~~
+warn  : /vnmr/biopack/psglib/rna_zdipsitocsy
+rna_zdipsitocsy.c: In function 'pulsesequence':
+rna_zdipsitocsy.c:164:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_zdipsitocsy.c:165:46: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        Wet4(wetpwr,wetshape,wetpw,zero,one); delay(dz);
+                                              ^~~~~
+rna_zdipsitocsy.c:79:40: warning: variable 'gswet' set but not used [-Wunused-but-set-variable]
+                    wetpwr,dz,wetpw,gtw,gswet,
+                                        ^~~~~
+rna_zdipsitocsy.c:79:36: warning: variable 'gtw' set but not used [-Wunused-but-set-variable]
+                    wetpwr,dz,wetpw,gtw,gswet,
+                                    ^~~
+rna_zdipsitocsy.c: In function 'x_pulsesequence':
+rna_zdipsitocsy.c:360:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_zdipsitocsy.c:361:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        x_Wet4(wetpwr,wetshape,wetpw,zero,one); DPSprint(dz, "10 delay  1 0 1 dz %.9f \n", (float)(dz));
+                                                ^~~~~~~~
+rna_zdipsitocsy.c: In function 't_pulsesequence':
+rna_zdipsitocsy.c:556:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+rna_zdipsitocsy.c:557:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        t_Wet4(wetpwr,wetshape,wetpw,zero,one); DPStimer(10,0,0,1,0,0,0,0,(double)dz);
+                                                ^~~~~~~~
+warn  : /vnmr/biopack/psglib/satxfer1D
+satxfer1D.c: In function 'x_pulsesequence':
+satxfer1D.c:372:9: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+         if (selfrqs != tof)
+         ^~
+satxfer1D.c:374:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPSprint(2*pw, "48 rgpulse  1 0 1 1 rof1 %.9f rof1 %.9f  1 t1 %d 2*pw %.9f \n", (float)(rof1), (float)(rof1), (int)(t1), (float)(2*pw));
+          ^~~~~~~~
+satxfer1D.c: In function 't_pulsesequence':
+satxfer1D.c:535:9: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+         if (selfrqs != tof)
+         ^~
+satxfer1D.c:537:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPStimer(48,0,0,3,0,0,0,0,(double)2*pw,(double)rof1,(double)rof1);
+          ^~~~~~~~
+warn  : /vnmr/biopack/psglib/sea_gCLNtrosy
+sea_gCLNtrosy.c: In function 'pulsesequence':
+sea_gCLNtrosy.c:225:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+sea_gCLNtrosy.c:227:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+sea_gCLNtrosy.c: In function 'x_pulsesequence':
+sea_gCLNtrosy.c:705:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+sea_gCLNtrosy.c:707:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+sea_gCLNtrosy.c: In function 't_pulsesequence':
+sea_gCLNtrosy.c:1189:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+sea_gCLNtrosy.c:1191:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/sea_gNtrosy
+sea_gNtrosy.c: In function 'pulsesequence':
+sea_gNtrosy.c:196:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+sea_gNtrosy.c:198:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+sea_gNtrosy.c: In function 'x_pulsesequence':
+sea_gNtrosy.c:539:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+sea_gNtrosy.c:541:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+sea_gNtrosy.c: In function 't_pulsesequence':
+sea_gNtrosy.c:889:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+sea_gNtrosy.c:891:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/biopack/psglib/seqhadamacP
+seqhadamacP.c: In function 'pulsesequence':
+seqhadamacP.c:112:33: warning: variable 'pwS6' set but not used [-Wunused-but-set-variable]
+    pwS1, pwS2, pwS3, pwS4, pwS5,pwS6,pwS7,
+                                 ^~~~
+seqhadamacP.c:112:4: warning: variable 'pwS1' set but not used [-Wunused-but-set-variable]
+    pwS1, pwS2, pwS3, pwS4, pwS5,pwS6,pwS7,
+    ^~~~
+seqhadamacP.c:83:6: warning: variable 'ala_flg' set but not used [-Wunused-but-set-variable]
+      ala_flg[MAXSTR],
+      ^~~~~~~
+warn  : /vnmr/biopack/psglib/sofastNhmqcHT
+sofastNhmqcHT.c: In function 'pulsesequence':
+sofastNhmqcHT.c:34:11: warning: variable 'phase' set but not used [-Wunused-but-set-variable]
+           phase;
+           ^~~~~
+warn  : /vnmr/biopack/psglib/soggy
+soggy.c: In function 'pulsesequence':
+soggy.c:588:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+soggy.c:589:41: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      Wet4(wetpwr,wetshape,wetpw,t1,t2); delay(dz);
+                                         ^~~~~
+warn  : /vnmr/biopack/psglib/water
+water.c: In function 'pulsesequence':
+water.c:630:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+water.c:631:41: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      Wet4(wetpwr,wetshape,wetpw,t1,t2); delay(dz);
+                                         ^~~~~
+warn  : /vnmr/biopack/psglib/wgnoesy
+wgnoesy.c: In function 'pulsesequence':
+wgnoesy.c:98:20: warning: variable 'ss' set but not used [-Wunused-but-set-variable]
+                    ss,
+                    ^~
+warn  : /vnmr/biopack/psglib/wnoesy
+wnoesy.c: In function 'pulsesequence':
+wnoesy.c:115:41: warning: variable 'gtw1' set but not used [-Wunused-but-set-variable]
+                    mix,wetpw,wetpw1,gtw,gtw1,gswet,gswet1;
+                                         ^~~~
+wnoesy.c:114:51: warning: variable 'gt1' set but not used [-Wunused-but-set-variable]
+                    corr1,corr,gstab,gzlvl1,gzlvl2,gt1,gt2,
+                                                   ^~~
+warn  : /vnmr/biopack/psglib/wroesy
+wroesy.c: In function 'pulsesequence':
+wroesy.c:233:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+wroesy.c:234:46: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        Wet4(wetpwr,wetshape,wetpw,zero,one); delay(dz);
+                                              ^~~~~
+wroesy.c:143:44: warning: variable 'gtw' set but not used [-Wunused-but-set-variable]
+                    wetpwr=getval("wetpwr"),gtw,gswet;
+                                            ^~~
+wroesy.c: In function 'x_pulsesequence':
+wroesy.c:524:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+wroesy.c:525:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        x_Wet4(wetpwr,wetshape,wetpw,zero,one); DPSprint(dz, "10 delay  1 0 1 dz %.9f \n", (float)(dz));
+                                                ^~~~~~~~
+wroesy.c: In function 't_pulsesequence':
+wroesy.c:825:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+wroesy.c:826:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        t_Wet4(wetpwr,wetshape,wetpw,zero,one); DPStimer(10,0,0,1,0,0,0,0,(double)dz);
+                                                ^~~~~~~~
+warn  : /vnmr/biopack/psglib/zdipsitocsy
+zdipsitocsy.c: In function 'pulsesequence':
+zdipsitocsy.c:220:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+zdipsitocsy.c:221:46: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        Wet4(wetpwr,wetshape,wetpw,zero,one); delay(dz);
+                                              ^~~~~
+zdipsitocsy.c:121:40: warning: variable 'gswet' set but not used [-Wunused-but-set-variable]
+                    wetpwr,dz,wetpw,gtw,gswet,
+                                        ^~~~~
+zdipsitocsy.c:121:36: warning: variable 'gtw' set but not used [-Wunused-but-set-variable]
+                    wetpwr,dz,wetpw,gtw,gswet,
+                                    ^~~
+zdipsitocsy.c: In function 'x_pulsesequence':
+zdipsitocsy.c:629:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+zdipsitocsy.c:630:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        x_Wet4(wetpwr,wetshape,wetpw,zero,one); DPSprint(dz, "10 delay  1 0 1 dz %.9f \n", (float)(dz));
+                                                ^~~~~~~~
+zdipsitocsy.c: In function 't_pulsesequence':
+zdipsitocsy.c:1037:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+zdipsitocsy.c:1038:48: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+        t_Wet4(wetpwr,wetshape,wetpw,zero,one); DPStimer(10,0,0,1,0,0,0,0,(double)dz);
+                                                ^~~~~~~~
+   Test       : Seqgen syntax of /vnmr/biosolidspack/psglib/ with 5 sequences
+        Passed: 4 pulse sequences
+       *Warned: 1 pulse sequences
+warn  : /vnmr/biosolidspack/psglib/ahX
+ahX.c: In function 'pulsesequence':
+ahX.c:371:27: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
+    if (!strcmp(ddec2,"y") != 1) {
+                           ^~
+/vnmr/psg/solidwshapes.h: In function 'x_pulsesequence':
+/vnmr/psg/solidwshapes.h:2925:27: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
+/vnmr/psg/solidwshapes.h: In function 't_pulsesequence':
+/vnmr/psg/solidwshapes.h:2925:27: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
+   Test       : Seqgen syntax of /vnmr/gxyzshim/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : Seqgen syntax of /vnmr/imaging/psglib/ with 57 sequences
+        Passed: 37 pulse sequences
+       *Warned: 20 pulse sequences
+warn  : /vnmr/imaging/psglib/asl
+asl.c: In function 'pulsesequence':
+asl.c:40:10: warning: variable 'tref' set but not used [-Wunused-but-set-variable]
+   double tref,
+          ^~~~
+warn  : /vnmr/imaging/psglib/cine
+cine.c: In function 'pulsesequence':
+cine.c:46:11: warning: variable 'flip' set but not used [-Wunused-but-set-variable]
+   int     flip[100];
+           ^~~~
+warn  : /vnmr/imaging/psglib/cpmgecho
+cpmgecho.c: In function 'pulsesequence':
+cpmgecho.c:40:20: warning: variable 'r' set but not used [-Wunused-but-set-variable]
+   double  r1,r2,r3,r,pd,seqtime,dw;
+                    ^
+warn  : /vnmr/imaging/psglib/ct3d
+ct3d.c: In function 'pulsesequence':
+ct3d.c:26:34: warning: variable 'gro' set but not used [-Wunused-but-set-variable]
+   double  gamma,sgro,sgpe1,sgpe2,gro,gpe1,gpe2,
+                                  ^~~
+warn  : /vnmr/imaging/psglib/epi
+epi.c: In function 'pulsesequence':
+epi.c:42:10: warning: variable 'tref' set but not used [-Wunused-but-set-variable]
+   double tref,
+          ^~~~
+warn  : /vnmr/imaging/psglib/episte
+episte.c: In function 'pulsesequence':
+episte.c:41:10: warning: variable 'tref' set but not used [-Wunused-but-set-variable]
+   double tref,
+          ^~~~
+warn  : /vnmr/imaging/psglib/fastestmap
+fastestmap.c: In function 'pulsesequence':
+fastestmap.c:54:24: warning: variable 'vphi' set but not used [-Wunused-but-set-variable]
+   double vtheta, vpsi, vphi;
+
+                        ^~~~
+fastestmap.c:54:18: warning: variable 'vpsi' set but not used [-Wunused-but-set-variable]
+   double vtheta, vpsi, vphi;
+
+                  ^~~~
+fastestmap.c:54:10: warning: variable 'vtheta' set but not used [-Wunused-but-set-variable]
+   double vtheta, vpsi, vphi;
+
+          ^~~~~~
+warn  : /vnmr/imaging/psglib/fse3d
+fse3d.c: In function 'pulsesequence':
+fse3d.c:76:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+     if (kzero<1) kzero=1; if (kzero>etl) kzero=etl;
+     ^~
+fse3d.c:76:27: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+     if (kzero<1) kzero=1; if (kzero>etl) kzero=etl;
+                           ^~
+warn  : /vnmr/imaging/psglib/fse3ddw
+fse3ddw.c: In function 'pulsesequence':
+fse3ddw.c:30:11: warning: variable 'diffamp' set but not used [-Wunused-but-set-variable]
+   double  diffamp;
+           ^~~~~~~
+fse3ddw.c:24:34: warning: variable 'te1_delay' set but not used [-Wunused-but-set-variable]
+   double  seqtime,tau1,tau2,tau3,te1_delay,te2_delay,te3_delay,tr_delay;
+                                  ^~~~~~~~~
+warn  : /vnmr/imaging/psglib/fsems
+fsems.c: In function 'pulsesequence':
+fsems.c:89:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (kzero<1) kzero=1; if (kzero>etl) kzero=etl;
+   ^~
+fsems.c:89:25: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (kzero<1) kzero=1; if (kzero>etl) kzero=etl;
+                         ^~
+warn  : /vnmr/imaging/psglib/fsemsdw
+fsemsdw.c: In function 'pulsesequence':
+fsemsdw.c:32:11: warning: variable 'diffamp' set but not used [-Wunused-but-set-variable]
+   double  diffamp;
+           ^~~~~~~
+fsemsdw.c:25:34: warning: variable 'te1_delay' set but not used [-Wunused-but-set-variable]
+   double  seqtime,tau1,tau2,tau3,te1_delay,te2_delay,te3_delay,tr_delay;
+                                  ^~~~~~~~~
+warn  : /vnmr/imaging/psglib/ge3dshim
+ge3dshim.c: In function 'pulsesequence':
+ge3dshim.c:24:11: warning: variable 'table' set but not used [-Wunused-but-set-variable]
+   int     table=0,shapeEx=0,sepSliceRephase=0,image,blocknvs;
+           ^~~~~
+warn  : /vnmr/imaging/psglib/mtx_spulse
+mtx_spulse.c:40:0: warning: "FP_GT" redefined
+ #define FP_GT(A,B) (((A) > (B)) && (fabs((A) - (B)) > EPSILON)) /* A greater than B */
+ 
+In file included from /vnmr/psg/sgl.h:13:0,
+                 from /vnmr/psg/sgl.c:13,
+                 from mtx_spulse.c:35:
+/vnmr/psg/sglCommon.h:81:0: note: this is the location of the previous definition
+ #define FP_GT(A,B) (((A) > (B)) && (fabs((double)(A) - (double)(B)) > EPSILON)) /* A greater than B */
+ 
+mtx_spulse.c: In function 'pulsesequence':
+mtx_spulse.c:66:6: warning: variable 'my_retval' set but not used [-Wunused-but-set-variable]
+  int my_retval;
+      ^~~~~~~~~
+warn  : /vnmr/imaging/psglib/prescanfreq
+prescanfreq.c: In function 'pulsesequence':
+prescanfreq.c:31:13: warning: variable 'pss0' set but not used [-Wunused-but-set-variable]
+     double  pss0;
+             ^~~~
+prescanfreq.c:30:13: warning: variable 'slice_offset' set but not used [-Wunused-but-set-variable]
+     double  slice_offset,f_offset;
+             ^~~~~~~~~~~~
+prescanfreq.c:29:40: warning: variable 't_plateau_min' set but not used [-Wunused-but-set-variable]
+     double  t_rampslice, t_plateau_sr, t_plateau_min, t_ramp_sr;
+                                        ^~~~~~~~~~~~~
+prescanfreq.c:27:32: warning: variable 'gssrint' set but not used [-Wunused-but-set-variable]
+     double  agss,grate,gssint, gssrint;
+                                ^~~~~~~
+warn  : /vnmr/imaging/psglib/prescanpower
+prescanpower.c: In function 'pulsesequence':
+prescanpower.c:27:19: warning: variable 'shape180' set but not used [-Wunused-but-set-variable]
+   int     shape90,shape180;
+                   ^~~~~~~~
+warn  : /vnmr/imaging/psglib/profile1d
+profile1d.c: In function 'pulsesequence':
+profile1d.c:35:11: warning: variable 'tpwr1f' set but not used [-Wunused-but-set-variable]
+   int     tpwr1f, tpwr2f;
+           ^~~~~~
+warn  : /vnmr/imaging/psglib/quickshim
+quickshim.c: In function 'pulsesequence':
+quickshim.c:26:10: warning: variable 'gdaclim' set but not used [-Wunused-but-set-variable]
+  double  gdaclim,shimscale;
+          ^~~~~~~
+warn  : /vnmr/imaging/psglib/se3ddw
+se3ddw.c: In function 'pulsesequence':
+se3ddw.c:26:11: warning: variable 'table' set but not used [-Wunused-but-set-variable]
+   int     table;
+           ^~~~~
+warn  : /vnmr/imaging/psglib/special
+special.c: In function 'pulsesequence':
+special.c:37:10: warning: variable 'wsfirst' set but not used [-Wunused-but-set-variable]
+   int    wsfirst; //wsfirst makes ws unit to be exececuted first
+          ^~~~~~~
+warn  : /vnmr/imaging/psglib/tagcine
+tagcine.c: In function 'pulsesequence':
+tagcine.c:66:11: warning: variable 'flip' set but not used [-Wunused-but-set-variable]
+   int     flip[100];
+           ^~~~
+   Test       : Seqgen syntax of /vnmr/psglib/ with 201 sequences
+        Passed: 155 pulse sequences
+       *Warned: 46 pulse sequences
+warn  : /vnmr/psglib/ADEQUATEAD
+ADEQUATEAD.c: In function 'pulsesequence':
+ADEQUATEAD.c:98:14: warning: variable 'satmove' set but not used [-Wunused-but-set-variable]
+  int   phase,satmove,maxni,t1_counter,icosel=1,
+              ^~~~~~~
+warn  : /vnmr/psglib/DQCOSY
+DQCOSY.c: In function 'pulsesequence':
+DQCOSY.c:67:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (getflag("prgflg") && (satmode[0] == 'y'))
+   ^~
+DQCOSY.c:70:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+  if (phase1 == 2)
+  ^~
+warn  : /vnmr/psglib/Dbppste_ghsqcse
+Dbppste_ghsqcse.c: In function 'pulsesequence':
+Dbppste_ghsqcse.c:173:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+Dbppste_ghsqcse.c:175:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+Dbppste_ghsqcse.c: In function 'x_pulsesequence':
+Dbppste_ghsqcse.c:1519:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+Dbppste_ghsqcse.c:1521:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+Dbppste_ghsqcse.c: In function 't_pulsesequence':
+Dbppste_ghsqcse.c:2873:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+Dbppste_ghsqcse.c:2875:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+warn  : /vnmr/psglib/Dbppste_wg
+Dbppste_wg.c: In function 'x_pulsesequence':
+Dbppste_wg.c:1461:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+        if (d1 - satdly > 0)
+        ^~
+Dbppste_wg.c:1463:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPSprint(0.00, "60 obspower  1 0 1 satpwr %.9f \n", (float)(satpwr));
+          ^~~~~~~~
+Dbppste_wg.c: In function 't_pulsesequence':
+Dbppste_wg.c:2764:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+        if (d1 - satdly > 0)
+        ^~
+Dbppste_wg.c:2766:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPStimer(60,0,0,0);
+          ^~~~~~~~
+warn  : /vnmr/psglib/Ddeptse
+Ddeptse.c: In function 'pulsesequence':
+Ddeptse.c:144:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (getflag("sspul"))
+    ^~
+Ddeptse.c:147:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if (sspulX[0]=='y')
+         ^~
+Ddeptse.c: In function 'x_pulsesequence':
+Ddeptse.c:1382:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (getflag("sspul"))
+    ^~
+Ddeptse.c:1385:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if (sspulX[0]=='y')
+         ^~
+Ddeptse.c: In function 't_pulsesequence':
+Ddeptse.c:2621:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (getflag("sspul"))
+    ^~
+Ddeptse.c:2624:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         if (sspulX[0]=='y')
+         ^~
+warn  : /vnmr/psglib/DgcsteSL_dpfgse
+DgcsteSL_dpfgse.c: In function 'pulsesequence':
+DgcsteSL_dpfgse.c:221:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+DgcsteSL_dpfgse.c:223:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+          delay(gstab);
+          ^~~~~
+DgcsteSL_dpfgse.c: In function 'x_pulsesequence':
+DgcsteSL_dpfgse.c:1594:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+DgcsteSL_dpfgse.c:1596:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+          DPSprint(gstab, "10 delay  1 0 1 gstab %.9f \n", (float)(gstab));
+          ^~~~~~~~
+DgcsteSL_dpfgse.c: In function 't_pulsesequence':
+DgcsteSL_dpfgse.c:2956:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+DgcsteSL_dpfgse.c:2958:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+          DPStimer(10,0,0,1,0,0,0,0,(double)gstab);
+          ^~~~~~~~
+warn  : /vnmr/psglib/Dgcstehmqc
+Dgcstehmqc.c: In function 'pulsesequence':
+Dgcstehmqc.c:217:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else delay(delcor2);
+     ^~~~
+Dgcstehmqc.c:218:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+          if (alt_grd[0] == 'y')          /* 2nd compensating gradient */
+          ^~
+Dgcstehmqc.c: In function 'x_pulsesequence':
+Dgcstehmqc.c:1573:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else DPSprint(delcor2, "10 delay  1 0 1 delcor2 %.9f \n", (float)(delcor2));
+     ^~~~
+Dgcstehmqc.c:1574:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+          if (alt_grd[0] == 'y')
+          ^~
+Dgcstehmqc.c: In function 't_pulsesequence':
+Dgcstehmqc.c:2933:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else DPStimer(10,0,0,1,0,0,0,0,(double)delcor2);
+     ^~~~
+Dgcstehmqc.c:2934:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+          if (alt_grd[0] == 'y')
+          ^~
+warn  : /vnmr/psglib/Dgcstehmqc_ps
+Dgcstehmqc_ps.c: In function 'x_pulsesequence':
+Dgcstehmqc_ps.c:1409:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else putCmd("dosy3Dproc=\'n\'\n");
+    ^~~~
+Dgcstehmqc_ps.c:1415:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         settable(t1, 4, ph1);
+         ^~~~~~~~
+Dgcstehmqc_ps.c: In function 't_pulsesequence':
+Dgcstehmqc_ps.c:2722:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else putCmd("dosy3Dproc=\'n\'\n");
+    ^~~~
+Dgcstehmqc_ps.c:2728:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         settable(t1, 4, ph1);
+         ^~~~~~~~
+warn  : /vnmr/psglib/Doneshot_nugmap
+Doneshot_nugmap.c: In function 'pulsesequence':
+Doneshot_nugmap.c:91:22: warning: variable 'Ddelta' set but not used [-Wunused-but-set-variable]
+  avm,gzlvl4,gt4,Dtau,Ddelta,dosytimecubed,dosyfrq;
+                      ^~~~~~
+warn  : /vnmr/psglib/Dpfgdste
+Dpfgdste.c: In function 'x_pulsesequence':
+Dpfgdste.c:1544:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+        if (d1 - satdly > 0)
+        ^~
+Dpfgdste.c:1546:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPSprint(0.00, "60 obspower  1 0 1 satpwr %.9f \n", (float)(satpwr));
+          ^~~~~~~~
+Dpfgdste.c: In function 't_pulsesequence':
+Dpfgdste.c:2938:8: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+        if (d1 - satdly > 0)
+        ^~
+Dpfgdste.c:2940:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPStimer(60,0,0,0);
+          ^~~~~~~~
+warn  : /vnmr/psglib/Dproject_cc
+Dproject_cc.c: In function 'pulsesequence':
+Dproject_cc.c:48:7: warning: variable 'Ddelta' set but not used [-Wunused-but-set-variable]
+  Dtau,Ddelta,Deltac,dosytimecubed, dosyfrq;
+       ^~~~~~
+warn  : /vnmr/psglib/HMBCRELAY
+HMBCRELAY.c: In function 'x_pulsesequence':
+HMBCRELAY.c:1435:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (satfrq != tof)
+       ^~
+HMBCRELAY.c:1437:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPSprint(satdly, "48 rgpulse  1 0 1 1 rof1 %.9f rof1 %.9f  1 zero %d satdly %.9f \n", (float)(rof1), (float)(rof1), (int)(zero), (float)(satdly));
+          ^~~~~~~~
+HMBCRELAY.c:1438:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (satfrq != tof)
+       ^~
+HMBCRELAY.c:1440:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPSprint(0.00, "60 obspower  1 0 1 tpwr %.9f \n", (float)(tpwr));
+          ^~~~~~~~
+HMBCRELAY.c: In function 't_pulsesequence':
+HMBCRELAY.c:2739:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (satfrq != tof)
+       ^~
+HMBCRELAY.c:2741:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPStimer(48,0,0,3,0,0,0,0,(double)satdly,(double)rof1,(double)rof1);
+          ^~~~~~~~
+HMBCRELAY.c:2742:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (satfrq != tof)
+       ^~
+HMBCRELAY.c:2744:10: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPStimer(60,0,0,0);
+          ^~~~~~~~
+warn  : /vnmr/psglib/NOESY1D
+NOESY1D.c: In function 'pulsesequence':
+NOESY1D.c:167:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D.c:170:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         zgradpulse(gzlvlB,gtB);
+         ^~~~~~~~~~
+NOESY1D.c:61:6: warning: variable 'mixNcorr' set but not used [-Wunused-but-set-variable]
+      mixNcorr,
+      ^~~~~~~~
+NOESY1D.c: In function 'x_pulsesequence':
+NOESY1D.c:1440:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D.c:1443:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(gtA, "94 zgradpulse  11 0 3 z gtA %.9f gzlvlA %.9f  gradalt  %.9f \n", (float)(gtA), (float)(gzlvlA), (float)gradalt);
+         ^~~~~~~~
+NOESY1D.c:1451:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D.c:1454:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(gtB, "94 zgradpulse  11 0 3 z gtB %.9f gzlvlB %.9f  gradalt  %.9f \n", (float)(gtB), (float)(gzlvlB), (float)gradalt);
+         ^~~~~~~~
+NOESY1D.c: In function 't_pulsesequence':
+NOESY1D.c:2723:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D.c:2726:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gtA);
+         ^~~~~~~~
+NOESY1D.c:2734:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D.c:2737:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gtB);
+         ^~~~~~~~
+warn  : /vnmr/psglib/NOESY1D_ES
+NOESY1D_ES.c: In function 'pulsesequence':
+NOESY1D_ES.c:189:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D_ES.c:192:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         ifzero(v10); zgradpulse(gzlvlB,gtB);
+         ^~~~~~
+NOESY1D_ES.c: In function 'x_pulsesequence':
+NOESY1D_ES.c:1460:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D_ES.c:1463:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(0.00, "23 ifzero  0 1 0 v10 %d \n", (int)(v10)); DPSprint(gtA, "94 zgradpulse  11 0 3 z gtA %.9f gzlvlA %.9f  gradalt  %.9f \n", (float)(gtA), (float)(gzlvlA), (float)gradalt);
+         ^~~~~~~~
+NOESY1D_ES.c:1473:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D_ES.c:1476:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(0.00, "23 ifzero  0 1 0 v10 %d \n", (int)(v10)); DPSprint(gtB, "94 zgradpulse  11 0 3 z gtB %.9f gzlvlB %.9f  gradalt  %.9f \n", (float)(gtB), (float)(gzlvlB), (float)gradalt);
+         ^~~~~~~~
+NOESY1D_ES.c: In function 't_pulsesequence':
+NOESY1D_ES.c:2743:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D_ES.c:2746:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(23,0,1,0,(int)v10,0,0,0); DPStimer(94,0,0,1,0,0,0,0,(double)gtA);
+         ^~~~~~~~
+NOESY1D_ES.c:2756:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+NOESY1D_ES.c:2759:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(23,0,1,0,(int)v10,0,0,0); DPStimer(94,0,0,1,0,0,0,0,(double)gtB);
+         ^~~~~~~~
+warn  : /vnmr/psglib/PSYCHE_zTOCSY
+PSYCHE_zTOCSY.c: In function 'x_pulsesequence':
+PSYCHE_zTOCSY.c:1339:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (strcmp(slpatT,"mlev17c") &&
+    ^~
+PSYCHE_zTOCSY.c:1349:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         gt1 = x_syncGradTime("gt1","gzlvl1",1.0);
+         ^~~
+PSYCHE_zTOCSY.c: In function 't_pulsesequence':
+PSYCHE_zTOCSY.c:2612:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (strcmp(slpatT,"mlev17c") &&
+    ^~
+PSYCHE_zTOCSY.c:2622:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         gt1 = t_syncGradTime("gt1","gzlvl1",1.0);
+         ^~~
+warn  : /vnmr/psglib/ROESY1D
+ROESY1D.c: In function 'pulsesequence':
+ROESY1D.c:220:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+ROESY1D.c:223:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         zgradpulse(gzlvlB,gtB);
+         ^~~~~~~~~~
+ROESY1D.c: In function 'x_pulsesequence':
+ROESY1D.c:1554:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+ROESY1D.c:1557:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(gtB, "94 zgradpulse  11 0 3 z gtB %.9f gzlvlB %.9f  gradalt  %.9f \n", (float)(gtB), (float)(gzlvlB), (float)gradalt);
+         ^~~~~~~~
+ROESY1D.c: In function 't_pulsesequence':
+ROESY1D.c:2887:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+ROESY1D.c:2890:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gtB);
+         ^~~~~~~~
+warn  : /vnmr/psglib/ROESY1D_ES
+ROESY1D_ES.c: In function 'pulsesequence':
+ROESY1D_ES.c:228:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+ROESY1D_ES.c:231:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         ifzero(v8); zgradpulse(gzlvlB,gtB);
+         ^~~~~~
+ROESY1D_ES.c: In function 'x_pulsesequence':
+ROESY1D_ES.c:1541:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+ROESY1D_ES.c:1544:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(0.00, "23 ifzero  0 1 0 v8 %d \n", (int)(v8)); DPSprint(gtB, "94 zgradpulse  11 0 3 z gtB %.9f gzlvlB %.9f  gradalt  %.9f \n", (float)(gtB), (float)(gzlvlB), (float)gradalt);
+         ^~~~~~~~
+ROESY1D_ES.c: In function 't_pulsesequence':
+ROESY1D_ES.c:2853:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+ROESY1D_ES.c:2856:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(23,0,1,0,(int)v8,0,0,0); DPStimer(94,0,0,1,0,0,0,0,(double)gtB);
+         ^~~~~~~~
+warn  : /vnmr/psglib/ROESYAD_ES
+ROESYAD_ES.c: In function 'pulsesequence':
+ROESYAD_ES.c:165:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (zfilt[0] == 'y')
+       ^~
+ROESYAD_ES.c:166:23: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          ifzero(v10); zgradpulse(gzlvlz,gtz);
+                       ^~~~~~~~~~
+ROESYAD_ES.c: In function 'x_pulsesequence':
+ROESYAD_ES.c:1403:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (zfilt[0] == 'y')
+       ^~
+ROESYAD_ES.c:1404:68: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPSprint(0.00, "23 ifzero  0 1 0 v10 %d \n", (int)(v10)); DPSprint(gtz, "94 zgradpulse  11 0 3 z gtz %.9f gzlvlz %.9f  gradalt  %.9f \n", (float)(gtz), (float)(gzlvlz), (float)gradalt);
+                                                                    ^~~~~~~~
+ROESYAD_ES.c: In function 't_pulsesequence':
+ROESYAD_ES.c:2640:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (zfilt[0] == 'y')
+       ^~
+ROESYAD_ES.c:2641:45: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+          DPStimer(23,0,1,0,(int)v10,0,0,0); DPStimer(94,0,0,1,0,0,0,0,(double)gtz);
+                                             ^~~~~~~~
+warn  : /vnmr/psglib/TOCSY1D
+TOCSY1D.c: In function 'pulsesequence':
+TOCSY1D.c:192:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+TOCSY1D.c:195:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         zgradpulse(gzlvlB,gtB);
+         ^~~~~~~~~~
+TOCSY1D.c: In function 'x_pulsesequence':
+TOCSY1D.c:1489:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+TOCSY1D.c:1492:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(gtB, "94 zgradpulse  11 0 3 z gtB %.9f gzlvlB %.9f  gradalt  %.9f \n", (float)(gtB), (float)(gzlvlB), (float)gradalt);
+         ^~~~~~~~
+TOCSY1D.c: In function 't_pulsesequence':
+TOCSY1D.c:2786:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+TOCSY1D.c:2789:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gtB);
+         ^~~~~~~~
+warn  : /vnmr/psglib/TOCSY1D_ES
+TOCSY1D_ES.c: In function 'pulsesequence':
+TOCSY1D_ES.c:181:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+TOCSY1D_ES.c:184:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         ifzero(v12); zgradpulse(gzlvlB,gtB);
+         ^~~~~~
+TOCSY1D_ES.c: In function 'x_pulsesequence':
+TOCSY1D_ES.c:1443:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+TOCSY1D_ES.c:1446:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(0.00, "23 ifzero  0 1 0 v12 %d \n", (int)(v12)); DPSprint(gtB, "94 zgradpulse  11 0 3 z gtB %.9f gzlvlB %.9f  gradalt  %.9f \n", (float)(gtB), (float)(gzlvlB), (float)gradalt);
+         ^~~~~~~~
+TOCSY1D_ES.c: In function 't_pulsesequence':
+TOCSY1D_ES.c:2705:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+TOCSY1D_ES.c:2708:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(23,0,1,0,(int)v12,0,0,0); DPStimer(94,0,0,1,0,0,0,0,(double)gtB);
+         ^~~~~~~~
+warn  : /vnmr/psglib/bsHSQCNOESY
+bsHSQCNOESY.c: In function 'pulsesequence':
+bsHSQCNOESY.c:331:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+bsHSQCNOESY.c:334:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if (getflag("Gzqfilt"))
+         ^~
+bsHSQCNOESY.c: In function 'x_pulsesequence':
+bsHSQCNOESY.c:1776:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+bsHSQCNOESY.c:1779:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if (getflag("Gzqfilt"))
+         ^~
+bsHSQCNOESY.c: In function 't_pulsesequence':
+bsHSQCNOESY.c:3221:7: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+       else
+       ^~~~
+bsHSQCNOESY.c:3224:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+         if (getflag("Gzqfilt"))
+         ^~
+warn  : /vnmr/psglib/bsHSQCROESY
+bsHSQCROESY.c: In function 'pulsesequence':
+bsHSQCROESY.c:298:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+bsHSQCROESY.c:301:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+       zgradpulse(gzlvlA,gtA);
+       ^~~~~~~~~~
+bsHSQCROESY.c: In function 'x_pulsesequence':
+bsHSQCROESY.c:1731:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+bsHSQCROESY.c:1734:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+       DPSprint(gtA, "94 zgradpulse  11 0 3 z gtA %.9f gzlvlA %.9f  gradalt  %.9f \n", (float)(gtA), (float)(gzlvlA), (float)gradalt);
+       ^~~~~~~~
+bsHSQCROESY.c: In function 't_pulsesequence':
+bsHSQCROESY.c:3163:5: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+     else
+     ^~~~
+bsHSQCROESY.c:3166:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+       DPStimer(94,0,0,1,0,0,0,0,(double)gtA);
+       ^~~~~~~~
+warn  : /vnmr/psglib/bsgHMBC
+bsgHMBC.c: In function 'pulsesequence':
+bsgHMBC.c:72:10: warning: variable 'tau' set but not used [-Wunused-but-set-variable]
+          tau,
+          ^~~
+warn  : /vnmr/psglib/cyclenoe
+cyclenoe.c: In function 'pulsesequence':
+cyclenoe.c:62:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+   ^~
+cyclenoe.c:62:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+                                  ^~
+cyclenoe.c: In function 'x_pulsesequence':
+cyclenoe.c:193:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+   ^~
+cyclenoe.c:193:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+                                  ^~
+cyclenoe.c: In function 't_pulsesequence':
+cyclenoe.c:334:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+   ^~
+cyclenoe.c:334:34: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+   if (pattern == 0) pattern = 1; if (tau == 0.0) tau = 0.1;
+                                  ^~
+warn  : /vnmr/psglib/dqcosyHT
+dqcosyHT.c: In function 'pulsesequence':
+dqcosyHT.c:63:6: warning: variable 'iphase' set but not used [-Wunused-but-set-variable]
+  int iphase;
+      ^~~~~~
+warn  : /vnmr/psglib/fidelity
+fidelity.c: In function 'pulsesequence':
+fidelity.c:52:6: warning: variable 'i' set but not used [-Wunused-but-set-variable]
+  int i,ret=-1;
+      ^
+warn  : /vnmr/psglib/gDQCOSY
+gDQCOSY.c: In function 'pulsesequence':
+gDQCOSY.c:79:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (getflag("prgflg") && (satmode[0] == 'y'))
+   ^~
+gDQCOSY.c:82:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+  if (phase1 == 2)
+  ^~
+warn  : /vnmr/psglib/gHMBCAD
+gHMBCAD.c: In function 'pulsesequence':
+gHMBCAD.c:58:10: warning: variable 'tau' set but not used [-Wunused-but-set-variable]
+          tau,
+          ^~~
+warn  : /vnmr/psglib/gHMBCRELAY
+gHMBCRELAY.c: In function 'pulsesequence':
+gHMBCRELAY.c:48:55: warning: variable 'satfrq' set but not used [-Wunused-but-set-variable]
+                  phase, hsgt, hsglvl, satdly, satpwr, satfrq, shapedpower;
+                                                       ^~~~~~
+gHMBCRELAY.c:48:47: warning: variable 'satpwr' set but not used [-Wunused-but-set-variable]
+                  phase, hsgt, hsglvl, satdly, satpwr, satfrq, shapedpower;
+                                               ^~~~~~
+gHMBCRELAY.c:48:31: warning: variable 'hsglvl' set but not used [-Wunused-but-set-variable]
+                  phase, hsgt, hsglvl, satdly, satpwr, satfrq, shapedpower;
+                               ^~~~~~
+gHMBCRELAY.c:48:25: warning: variable 'hsgt' set but not used [-Wunused-but-set-variable]
+                  phase, hsgt, hsglvl, satdly, satpwr, satfrq, shapedpower;
+                         ^~~~
+warn  : /vnmr/psglib/gc2hsqcse
+gc2hsqcse.c: In function 'pulsesequence':
+gc2hsqcse.c:69:6: warning: variable 'ZZgsign' set but not used [-Wunused-but-set-variable]
+      ZZgsign;
+      ^~~~~~~
+warn  : /vnmr/psglib/gnoesy
+gnoesy.c: In function 'pulsesequence':
+gnoesy.c:89:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (iphase == 2)
+   ^~
+gnoesy.c:93:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    settable(t1, 2, ph1);
+    ^~~~~~~~
+gnoesy.c: In function 'x_pulsesequence':
+gnoesy.c:172:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (iphase == 2)
+   ^~
+gnoesy.c:176:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    settable(t1, 2, ph1);
+    ^~~~~~~~
+gnoesy.c: In function 't_pulsesequence':
+gnoesy.c:254:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (iphase == 2)
+   ^~
+gnoesy.c:258:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    settable(t1, 2, ph1);
+    ^~~~~~~~
+warn  : /vnmr/psglib/gtnnoesy
+gtnnoesy.c: In function 'pulsesequence':
+gtnnoesy.c:89:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (phase1 == 2)
+   ^~
+gtnnoesy.c:92:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if (phase1 == 3)
+    ^~
+gtnnoesy.c: In function 'x_pulsesequence':
+gtnnoesy.c:271:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+   if (phase1 == 2)
+   ^~
+gtnnoesy.c:274:4: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+    if (phase1 == 3)
+    ^~
+warn  : /vnmr/psglib/hmqctoxy3d
+hmqctoxy3d.c: In function 'pulsesequence':
+hmqctoxy3d.c:148:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+hmqctoxy3d.c:152:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     if (iphase == 2)
+     ^~
+hmqctoxy3d.c: In function 'x_pulsesequence':
+hmqctoxy3d.c:362:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+hmqctoxy3d.c:366:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     if (iphase == 2)
+     ^~
+hmqctoxy3d.c: In function 't_pulsesequence':
+hmqctoxy3d.c:581:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+hmqctoxy3d.c:585:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+     if (iphase == 2)
+     ^~
+warn  : /vnmr/psglib/hsqctoxySE
+hsqctoxySE.c: In function 'pulsesequence':
+hsqctoxySE.c:90:4: warning: variable 'pwxsel' set but not used [-Wunused-but-set-variable]
+    pwxsel,
+    ^~~~~~
+hsqctoxySE.c:89:4: warning: variable 'sellvl' set but not used [-Wunused-but-set-variable]
+    sellvl,
+    ^~~~~~
+warn  : /vnmr/psglib/selexcit
+selexcit.c: In function 'pulsesequence':
+selexcit.c:144:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+selexcit.c:147:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         zgradpulse(gzlvlB,gtB);
+         ^~~~~~~~~~
+warn  : /vnmr/psglib/stepNOESY1D
+stepNOESY1D.c: In function 'pulsesequence':
+stepNOESY1D.c:189:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+stepNOESY1D.c:192:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         zgradpulse(gzlvlB,gtB);
+         ^~~~~~~~~~
+stepNOESY1D.c:62:6: warning: variable 'mixNcorr' set but not used [-Wunused-but-set-variable]
+      mixNcorr,
+      ^~~~~~~~
+stepNOESY1D.c: In function 'x_pulsesequence':
+stepNOESY1D.c:1485:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+stepNOESY1D.c:1488:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(gtA, "94 zgradpulse  11 0 3 z gtA %.9f gzlvlA %.9f  gradalt  %.9f \n", (float)(gtA), (float)(gzlvlA), (float)gradalt);
+         ^~~~~~~~
+stepNOESY1D.c:1496:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+stepNOESY1D.c:1499:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(gtB, "94 zgradpulse  11 0 3 z gtB %.9f gzlvlB %.9f  gradalt  %.9f \n", (float)(gtB), (float)(gzlvlB), (float)gradalt);
+         ^~~~~~~~
+stepNOESY1D.c: In function 't_pulsesequence':
+stepNOESY1D.c:2792:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+stepNOESY1D.c:2795:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gtA);
+         ^~~~~~~~
+stepNOESY1D.c:2803:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+stepNOESY1D.c:2806:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gtB);
+         ^~~~~~~~
+warn  : /vnmr/psglib/troesy
+troesy.c: In function 'x_pulsesequence':
+troesy.c:221:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (iphase == 3)
+    ^~
+troesy.c:223:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       DPSprint(0.00, "70 add 51 3 0 v1 %d v14 %d v1 %d \n", (int)(v1), (int)(v14), (int)(v1));
+       ^~~~~~~~
+troesy.c: In function 't_pulsesequence':
+troesy.c:363:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (iphase == 3)
+    ^~
+troesy.c:365:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       DPStimer(70,51,3,0,(int)v1,(int)v14,(int)v1,0);
+       ^~~~~~~~
+warn  : /vnmr/psglib/trtune
+trtune.c: In function 'pulsesequence':
+trtune.c:39:8: warning: variable 'nfv' set but not used [-Wunused-but-set-variable]
+    int nfv,index;
+        ^~~
+warn  : /vnmr/psglib/wLOGSY_ES
+wLOGSY_ES.c: In function 'x_pulsesequence':
+wLOGSY_ES.c:1344:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+wLOGSY_ES.c:1346:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      DPSprint(0.00, "23 ifzero  0 1 0 v6 %d \n", (int)(v6)); DPSprint(gt1, "94 zgradpulse  11 0 3 z gt1 %.9f gzlvl1 %.9f  gradalt  %.9f \n", (float)(gt1), (float)(gzlvl1), (float)gradalt);
+      ^~~~~~~~
+wLOGSY_ES.c: In function 't_pulsesequence':
+wLOGSY_ES.c:2554:4: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
+    else
+    ^~~~
+wLOGSY_ES.c:2556:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
+      DPStimer(23,0,1,0,(int)v6,0,0,0); DPStimer(94,0,0,1,0,0,0,0,(double)gt1);
+      ^~~~~~~~
+warn  : /vnmr/psglib/wet1D
+wet1D.c: In function 'pulsesequence':
+wet1D.c:41:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (sspul[0] == 'y')
+    ^~
+wet1D.c:44:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+  delay(d1);
+  ^~~~~
+warn  : /vnmr/psglib/wetgHMBC
+wetgHMBC.c: In function 'x_pulsesequence':
+wetgHMBC.c:174:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (getflag("wet"))
+    ^~
+wetgHMBC.c:176:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPSprint(0.00, "60 decpower  2 0 1 pwxlvl %.9f \n", (float)(pwxlvl));
+      ^~~~~~~~
+wetgHMBC.c: In function 't_pulsesequence':
+wetgHMBC.c:266:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (getflag("wet"))
+    ^~
+wetgHMBC.c:268:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPStimer(60,0,0,0);
+      ^~~~~~~~
+warn  : /vnmr/psglib/wetgHMQC
+wetgHMQC.c: In function 'x_pulsesequence':
+wetgHMQC.c:206:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (getflag("wet"))
+    ^~
+wetgHMQC.c:208:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPSprint(0.00, "60 decpower  2 0 1 pwxlvl %.9f \n", (float)(pwxlvl));
+      ^~~~~~~~
+wetgHMQC.c: In function 't_pulsesequence':
+wetgHMQC.c:327:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (getflag("wet"))
+    ^~
+wetgHMQC.c:329:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPStimer(60,0,0,0);
+      ^~~~~~~~
+warn  : /vnmr/psglib/wetgHSQC
+wetgHSQC.c: In function 'x_pulsesequence':
+wetgHSQC.c:233:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (getflag("wet"))
+    ^~
+wetgHSQC.c:235:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPSprint(0.00, "60 decpower  2 0 1 pwxlvl %.9f \n", (float)(pwxlvl));
+      ^~~~~~~~
+wetgHSQC.c: In function 't_pulsesequence':
+wetgHSQC.c:373:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (getflag("wet"))
+    ^~
+wetgHSQC.c:375:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPStimer(60,0,0,0);
+      ^~~~~~~~
+warn  : /vnmr/psglib/wetghmqcps
+wetghmqcps.c: In function 'pulsesequence':
+wetghmqcps.c:127:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+wetghmqcps.c:130:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+wetghmqcps.c:164:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (d2 > 0);
+    ^~
+wetghmqcps.c:165:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      delay(d2/2 + (2.0*pwx/3.14159) - pw + D2_FUDGEFACTOR);
+      ^~~~~
+wetghmqcps.c:174:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (d2 > 0);
+    ^~
+wetghmqcps.c:175:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      delay(d2/2 + (2.0*pwx/3.14159) - pw + D2_FUDGEFACTOR);
+      ^~~~~
+wetghmqcps.c:75:58: warning: variable 'gstab' set but not used [-Wunused-but-set-variable]
+   double j,pwxpwr,gzlvl1,gt1,gzlvl2,gt2,gzlvl3,gt3,grise,gstab,phase;
+                                                          ^~~~~
+wetghmqcps.c: In function 'x_pulsesequence':
+wetghmqcps.c:258:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+wetghmqcps.c:261:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+wetghmqcps.c:297:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (d2 > 0);
+    ^~
+wetghmqcps.c:298:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPSprint(d2/2+(2.0*pwx/3.14159)-pw+1.0e-06, "10 delay  1 0 1 d2/2+(2.0*pwx/3.14159)-pw+1.0e-06 %.9f \n", (float)(d2/2+(2.0*pwx/3.14159)-pw+1.0e-06));
+      ^~~~~~~~
+wetghmqcps.c:307:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (d2 > 0);
+    ^~
+wetghmqcps.c:308:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPSprint(d2/2+(2.0*pwx/3.14159)-pw+1.0e-06, "10 delay  1 0 1 d2/2+(2.0*pwx/3.14159)-pw+1.0e-06 %.9f \n", (float)(d2/2+(2.0*pwx/3.14159)-pw+1.0e-06));
+      ^~~~~~~~
+wetghmqcps.c: In function 't_pulsesequence':
+wetghmqcps.c:388:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if(ix == 1)
+    ^~
+wetghmqcps.c:391:7: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+       t1_counter = (int) ( (d2-d2_init)*sw1 + 0.5);
+       ^~~~~~~~~~
+wetghmqcps.c:427:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (d2 > 0);
+    ^~
+wetghmqcps.c:428:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPStimer(10,0,0,1,0,0,0,0,(double)d2/2+(2.0*pwx/3.14159)-pw+1.0e-06);
+      ^~~~~~~~
+wetghmqcps.c:437:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+    if (d2 > 0);
+    ^~
+wetghmqcps.c:438:6: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+      DPStimer(10,0,0,1,0,0,0,0,(double)d2/2+(2.0*pwx/3.14159)-pw+1.0e-06);
+      ^~~~~~~~
+warn  : /vnmr/psglib/zTOCSY1D
+zTOCSY1D.c: In function 'pulsesequence':
+zTOCSY1D.c:220:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D.c:223:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         zgradpulse(gzlvlB,gtB);
+         ^~~~~~~~~~
+zTOCSY1D.c: In function 'x_pulsesequence':
+zTOCSY1D.c:1538:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D.c:1541:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(gtA, "94 zgradpulse  11 0 3 z gtA %.9f gzlvlA %.9f  gradalt  %.9f \n", (float)(gtA), (float)(gzlvlA), (float)gradalt);
+         ^~~~~~~~
+zTOCSY1D.c:1549:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D.c:1552:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(gtB, "94 zgradpulse  11 0 3 z gtB %.9f gzlvlB %.9f  gradalt  %.9f \n", (float)(gtB), (float)(gzlvlB), (float)gradalt);
+         ^~~~~~~~
+zTOCSY1D.c:1560:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D.c:1563:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(pw, "48 rgpulse  1 0 1 1 rof1 %.9f rof1 %.9f  1 v14 %d pw %.9f \n", (float)(rof1), (float)(rof1), (int)(v14), (float)(pw));
+         ^~~~~~~~
+zTOCSY1D.c: In function 't_pulsesequence':
+zTOCSY1D.c:2868:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D.c:2871:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gtA);
+         ^~~~~~~~
+zTOCSY1D.c:2879:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D.c:2882:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(94,0,0,1,0,0,0,0,(double)gtB);
+         ^~~~~~~~
+zTOCSY1D.c:2890:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D.c:2893:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)rof1,(double)rof1);
+         ^~~~~~~~
+warn  : /vnmr/psglib/zTOCSY1D_ES
+zTOCSY1D_ES.c: In function 'pulsesequence':
+zTOCSY1D_ES.c:218:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D_ES.c:221:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         ifzero(v10); zgradpulse(gzlvlB,gtB);
+         ^~~~~~
+zTOCSY1D_ES.c: In function 'x_pulsesequence':
+zTOCSY1D_ES.c:1517:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D_ES.c:1520:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(0.00, "23 ifzero  0 1 0 v10 %d \n", (int)(v10)); DPSprint(gtA, "94 zgradpulse  11 0 3 z gtA %.9f gzlvlA %.9f  gradalt  %.9f \n", (float)(gtA), (float)(gzlvlA), (float)gradalt);
+         ^~~~~~~~
+zTOCSY1D_ES.c:1530:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D_ES.c:1533:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(0.00, "23 ifzero  0 1 0 v10 %d \n", (int)(v10)); DPSprint(gtB, "94 zgradpulse  11 0 3 z gtB %.9f gzlvlB %.9f  gradalt  %.9f \n", (float)(gtB), (float)(gzlvlB), (float)gradalt);
+         ^~~~~~~~
+zTOCSY1D_ES.c:1543:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D_ES.c:1546:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPSprint(pw, "48 rgpulse  1 0 1 1 rof1 %.9f rof1 %.9f  1 v14 %d pw %.9f \n", (float)(rof1), (float)(rof1), (int)(v14), (float)(pw));
+         ^~~~~~~~
+zTOCSY1D_ES.c: In function 't_pulsesequence':
+zTOCSY1D_ES.c:2830:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D_ES.c:2833:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(23,0,1,0,(int)v10,0,0,0); DPStimer(94,0,0,1,0,0,0,0,(double)gtA);
+         ^~~~~~~~
+zTOCSY1D_ES.c:2843:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D_ES.c:2846:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(23,0,1,0,(int)v10,0,0,0); DPStimer(94,0,0,1,0,0,0,0,(double)gtB);
+         ^~~~~~~~
+zTOCSY1D_ES.c:2856:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
+       if (selfrq != tof)
+       ^~
+zTOCSY1D_ES.c:2859:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
+         DPStimer(48,0,0,3,0,0,0,0,(double)pw,(double)rof1,(double)rof1);
+         ^~~~~~~~
+   Test       : Seqgen syntax of /vnmr/solidspack/psglib/ with 162 sequences
+        Passed: 161 pulse sequences
+       *Warned: 1 pulse sequences
+warn  : /vnmr/solidspack/psglib/mashsqc2d
+mashsqc2d.c: In function 'pulsesequence':
+mashsqc2d.c:90:41: warning: right-hand operand of comma expression has no effect [-Wunused-value]
+       del1 = (pw1Hhxhsqc - pw1Xhxhsqc)/2,0;
+
+                                         ^
+mashsqc2d.c:115:41: warning: right-hand operand of comma expression has no effect [-Wunused-value]
+       del2 = (pw2Hhxhsqc - pw2Xhxhsqc)/2,0;
+
+                                         ^
+mashsqc2d.c:146:41: warning: right-hand operand of comma expression has no effect [-Wunused-value]
+       del3 = (pw1Hhxhsqc - pw1Xhxhsqc)/2,0;
+
+                                         ^
+/vnmr/psg/solidwshapes.h: In function 'x_pulsesequence':
+/vnmr/psg/solidwshapes.h:1780:41: warning: right-hand operand of comma expression has no effect [-Wunused-value]
+/vnmr/psg/solidwshapes.h:1808:41: warning: right-hand operand of comma expression has no effect [-Wunused-value]
+/vnmr/psg/solidwshapes.h:1842:41: warning: right-hand operand of comma expression has no effect [-Wunused-value]
+/vnmr/psg/solidwshapes.h: In function 't_pulsesequence':
+/vnmr/psg/solidwshapes.h:1780:41: warning: right-hand operand of comma expression has no effect [-Wunused-value]
+/vnmr/psg/solidwshapes.h:1808:41: warning: right-hand operand of comma expression has no effect [-Wunused-value]
+/vnmr/psg/solidwshapes.h:1842:41: warning: right-hand operand of comma expression has no effect [-Wunused-value]
+   Test       : Seqgen syntax of /vnmr/veripulse/psglib/ with 1 sequences
+        Passed: 1 pulse sequences
+   Test       : psggen
+        Passed: psggen
+   Test       : fixpsg
+        Passed: fixpsg

--- a/src/vnmr/builtin.c
+++ b/src/vnmr/builtin.c
@@ -2298,8 +2298,44 @@ static int countitems(char *dirname)
 |	in the selected directory
 |
 +-----------------------------------------------------------------------*/
+static int getitem(char *dirname, int index, char filename[])	
+{
+    DIR            *dirp;
+    struct dirent  *dp;
+    int             temp;
+
+    if ( (dirp = opendir(dirname)) )
+    {
+      dp = NULL;
+      temp = 0;
+      while ((temp < index) && ((dp = readdir(dirp)) != NULL))
+        if (*dp->d_name != '.')  /* no . files */
+          temp++;
+      if ((index == temp) && (dp != NULL))
+        strcpy(filename,dp->d_name);
+      else
+      {
+        closedir(dirp);
+        Werrprintf("cannot get item %d from %s",index,dirname);
+	ABORT;
+      }	
+      closedir(dirp);
+      RETURN;
+    }
+    else
+    {	Werrprintf("trouble opening %s",dirname);
+	ABORT;
+    }	
+}
+
+/*------------------------------------------------------------------------
+|
+|	This module returns the name of the n th file
+|	in the selected directory, sorted
+|
++-----------------------------------------------------------------------*/
 static int nodotfiles(const struct dirent * dp) { return dp->d_name[0] != '.'; }
-static int getitem(char *dirname, int index, char filename[])
+static int getitem_sorted(char *dirname, int index, char filename[], const char * sorttype)
 {
   int             temp;
   struct dirent **namelist;
@@ -2307,6 +2343,12 @@ static int getitem(char *dirname, int index, char filename[])
 
   /* make index 0-based */
   index--;
+
+  if (strcmp(sorttype, "alphasort"))
+  {
+    Werrprintf("unknown sort type '%s'", sorttype);
+    ABORT;
+  }
 
   if (-1 != (n = scandir(dirname, &namelist, nodotfiles, alphasort)))
   {
@@ -2324,13 +2366,13 @@ static int getitem(char *dirname, int index, char filename[])
       RETURN;
     else
     {
-      Werrprintf("cannot get item %d from %s",index+1,dirname);
+      Werrprintf("cannot get item %d from %s", index+1, dirname);
       ABORT;
     }
   }
   else
   {
-    Werrprintf("trouble opening %s",dirname);
+    Werrprintf("trouble opening %s", dirname);
     ABORT;
   }
 }
@@ -2353,7 +2395,7 @@ int getfile(int argc, char *argv[], int retc, char *retv[])
   char extension[MAXPATHL];
   int  temp,len,i;
 
-  if (argc == 3)       /* a specific file name is wanted */
+  if (argc == 3 || argc == 4)       /* a specific file name is wanted */
   {
     filename[0] = '\0';
     if ((isReal(argv[2])) && (isDirectory(argv[1])))
@@ -2364,12 +2406,17 @@ int getfile(int argc, char *argv[], int retc, char *retv[])
         Werrprintf("file index %d does not exist",index);
         ABORT;
       }
-      else if (getitem(argv[1],index,filename))
+      else if (argc == 3)
+      {
+        if (getitem(argv[1],index,filename))
+          ABORT;
+      }
+      else if (getitem_sorted(argv[1],index,filename,argv[3]))
         ABORT;
     }
     else
     {
-      Werrprintf("Usage -- getfile(directory <,index>)");
+      Werrprintf("Usage -- getfile(directory <,index[,'alphasort']>)");
       ABORT;
     }
     extension[0] = '\0';

--- a/src/vnmr/builtin.c
+++ b/src/vnmr/builtin.c
@@ -2298,34 +2298,41 @@ static int countitems(char *dirname)
 |	in the selected directory
 |
 +-----------------------------------------------------------------------*/
-static int getitem(char *dirname, int index, char filename[])	
+static int nodotfiles(const struct dirent * dp) { return dp->d_name[0] != '.'; }
+static int getitem(char *dirname, int index, char filename[])
 {
-    DIR            *dirp;
-    struct dirent  *dp;
-    int             temp;
+  int             temp;
+  struct dirent **namelist;
+  int             n;
 
-    if ( (dirp = opendir(dirname)) )
-    {
-      dp = NULL;
-      temp = 0;
-      while ((temp < index) && ((dp = readdir(dirp)) != NULL))
-        if (*dp->d_name != '.')  /* no . files */
-          temp++;
-      if ((index == temp) && (dp != NULL))
-        strcpy(filename,dp->d_name);
-      else
-      {
-        closedir(dirp);
-        Werrprintf("cannot get item %d from %s",index,dirname);
-	ABORT;
-      }	
-      closedir(dirp);
-      RETURN;
+  /* make index 0-based */
+  index--;
+
+  if (-1 != (n = scandir(dirname, &namelist, nodotfiles, alphasort)))
+  {
+    if (index >= 0 && index < n)
+      strcpy(filename, namelist[index]->d_name);
+
+    /* cleanup for scandir */
+    for (temp = 0; temp < n; temp++) {
+      free(namelist[temp]);
     }
+    free(namelist);
+
+    /* return */
+    if (index >= 0 && index < n)
+      RETURN;
     else
-    {	Werrprintf("trouble opening %s",dirname);
-	ABORT;
-    }	
+    {
+      Werrprintf("cannot get item %d from %s",index+1,dirname);
+      ABORT;
+    }
+  }
+  else
+  {
+    Werrprintf("trouble opening %s",dirname);
+    ABORT;
+  }
 }
 
 /*------------------------------------------------------------------------


### PR DESCRIPTION
readdir() returns directory items in an undefined order, determined by the underlying filesystem.

This replaces readdir() with scandir() so that the built-in command 'getfile' will return directory items in alphabetic order.  The main reason is so that auto-generated files that depend on directory traversal will be stable over time.  In particular the test output produced by vjqa (#199 ).  There is some extra overhead: every call to scandir() has to re-scan the entire directory, instead of being able to break out of the loop when 'index' has been reached - on avg twice as many calls to readdir().  Plus there's a call to qsort() every call to scandir().  These should both be pretty negligible on modern systems though.

I *think* it shouldn't break anything, since the old semantics had an undefined mapping of index to filename.

Haven't tested on macos, but looks good on centos6 & 7 ubuntu14 & 16.