### PR TITLE
Updated for tcl/tk

### DIFF
--- a/src/scripts/adddevices.sh
+++ b/src/scripts/adddevices.sh
@@ -42,14 +42,9 @@ set user = `id | sed -e 's/[^(]*[(]\([^)]*\)[)].*/\1/'`
       setenv VNMR_ADM_DIR  "$vnmrsystem/adm"
       set path = ($path "$vnmrsystem/tcl/bin")
 
-      set ostype = `uname -s`
-      if ( "x$ostype" == "xLinux" ) then
-          set WISH = /usr/bin/wish
-      else
-          setenv TCL_LIBRARY   "$TCLDIR/tcllibrary"
-          setenv TK_LIBRARY    "$TCLDIR/tklibrary"
-          set WISH = "$vnmrsystem/tcl/bin/vnmrWish"
-      endif
+      setenv TCL_LIBRARY   "$TCLDIR/tcllibrary"
+      setenv TK_LIBRARY    "$TCLDIR/tklibrary"
+      set WISH = "$vnmrsystem/tcl/bin/vnmrWish"
 
       "$WISH" "$TCLDIR/bin/add_printer" &
 

--- a/src/scripts/atrecord.sh
+++ b/src/scripts/atrecord.sh
@@ -11,23 +11,9 @@
 # 
 #
 
-
-set ostype = `uname -s`
-if ( "x$ostype" == "xLinux" ) then
-   set TCLSH = /usr/bin/tclsh
-   set cmd = "$vnmrsystem/tcl/bin/atrecord.tcl"
-else
-   if ( "x$ostype" == "xInterix" ) then
-      cd $vnmrsystem/tcl/bin
-      set TCLSH = "./tclsh84.exe"
-      setenv TCL_LIBRARY   "../tcllibrary"
-      set cmd = "./atrecord.tcl"
-   else
-      setenv TCLDIR        "$vnmrsystem/tcl"
-      setenv TCL_LIBRARY   "$TCLDIR/tcllibrary"
-      set TCLSH = "$vnmrsystem/tcl/bin/tclsh"
-      set cmd = "$vnmrsystem/tcl/bin/atrecord.tcl"
-   endif
-endif
+setenv TCLDIR        "$vnmrsystem/tcl"
+setenv TCL_LIBRARY   "$TCLDIR/tcllibrary"
+set TCLSH = "$vnmrsystem/bin/tclsh"
+set cmd = "$vnmrsystem/tcl/bin/atrecord.tcl"
 
 "$TCLSH" "$cmd" "$1" "$2" "$3" "$4" $argv[5-] < /dev/null > /dev/null

--- a/src/scripts/atregbuilt.sh
+++ b/src/scripts/atregbuilt.sh
@@ -11,23 +11,9 @@
 # 
 #
 
-
-set ostype = `uname -s`
-if ( "x$ostype" == "xLinux" ) then
-   set TCLSH = /usr/bin/tclsh
-   set cmd = "$vnmrsystem/tcl/bin/atregbuilt.tcl"
-else
-   if ( "x$ostype" == "xInterix" ) then
-      cd $vnmrsystem/tcl/bin
-      set TCLSH = "./tclsh84.exe"
-      setenv TCL_LIBRARY   "../tcllibrary"
-      set cmd = "./atregbuilt.tcl"
-   else
-      setenv TCLDIR        "$vnmrsystem/tcl"
-      setenv TCL_LIBRARY   "$TCLDIR/tcllibrary"
-      set TCLSH = "$vnmrsystem/tcl/bin/tclsh"
-      set cmd = "$vnmrsystem/tcl/bin/atregbuilt.tcl"
-   endif
-endif
+setenv TCLDIR        "$vnmrsystem/tcl"
+setenv TCL_LIBRARY   "$TCLDIR/tcllibrary"
+set TCLSH = "$vnmrsystem/bin/tclsh"
+set cmd = "$vnmrsystem/tcl/bin/atregbuilt.tcl"
 
 "$TCLSH" "$cmd" "$1" "$2" "$3" "$4" "$5" "$6" < /dev/null > /dev/null

--- a/src/scripts/chksystempkgs.sh
+++ b/src/scripts/chksystempkgs.sh
@@ -1,5 +1,4 @@
-#! /bin/sh
-# 'chksystempkgs.sh 2008-2009 '
+#! /bin/bash
 # 
 #
 # Copyright (C) 2015  University of Oregon
@@ -10,73 +9,79 @@
 # For more information, see the LICENSE file.
 # 
 #
-#set -x
-# check for the packages required for installation of VnmrJ on RHEL 5.X
+# set -x
+# check for the packages required for installation of OpenVnmrJ
 status=0
 
 #
-# rpm (RedHat) vs dpkg (Debian)
+# rpm (RedHat and CentOS) vs dpkg (Debian)
 #
 if [ ! -x /usr/bin/dpkg ]; then
-   packagecommonlist='make gcc gcc-c++ gdb libtool binutils automake strace autoconf glibc-devel expect rsh-server xinetd tftp-server kernel-headers kernel-devel libidn compat-libf2c-34 compat-gcc-34-g77 libXp libXmu openmotif22 tk tcl mutt sendmail-cf gnome-power-manager k3b ghostscript ImageMagick'
-
-   # for RHEL 5.X  separate since these are no longer on the 6.x Installation DVD.
-   package5xlist='sharutils rarpd hwbrowser'
-
-   # for RHEL 6.X must list 32-bit packages, since these are no longer installed along with the 64-bit versions
-   package61list='rsh libXau.i686 libX11.i686 libXext-devel.i686 libXtst-devel.i686 libXi.i686 libstdc++.i686 libstdc++-devel.i686 glibc.i686 glibc-devel.i686 libXt.i686 libXt-devel.i686 ncurses-libs.i686 ncurses-devel.i686 openmotif.i686 openmotif-devel.i686 mesa-libGL-devel mesa-libGL-devel.i686 tcl.i686 tcl-devel.i686 tk.i686 tk-devel.i686 libtiff.i686 libtiff-devel.i686 atk.i686 gtk2.i686 mesa-libGL mesa-libGL.i686 mesa-libGLU mesa-libGLU.i686 libidn.i686 libxml2.i686 expat.i686 libXaw.i686 libXpm.i686'
-
-   if [ "$(cat /etc/issue | grep 'release 6' > /dev/null;echo $?)" == "0" ]; then
-      # this list excludes sharutils and hwbrowser, sharutils will be installed from our DVD, RHEL 6.1 appears not to have hwbrowser
-      packagelist="$packagecommonlist $package61list"
+   if [ -f /etc/centos-release ]; then
+      rel=centos-release
    else
-      # add sharutils separately for RHEL 5.x , sharutils is not on the DVD like 5.X
-      # add hwbrowser separately for RHEL 5.x , hwbrowser appears to be unavailable for RHEL 6.1
-      # add rarpd     separately for RHEL 5.x , hwbrowser appears to be unavailable for RHEL 6.1
+      rel=redhat-release
+   fi
+   version=$(rpm -q $rel | cut -d'-' -f3)
+   packagecommonlist='make gcc gcc-c++ gdb libtool binutils automake strace autoconf glibc-devel expect rsh-server xinetd tftp-server kernel-headers kernel-devel libidn libXp libXmu mutt sendmail-cf k3b ghostscript ImageMagick'
+   if [ $version -eq 7 ]
+   then
+#     for RHEL 7.X must list 32-bit packages, since these are no longer installed with the 64-bit versions
+      package71list='libgfortran motif'
+      package32Bitlist='rsh libXau.i686 libX11.i686 libXext-devel.i686 libXtst-devel.i686 libXi.i686 libstdc++.i686 libstdc++-devel.i686 glibc.i686 glibc-devel.i686 libXt.i686 libXt-devel.i686 ncurses-libs.i686 ncurses-devel.i686 motif.i686 motif-devel.i686 mesa-libGL-devel mesa-libGL-devel.i686 atk.i686 gtk2.i686 mesa-libGL mesa-libGL.i686 mesa-libGLU mesa-libGLU.i686 libidn.i686 libxml2.i686 expat.i686 libXaw.i686 libXpm.i686'
+      packagelist="$packagecommonlist $package71list $package32Bitlist"
+   elif [ $version -eq 6 ]
+   then
+#     for RHEL 6.X must list 32-bit packages, since these are no longer installed with the 64-bit versions
+      package61list='libgfortran openmotif22 gnome-power-manager'
+      package32Bitlist='rsh libXau.i686 libX11.i686 libXext-devel.i686 libXtst-devel.i686 libXi.i686 libstdc++.i686 libstdc++-devel.i686 glibc.i686 glibc-devel.i686 libXt.i686 libXt-devel.i686 ncurses-libs.i686 ncurses-devel.i686 openmotif.i686 openmotif-devel.i686 mesa-libGL-devel mesa-libGL-devel.i686 atk.i686 gtk2.i686 mesa-libGL mesa-libGL.i686 mesa-libGLU mesa-libGLU.i686 libidn.i686 libxml2.i686 expat.i686 libXaw.i686 libXpm.i686'
+      packagelist="$packagecommonlist $package61list $package32Bitlist"
+   else
+      packagecommonlist='compat-libf2c-34 compat-gcc-34-g77 openmotif22 gnome-power-manager'
+   # for RHEL 5.X  separate since these are no longer on the 6.x Installation DVD.
+      package5xlist='sharutils rarpd hwbrowser'
       packagelist="$packagecommonlist $package5xlist";
    fi
 
 else
    # In Ubuntu 11 & 12 the ia32-sun-java6-bin package has been dropped from the repositories due to licensing issues with Oracle
    #   12.04
-   distrover=`lsb_release -rs`
+   distrover=$(lsb_release -rs)
    #   12
-   distmajor=`expr substr $distrover 1 2`
+   distmajor=${distrover:0:2}
+   packagecommonlist='csh make gcc expect ethtool rarpd rsh-server tftpd openssh-server mutt sharutils sendmail-cf gnome-power-manager k3b kdiff3 ghostscript imagemagick'
    if [ $distmajor -ge 16 ] ; then
-     packagelist='openjdk-8-jre bc csh libmotif-dev make gcc expect ethtool tcl8.4-dev tk8.4-dev rarpd rsh-server tftpd openssh-server mutt sharutils sendmail-cf gnome-power-manager k3b kdiff3 ghostscript imagemagick'
+     packageXlist='openjdk-8-jre bc libmotif-dev'
    elif [ $distmajor -ge 14 ] ; then
-     packagelist='openjdk-6-jre csh libmotif-dev make gcc expect ethtool tcl8.4-dev tk8.4-dev rarpd rsh-server tftpd openssh-server mutt sharutils sendmail-cf gnome-power-manager k3b kdiff3 ghostscript imagemagick'
+     packageXlist='openjdk-6-jre libmotif-dev'
    elif [ $distmajor -gt 10 ] ; then
-     packagelist='openjdk-6-jre ia32-libs csh lesstif2-dev make gcc expect ethtool tcl8.4-dev tk8.4-dev rarpd rsh-server tftpd openssh-server mutt sharutils sendmail-cf gnome-power-manager k3b kdiff3 ghostscript imagemagick'
+     packageXlist='openjdk-6-jre ia32-libs lesstif2-dev'
    else
-     packagelist='ia32-sun-java6-bin ia32-libs csh lesstif2-dev make gcc expect ethtool tcl8.4-dev tk8.4-dev rarpd rsh-server tftpd openssh-server mutt sharutils sendmail-cf gnome-power-manager k3b kdiff3 ghostscript imagemagick'
+     packageXlist='ia32-sun-java6-bin ia32-libs lesstif2-dev'
    fi
+   packagelist="$packagecommonlist $packageXlist";
 fi
-# Note: Ubuntu libg2c is nolonger used, must recompile code with gfortran and use libgfortran3  (DOSY dependency)
-#       The package is available from HARDY repo  Updates: libg2c0 libg2c0-dev ;  
-#       http://packages.ubuntu.com/search?searchon=contents&keywords=libg2c&mode=filename&suite=hardy-updates&arch=any
 #       libidn is contained within the ia32-libs
 
-for xpack in $packagelist
-do
-   if [ ! -x /usr/bin/dpkg ]; then
+if [ ! -x /usr/bin/dpkg ]; then
+   for xpack in $packagelist
+   do
       # not installed then install dkms package rpm
-      if [ "$(rpm -q $xpack | grep 'not installed' > /dev/null;echo $?)" == "0" ]
+      if [ "$(rpm -q $xpack | grep 'not installed' > /dev/null;echo $?)" = "0" ]
       then
-        echo "VnmrJ required RHEL package \"$xpack\" NOT installed"
+        echo "OpenVnmrJ required RHEL / CentOS package \"$xpack\" not installed"
         status=1 
-      ##else
-      ##  echo "VnmrJ required RHEL package \"$xpack\" installed"
       fi
+   done
 
-   else
+else
+   for xpack in $packagelist
+   do
       if [ "$(dpkg --get-selections $xpack 2>&1 | grep 'install' > /dev/null;echo $?)" != "0" ] 
       then
-          echo "VnmrJ required Ubuntu package \"$xpack\" NOT installed"
+          echo "OpenVnmrJ required Ubuntu package \"$xpack\" not installed"
           status=1
-      ##else
-      ##   echo "VnmrJ required Ubuntu package \"$xpack\" installed"
       fi
-   fi
-done
+   done
+fi
 exit $status

--- a/src/tcl/SConstruct.vnmrwish
+++ b/src/tcl/SConstruct.vnmrwish
@@ -2,9 +2,18 @@
 
 import os
 import shutil
+import sys
+
+# can be called from any other SConstruct file
+cwd = os.getcwd()
 
 ovjtools=os.getenv('OVJ_TOOLS')
 if not ovjtools:
+# If not defined, try the default location
+    print "OVJ_TOOLS env not found. Trying default location."
+    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
+
+if not os.path.exists(ovjtools):
     print "OVJ_TOOLS env not found."
     print "For bash and variants, use export OVJ_TOOLS=<path>"
     print "For csh and variants,  use setenv OVJ_TOOLS <path>"
@@ -12,10 +21,6 @@ if not ovjtools:
 
 # define target file names
 vnmrwishTarget = 'vnmrwish'
-
-# we need to specify an absolute path so this SConstruct file
-# can be called from any other SConstruct file
-cwd = os.getcwd()
 
 # library dependancies
 ncommPath = os.path.join(cwd, os.pardir, 'ncomm')
@@ -58,23 +63,43 @@ env.AddPostAction(vnmrwish,
 #
 #                 Action('ln -sf vnmrwish vnmrWish', chdir=installPath ))
 #
+libInstallPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'lib')
+if not os.path.exists(libInstallPath):
+   os.makedirs(libInstallPath)
+
+env.AddPostAction(vnmrwish,
+                  Action(Copy(libInstallPath, os.path.join(ovjtools, 'tcl','srcBlt','libBLT24.so.8.4'))))
+env.AddPostAction(vnmrwish,
+                  Action('ln -sf libBLT24.so.8.4 libBLT.so', chdir=libInstallPath ))
+env.AddPostAction(vnmrwish,
+                  Action(Copy(libInstallPath, os.path.join(ovjtools, 'tcl','srcTcl','libtcl8.4.so'))))
+env.AddPostAction(vnmrwish,
+                  Action(Copy(libInstallPath, os.path.join(ovjtools, 'tcl','srcTk','libtk8.4.so'))))
 
 tklibPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'tcl', 'tklibrary','vnmr')
 # make sure the path(s) exist
 if not os.path.exists(tklibPath):
    os.makedirs(tklibPath)
 tklibList =  [ 'Right',
-               'Left' ]
+               'Left',
+               'deck.tk',
+               'menu2.tk',
+             ]
 for i in tklibList:
    srcfile = os.path.join(cwd,i)
    dstfile =  os.path.join(tklibPath,i)
    shutil.copyfile(srcfile,dstfile)
 
-#the build wound attempt to make symlink even if target 'vnmrwish' wasn't created and thus copied
-#to the install directory, causing the link to fail..
-#tclSymLinkBld = Builder(action = 'cd ' + installPath + ' && ' + \
-#				'ln -f $SOURCE.file $TARGET.file')
-#env.Append(BUILDERS = {'SymLink' : tclSymLinkBld} )
+tcltkPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'tcl')
+Execute('unzip -d '+tcltkPath+ ' -oq '+ os.path.join(ovjtools, 'tcl','tcltk.zip'))
 
-#tclDerived = []
-#tclDerived.append(env.SymLink(target = 'vnmrWish', source = 'vnmrwish' ))
+binPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'bin')
+
+# make sure the path(s) exist
+if not os.path.exists(binPath):
+   os.makedirs(binPath)
+
+srcfile=os.path.join(ovjtools, 'tcl','tclsh')
+dstfile=os.path.join(binPath, 'tclsh')
+shutil.copyfile(srcfile,dstfile)
+os.system('chmod 755 ' + dstfile)

--- a/src/tcl/at.tcl
+++ b/src/tcl/at.tcl
@@ -72,16 +72,8 @@ set PREV_SET_FILE        $AT_DIR/atdb/at_prev_setting
 set REPORT_FILE          $AT_DIR/atrecord_report
 set NMR_INIT_FILE        $env(vnmruser)/maclib/ATinit
 
-if { ($osType == "Linux") } {
-   set bitmapdir $env(vnmrsystem)/tcl/tklibrary/vnmr
-   option readfile $env(vnmrsystem)/app-defaults/Enter
-} elseif { ($osType == "Interix") } {
-   set bitmapdir $env(SFUDIR)usr/X11R6/include/X11/bitmaps
-   option readfile ../../app-defaults/Enter
-} else {
-   set bitmapdir /usr/openwin/share/include/X11/bitmaps
-   option readfile $env(vnmrsystem)/app-defaults/Enter
-}
+set bitmapdir $env(vnmrsystem)/tcl/tklibrary/vnmr
+catch { option readfile $env(vnmrsystem)/app-defaults/Enter }
 
 option add *Graph.x.title             "Number of Trials"
 #option add *Graph.x.MajorTicks        "1 2 3 4 5 6 7 8 9"


### PR DESCRIPTION
Removed the need to install an old version of tcl/tk (8.4)
Everything is now local to /vnmr. The tcl/tk autotest command was
not working. This is fixed. This PR requires the PR #35 for ovjTools
Also cleaned up the checks for installed packages and updated the
OpenVnmrJ installation script.