### PR TITLE
scons options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # for projects that use SCons for building: http://http://www.scons.org/
 .sconsign.dblite
+config.py

--- a/SConstruct
+++ b/SConstruct
@@ -1,28 +1,11 @@
 #
-
-import os
-import sys
-import string
-import subprocess
-
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
-
-if not os.path.exists(ovjtools):
-    print "OVJ_TOOLS path "+ovjtools+" not found."
-    sys.exit(1)
-
-# os.environ['OPENVNMRJ']="true"
-# os.environ['OPENVNMRJ_GSL']="false"
-# os.environ['OPENVNMRJ_GSL']="true"
-
-platform = sys.platform        # sys.platform -> 'linux2' linux, 'interix6' win7 SUA
-print "Platform: ", platform
-
+# Copyright (C) 2015  University of Oregon
+#
+# You may distribute under the terms of either the GNU General Public
+# License or the Apache License, as specified in the LICENSE file.
+#
+# For more information, see the LICENSE file.
+#
 
 #
 # top level build file
@@ -44,6 +27,31 @@ print "Platform: ", platform
 # be running and SMP kernel to take advantage of multi-
 # core CPUs.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+import os
+import sys
+import string
+import subprocess
+
+execfile(os.path.join('scripts', 'buildoptions.py'))
+
+ovjtools=os.getenv('OVJ_TOOLS')
+if not ovjtools:
+    print "OVJ_TOOLS env not found."
+    print "For bash and variants, use export OVJ_TOOLS=<path>"
+    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
+    sys.exit(1)
+
+if not os.path.exists(ovjtools):
+    print "OVJ_TOOLS path "+ovjtools+" not found."
+    sys.exit(1)
+
+# os.environ['OPENVNMRJ']="true"
+# os.environ['OPENVNMRJ_GSL']="false"
+# os.environ['OPENVNMRJ_GSL']="true"
+
+platform = sys.platform        # sys.platform -> 'linux2' linux, 'interix6' win7 SUA
+print "Platform: ", platform
 
 SetOption('warn', ['no-duplicate-environment'] + GetOption('warn'))
 
@@ -235,7 +243,7 @@ else:
 
 vnmrPath    = os.path.join(cwd, os.pardir,'vnmr')
 
-if ( 'darwin' not in platform):
+if 'darwin' not in platform:
    for i in acqBuildList:
       SConscript(os.path.join('src',i, 'SConstruct'))
 

--- a/scripts/bo.py
+++ b/scripts/bo.py
@@ -34,9 +34,6 @@ if 'optinc_once' not in globals():
     cmdline = Variables(os.path.join(bodir, os.path.pardir, 'custom.py'))
 
     # command line variables
-    cmdline.Add(EnumVariable('COLOR', 'Set background color', 'red',
-                             allowed_values=('red', 'green', 'blue'),
-                             map={'navy':'blue'}))
     cmdline.AddVariables(
         BoolVariable('RELEASE', 'Set to build for release', False),
         BoolVariable('apt_0', '', False),
@@ -51,6 +48,7 @@ if 'optinc_once' not in globals():
         BoolVariable('DIFFUS', '', False),
         BoolVariable('FDM', '', False),
         BoolVariable('FIDDLE', '', False),
+        BoolVariable('gsl', 'enable gsl-dependent features', True),
         BoolVariable('GMAP', '', False),
         BoolVariable('Gxyz', '', False),
         BoolVariable('IMAGE', '', False),
@@ -74,6 +72,7 @@ if 'optinc_once' not in globals():
         BoolVariable('stars', '', False),
         BoolVariable('VAST', '', False),
         BoolVariable('vnmrj_O', '', False),
+        BoolVariable('progress', 'display progress info while building', False),
         PathVariable('prefix', 'install prefix (OVJ_BUILDDIR)',
                      os.path.abspath(os.path.join(bodir, os.pardir, os.pardir)),
                      PathVariable.PathIsDir),
@@ -89,26 +88,39 @@ if 'optinc_once' not in globals():
     env = Environment(variables = cmdline)
     Help(cmdline.GenerateHelpText(env))
 
-    # bo.prefix
+    #
+    # bo.prefix - installation prefix, where to build the dvd image
+    #
     global prefix
-    prefix=env['prefix']
+    prefix = env['prefix']
 
     #
     # get and check the OVJ_TOOLS directory
     #
     global OVJ_TOOLS
-    OVJ_TOOLS = env['OVJ_TOOLS']
-    if not OVJ_TOOLS:
+    if 'OVJ_TOOLS' not in env:
         # If not defined, try the default location
-        print "OVJ_TOOLS env not found. Trying default location."
-        OVJ_TOOLS = os.path.abspath(os.path.join(bodir, os.pardir, os.pardir, 'ojvTools'))
+        print "OVJ_TOOLS env not found. Trying default location..."
+        env['OVJ_TOOLS'] = os.path.abspath(os.path.join(bodir, os.pardir, os.pardir, 'ovjTools'))
 
+    OVJ_TOOLS = env['OVJ_TOOLS']
     if not os.path.exists(OVJ_TOOLS):
-        print "OVJ_TOOLS env not found."
+        print "OVJ_TOOLS env not found:",OVJ_TOOLS
         print "For bash and variants, use export OVJ_TOOLS=<path>"
         print "For csh and variants,  use setenv OVJ_TOOLS <path>"
         print "or when running scons: scons OVJ_TOOLS=<path>"
         sys.exit(1)
 
+    #
+    # Setup scons progress indication
+    #
+    if env['progress']:
+        #Progress(['-\r', '\\\r', '|\r', '/\r'], interval=1) # spinny cursor
+        Progress('Evaluating $TARGET\n')
+
+    #
+    # TODO: javaPath, javaBin, jarBin, ...
+    #
+    
     # I'm not sure if this is needed
     optinc_once = True

--- a/scripts/bo.py
+++ b/scripts/bo.py
@@ -33,6 +33,14 @@ if 'optinc_once' not in globals():
     # load the customization file
     cmdline = Variables(os.path.join(bodir, os.path.pardir, 'custom.py'))
 
+    # check if libgsl is available (should maybe check for header files instead)
+    if (os.path.exists(os.path.join('/usr','lib','libgsl.so')) or
+        os.path.exists(os.path.join('/usr','lib64','libgsl.so')) or
+        os.path.exists(os.path.join('/usr','lib','libgsl.a')) ):
+        gsl_default = True
+    else:
+        gsl_default = False
+
     # command line variables
     cmdline.AddVariables(
         BoolVariable('RELEASE', 'Set to build for release', False),
@@ -48,7 +56,7 @@ if 'optinc_once' not in globals():
         BoolVariable('DIFFUS', '', False),
         BoolVariable('FDM', '', False),
         BoolVariable('FIDDLE', '', False),
-        BoolVariable('gsl', 'enable gsl-dependent features', True),
+        BoolVariable('gsl', 'enable gsl-dependent features', gsl_default),
         BoolVariable('GMAP', '', False),
         BoolVariable('Gxyz', '', False),
         BoolVariable('IMAGE', '', False),

--- a/scripts/bo.py
+++ b/scripts/bo.py
@@ -1,0 +1,79 @@
+#
+# Copyright (C) 2016  Michael Tesch
+#
+# This file is a part of the OpenVnmrJ project.  You may distribute it
+# under the terms of either the GNU General Public License or the
+# Apache 2.0 License, as specified in the LICENSE file.
+#
+# For more information, see the OpenVnmrJ LICENSE file.
+#
+
+import sys, os
+from SCons.Variables import *
+from SCons.Environment import *
+from SCons.Script import *
+
+# bo module
+if 'optinc_once' not in globals():
+    print("******************** ONCE ***********************")
+
+    # the directory of bo.py
+    bodir = os.path.dirname(__file__)
+
+    # load the customization file
+    cmdline = Variables(os.path.join(bodir, os.path.pardir, 'custom.py'))
+
+    # command line variables
+    cmdline.Add(EnumVariable('COLOR', 'Set background color', 'red',
+                             allowed_values=('red', 'green', 'blue'),
+                             map={'navy':'blue'}))
+    cmdline.AddVariables(
+        BoolVariable('RELEASE', 'Set to build for release', False),
+        BoolVariable('apt_0', '', False),
+        BoolVariable('AS768', '', False),
+        BoolVariable('BACKPROJ', '', True),
+        BoolVariable('BIR', '', False),
+        BoolVariable('CHEMPACK', '', False),
+        BoolVariable('cryomon_O', '', False),
+        BoolVariable('CSI', '', False),
+        BoolVariable('dasho', '', False),
+        BoolVariable('DOSY', '', False),
+        BoolVariable('DIFFUS', '', False),
+        BoolVariable('FDM', '', False),
+        BoolVariable('FIDDLE', '', False),
+        BoolVariable('GMAP', '', False),
+        BoolVariable('Gxyz', '', False),
+        BoolVariable('IMAGE', '', False),
+        BoolVariable('INOVA', '', False),
+        BoolVariable('jaccount_O', '', False),
+        BoolVariable('JCP', '', False),
+        BoolVariable('JMOL', '', False),
+        BoolVariable('LC', '', False),
+        BoolVariable('managedb_O', '', False),
+        BoolVariable('MR400FH', '', False),
+        ('NDDS_VERSION', 'ndds version', '4.2e'),
+        ('NDDS_LIB_VERSION', 'ndds library version', 'i86Linux2.6gcc3.4.3'),
+        BoolVariable('P11', '', False),
+        BoolVariable('PATENT', '', False),
+        BoolVariable('PFG', '', False),
+        BoolVariable('PROTUNE', '', False),
+        BoolVariable('protune_0', '', False),
+        BoolVariable('probeid_0', '', False),
+        BoolVariable('SENSE', '', False),
+        BoolVariable('SOLIDS', '', True),
+        BoolVariable('stars', '', False),
+        BoolVariable('VAST', '', False),
+        BoolVariable('vnmrj_O', '', False),
+        PathVariable('prefix', 'install prefix', os.path.abspath(os.path.join(bodir, os.pardir)), False),
+    )
+
+    #
+    # this will be exported to users of 'import bo' as bo.env / boEnv
+    #
+    global env
+    env = Environment(variables = cmdline)
+    Help(cmdline.GenerateHelpText(env))
+    optinc_once = True
+
+    global PREFIX
+    PREFIX=env['prefix']

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -251,11 +251,10 @@ do_package () {
     # copy and run the packing script
     log_cmd mkdir -p "${OVJ_BUILDDIR}/bin/"
     log_cmd cd "${OVJ_BUILDDIR}/bin/"
-    #log_cmd make ${PACK_SCRIPT} # what does this do?
 
     # export vars used by the ovj???out.sh ($PACK_SCRIPT) scripts
     export workspacedir dvdBuildName1 dvdBuildName2 ovjAppName OVJ_TOOLS
-    cmdspin "${PACK_SCRIPT_SRC}/${PACK_SCRIPT}" || return $?
+    cmdspin "${PACK_SCRIPT_SRC}" || return $?
 
     # make a second copy? make an iso? todo...
     #dvdCopyName1=OVJ_$shortDate

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -39,6 +39,7 @@ numcpus() {
 : ${OVJ_DO_CHECKOUT=no}
 : ${OVJ_DO_BUILD=no}
 : ${OVJ_DO_PACKAGE=no}
+: ${OVJ_CODESIGN="3rd Party Mac Developer Application:"}
 : ${OVJ_BUILDDIR=${ovjBuildDir}}
 : ${OVJ_DEVELOPER=OpenVnmrJ}
 : ${OVJ_GITBRANCH=master}
@@ -77,6 +78,7 @@ where [options...] are:
   --ddr yes|no              - enable Direct-Drive (VnmrS/DD2/ProPulse) DVD build
                               [${OVJ_PACK_DDR}]
   --inova yes|no            - enable Mercury/Inova DVD build [${OVJ_PACK_MINOVA}]
+  --codesign id|none        - set code signing identity [${OVJ_CODESIGN}]
   -v|--verbose              - be more verbose (can add multiple times)
   -q|--quiet                - be more quiet   (can add multiple times)
   -h|--help                 - print this message and exit
@@ -107,6 +109,7 @@ while [ $# -gt 0 ]; do
         -s)                     OVJ_SCONSFLAGS="$2"; shift    ;;
         --ddr)                  OVJ_PACK_DDR="$2"; shift      ;;
         --inova)                OVJ_PACK_MINOVA="$2"; shift   ;;
+        --codesign)             OVJ_CODESIGN="$2"; shift      ;;
         -h|--help)              usage                         ;;
         -v|--verbose)           VERBOSE=$(( VERBOSE + 1 )) ;;
         -q|--quiet)             VERBOSE=$(( VERBOSE - 1 )) ;;
@@ -248,12 +251,11 @@ do_package () {
     # copy and run the packing script
     log_cmd mkdir -p "${OVJ_BUILDDIR}/bin/"
     log_cmd cd "${OVJ_BUILDDIR}/bin/"
-    log_cmd cp "${PACK_SCRIPT_SRC}" ./
     #log_cmd make ${PACK_SCRIPT} # what does this do?
 
     # export vars used by the ovj???out.sh ($PACK_SCRIPT) scripts
     export workspacedir dvdBuildName1 dvdBuildName2 ovjAppName OVJ_TOOLS
-    cmdspin "./${PACK_SCRIPT}" || return $?
+    cmdspin "${PACK_SCRIPT_SRC}/${PACK_SCRIPT}" || return $?
 
     # make a second copy? make an iso? todo...
     #dvdCopyName1=OVJ_$shortDate

--- a/scripts/buildoptions.py
+++ b/scripts/buildoptions.py
@@ -1,5 +1,6 @@
 #
-# Copyright (C) 2016  Michael Tesch
+#
+# Copyright (C) 2015  University of Oregon
 #
 # This file is a part of the OpenVnmrJ project.  You may distribute it
 # under the terms of either the GNU General Public License or the
@@ -7,8 +8,22 @@
 #
 # For more information, see the OpenVnmrJ LICENSE file.
 #
-
-# execfile() on this file to import 'bo' into a SConstruct environment
+#
+# Frits Vosman
+#
+# do not change this file.
+#
+# execfile() on this file to import the 'bo' (build options) module
+# into the SConstruct environment, ie src/vnmrj/SConstruct does:
+#
+#  execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+#
+# this make bo and boEnv available.  It will also let you run scons
+# directly from the directory in question (in this example
+# ../src/vnmrj/) and still inherit the build configuration from the
+# command-line and/or the top-level 'config.py'.  See bo.py for more
+# info on build configuration.
+#
 
 from __future__ import print_function
 import os
@@ -16,12 +31,12 @@ import sys
 import inspect
 
 # directory of this file
-optdir = os.path.abspath(os.path.dirname(inspect.getfile(inspect.currentframe())))
+scriptsdir = os.path.abspath(os.path.dirname(inspect.getfile(inspect.currentframe())))
 
-if optdir not in sys.path:
+if scriptsdir not in sys.path:
     # if this file was execfile()'d from above, need to add our path before 'import bo'
     #print('xxxx:', os.getcwd())
-    sys.path.insert(0, optdir)
+    sys.path.insert(0, scriptsdir)
 
 import bo
 from bo import env as boEnv

--- a/scripts/buildoptions.py
+++ b/scripts/buildoptions.py
@@ -1,62 +1,27 @@
-# Frits Vosman
 #
-# do not change this file, instead copy it up one directory level to 
-# the git-repo directory, it is .gitignored there, so the defaults remain
+# Copyright (C) 2016  Michael Tesch
 #
-# if you want to keep the default, leave it here as is (no need to copy)
+# This file is a part of the OpenVnmrJ project.  You may distribute it
+# under the terms of either the GNU General Public License or the
+# Apache 2.0 License, as specified in the LICENSE file.
 #
-# 'include' file for SConstruct files
-#  Creates a boEnv (build-options Environment)
-#  if needed, inlcude with:
-#      # get options settings
-#      boFile=os.path.join(cwd,os.pardir,...,'buildoptions.py')
-#      if not os.path.exists(boFile):
-#         boFile=os.path.join(cwd,os.pardir,...,'scripts','buildoptions.py')
-#      execfile(boFile)
-#  adjust number of os.pardir for ....  as needed.
-#  Then use to test:
-#      if boEnv['dasho'] == 'y':
-#  etc
-#  Add more values as needed 
+# For more information, see the OpenVnmrJ LICENSE file.
 #
 
-opts = Options()
-boEnv = Environment(options = opts,
-                apt_0='n',
-                AS768='n',
-                BACKPROJ='y',
-                BIR='n',
-                CHEMPACK='n',
-                cryomon_O='n',
-                CSI='n',
-                dasho='n',
-                DOSY='n',
-                DIFFUS='n',
-                FDM='n',
-                FIDDLE='n',
-                GMAP='n',
-                Gxyz='n',
-                IMAGE='n',
-                INOVA='n',
-                jaccount_O='n',
-                JCP='n',
-                JMOL='n',
-                LC='n',
-                managedb_O='n',
-                MR400FH='n',
-                NDDS_VERSION='4.2e',
-                NDDS_LIB_VERSION='i86Linux2.6gcc3.4.3',
-                P11='n',
-                PATENT='n',
-                PFG='n',
-                PROTUNE='n',
-                protune_0='n',
-                probeid_0='n',
-                SENSE='n',
-                SOLIDS='Y',
-                stars='n',
-                VAST='n',
-                vnmrj_O='n',
-		)
+# execfile() on this file to import 'bo' into a SConstruct environment
 
+from __future__ import print_function
+import os
+import sys
+import inspect
 
+# directory of this file
+optdir = os.path.abspath(os.path.dirname(inspect.getfile(inspect.currentframe())))
+
+if optdir not in sys.path:
+    # if this file was execfile()'d from above, need to add our path before 'import bo'
+    #print('xxxx:', os.getcwd())
+    sys.path.insert(0, optdir)
+
+import bo
+from bo import env as boEnv

--- a/scripts/buildoptions.py
+++ b/scripts/buildoptions.py
@@ -1,5 +1,4 @@
 #
-#
 # Copyright (C) 2015  University of Oregon
 #
 # This file is a part of the OpenVnmrJ project.  You may distribute it
@@ -18,7 +17,7 @@
 #
 #  execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 #
-# this make bo and boEnv available.  It will also let you run scons
+# this makes bo and boEnv available.  It will also let you run scons
 # directly from the directory in question (in this example
 # ../src/vnmrj/) and still inherit the build configuration from the
 # command-line and/or the top-level 'config.py'.  See bo.py for more

--- a/scripts/createSha1ChkList.sh
+++ b/scripts/createSha1ChkList.sh
@@ -6,6 +6,19 @@
 # this line starts from the currecnt work directory
 # find . -type f -exec sha1sum {} > sha1chklist.txt \;
 
+set -e
+: ${prefix=../..}
+
+if [ ! -z "$1" ]; then
+   prefix=$1
+fi
+
+# make sure prefix is sensible
+if [ ! -d "$prefix/vnmr" ]; then
+    echo "$0 Invalid prefix, missing vnmr/: '$prefix'"
+    exit 1
+fi
+
 #
 # RHEl, Ubuntu sha1sum, INterix sha1  (note output is reversed name then sha1)
 #
@@ -14,7 +27,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
      SHA1SUM="/sbin/md5"
   else
      echo "No md5 application, exiting."
-     exit
+     exit 1
   fi
 elif [ -x /usr/bin/sha1sum ]; then
   SHA1SUM="sha1sum"
@@ -22,15 +35,14 @@ elif [ -x /bin/sha1 ]; then
   SHA1SUM="sha1"
 else
   echo "No sha1 application, exiting."
-  exit
+  exit 1
 fi
 
 # this one would go to the working vnmr directory and start there.
-if [ ! -d ../../vnmr/adm/sha1 ]
+if [ ! -d "${prefix}/vnmr/adm/sha1" ]
 then
-   mkdir -p ../../vnmr/adm/sha1
+   mkdir -p "${prefix}/vnmr/adm/sha1"
 fi
-cd ../../vnmr; 
 
 ## regular files 
 # find . -type f -exec sha1sum {} > sha1chklist.txt \;
@@ -46,12 +58,15 @@ cd ../../vnmr;
 #  find ../../vnmr  ! -regex '.*/help/html/.*'  -print > /workspace/greg/master/git-repo/scripts/tst.txt
 #   GMB
 # find . -follow \( -type f -o -type l \) ! -name ".git*" -exec sha1sum {} > adm/sha1/sha1chklist.txt \;
-find . -follow \( -type f -o -type l \) ! -name ".git*" -exec $SHA1SUM {} > adm/sha1/sha1chklist.txt \;
-cd ../options
-find standard -follow \( -type f -o -type l \)  ! -name ".git*" -exec $SHA1SUM {} > ../vnmr/adm/sha1/sha1chklistOptionsStd.txt \;
-find console -follow \( -type f -o -type l \)  ! -name ".git*" -exec $SHA1SUM {} > ../vnmr/adm/sha1/sha1chklistOptionsConsole.txt \;
-cd ../console
-find . -follow \( -type f -o -type l \) ! -name ".git*" -exec $SHA1SUM {} > ../vnmr/adm/sha1/sha1chklistConsole.txt \;
+cd "${prefix}/vnmr"
+find . -follow \( -type f -o -type l \) ! -name ".git*" -exec $SHA1SUM {} \; > adm/sha1/sha1chklist.txt
+cd "${prefix}/options"
+find standard -follow \( -type f -o -type l \)  ! -name ".git*" -exec $SHA1SUM {} \; > ../vnmr/adm/sha1/sha1chklistOptionsStd.txt
+find console -follow \( -type f -o -type l \)  ! -name ".git*" -exec $SHA1SUM {} \; > ../vnmr/adm/sha1/sha1chklistOptionsConsole.txt
+cd "${prefix}/console"
+find . -follow \( -type f -o -type l \) ! -name ".git*" -exec $SHA1SUM {} \; > ../vnmr/adm/sha1/sha1chklistConsole.txt
 
-cd ../vnmr
-$SHA1SUM ./adm/sha1/Build_Id.txt ./adm/sha1/sha1chklist.txt ./adm/sha1/sha1chklistOptionsStd.txt ./adm/sha1/sha1chklistOptionsConsole.txt ./adm/sha1/sha1chklistConsole.txt > adm/sha1/sha1chklistFiles.txt
+cd "${prefix}/vnmr"
+$SHA1SUM ./adm/sha1/Build_Id.txt ./adm/sha1/sha1chklist.txt \
+         ./adm/sha1/sha1chklistOptionsStd.txt ./adm/sha1/sha1chklistOptionsConsole.txt \
+         ./adm/sha1/sha1chklistConsole.txt > adm/sha1/sha1chklistFiles.txt

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -133,6 +133,7 @@ while [ $# -gt 0 ]; do
         -O)                     OVJ_INS_OPTS=()             ;;
         -c)                     OVJ_CONSOLE="$2"; shift      ;;
         -p)                     OVJ_PASSWD="$2"; shift      ;;
+        --nolink)               OVJ_SETVNMRLINK=no          ;;
         -f|--force)             FORCE=yes                   ;;
         -s)                     OVJ_SUPERCLEAN=yes          ;;
         -d)                     OVJ_SYSTEM=Datastation      ;;

--- a/src/admin/SConstruct
+++ b/src/admin/SConstruct
@@ -4,12 +4,12 @@ import os
 import sys
 import datetime
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# current working directory
+cwd = os.getcwd()
+
+# import build options 'bo'
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
 
 # obtain system platform
 platform = sys.platform
@@ -27,9 +27,6 @@ def Sua2WinPath(suaPath):
 
 # target
 VnmrAdminTarget = 'VnmrAdmin.jar'
-
-# current working directory
-cwd = os.getcwd()
 
 # paths
 classPath = cwd
@@ -93,12 +90,13 @@ jEnv.Java(JAVACFLAGS = '-J-mx128m',
 
 todaysDate = datetime.datetime.now().strftime("%B %e, %Y %T %Z")
 manifestFile = os.path.join(cwd, 'Manifest')
-f = open(manifestFile, 'w')
-f.write('Manifest-Version: 1.0 ')
-f.write(todaysDate)
-f.write('\n')
-f.write('Main-Class: LoadNmr\n')
-f.close()
+if not GetOption('no_exec'):
+    f = open(manifestFile, 'w')
+    f.write('Manifest-Version: 1.0 ')
+    f.write(todaysDate)
+    f.write('\n')
+    f.write('Main-Class: LoadNmr\n')
+    f.close()
 
 if ( 'interix' in platform):
   # cdCmd = 'cd ' + os.path.join(classesPath,os.pardir) +' ; '
@@ -120,7 +118,7 @@ else:
                           JARCHDIR = classesPath)
 
 # define with absolute path where built files will be copied
-installPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'options', 'code')
+installPath = os.path.join(bo.prefix, 'options', 'code')
 
 # make sure the path(s) exist
 if not os.path.exists(installPath):

--- a/src/apt/SConstruct
+++ b/src/apt/SConstruct
@@ -4,26 +4,21 @@ import os
 import shutil
 import datetime
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
-
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
-
-# target
-aptTarget = 'apt.jar'
-aptDashOTarget = 'apt.jar.dasho'
-aptProGuardTarget = 'apt.jar.pro'
 
 # current working directory
 cwd = os.getcwd()
 
 # get options environment
 execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+import buildMethods
+
+ovjtools = bo.OVJ_TOOLS
+
+# target
+aptTarget = 'apt.jar'
+aptDashOTarget = 'apt.jar.dasho'
+aptProGuardTarget = 'apt.jar.pro'
+
 
 # paths
 javaPath = os.path.join(ovjtools, 'java', 'bin')

--- a/src/apt/SConstruct
+++ b/src/apt/SConstruct
@@ -23,10 +23,7 @@ aptProGuardTarget = 'apt.jar.pro'
 cwd = os.getcwd()
 
 # get options environment
-boFile = os.path.join(cwd, os.pardir, os.pardir, 'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile = os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # paths
 javaPath = os.path.join(ovjtools, 'java', 'bin')

--- a/src/apt/SConstruct
+++ b/src/apt/SConstruct
@@ -173,11 +173,11 @@ if not os.path.exists(installPath):
 
 
 # actions to be performed after targets are built
-if boEnv['dasho']=='y' or boEnv['apt_0']=='y':
+if boEnv['dasho'] or boEnv['apt_0']:
    jEnv.AddPostAction(jarBuildObject,
                    Action(os.path.join(cwd,'AptProGuard.sh')))
 #                   Action(os.path.join(cwd,'AptDasho.sh')))
-if boEnv['apt_0']=='y':
+if boEnv['apt_0']:
    jEnv.AddPostAction(jarBuildObject,
                    Action(Copy(os.path.join(installPath,aptTarget),
                                os.path.join(cwd, aptProGuardTarget))))

--- a/src/apt_32_MMI/SConstruct
+++ b/src/apt_32_MMI/SConstruct
@@ -23,10 +23,7 @@ aptProGuardTarget = 'apt.jar.pro'
 cwd = os.getcwd()
 
 # get options environment
-boFile = os.path.join(cwd, os.pardir, os.pardir, 'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile = os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # paths
 javaPath = os.path.join(ovjtools, 'java', 'bin')

--- a/src/apt_32_MMI/SConstruct
+++ b/src/apt_32_MMI/SConstruct
@@ -4,26 +4,19 @@ import os
 import shutil
 import datetime
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
-
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
-
-# target
-aptTarget = 'apt.jar'
-aptDashOTarget = 'apt.jar.dasho'
-aptProGuardTarget = 'apt.jar.pro'
 
 # current working directory
 cwd = os.getcwd()
 
 # get options environment
 execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+import buildMethods
+ovjtools = bo.OVJ_TOOLS
+
+# target
+aptTarget = 'apt.jar'
+aptDashOTarget = 'apt.jar.dasho'
+aptProGuardTarget = 'apt.jar.pro'
 
 # paths
 javaPath = os.path.join(ovjtools, 'java', 'bin')
@@ -147,15 +140,16 @@ javaBuildObj = jEnv.Java(JAVACFLAGS = '-J-mx128m',
 todaysDate = datetime.datetime.now().strftime("%B %e, %Y %T %Z")
 shortDate = datetime.datetime.now().strftime("%Y-%m-%d %T")
 manifestFile = os.path.join(cwd,'Manifest')
-f = open(manifestFile,'w')
-f.write('Manifest-Version: 1.0 ')
-f.write(todaysDate)
-f.write('\n')
-f.write('Main-Class: vnmr.apt.ProbeTune\n')
-f.write('Implementation-Version: ')
-f.write(shortDate)
-f.write('\n')
-f.close()
+if not GetOption('no_exec'):
+    f = open(manifestFile,'w')
+    f.write('Manifest-Version: 1.0 ')
+    f.write(todaysDate)
+    f.write('\n')
+    f.write('Main-Class: vnmr.apt.ProbeTune\n')
+    f.write('Implementation-Version: ')
+    f.write(shortDate)
+    f.write('\n')
+    f.close()
 
 jarBuildObject = jEnv.Jar(JAR      = jarBin,
                           target   = aptTarget,
@@ -164,14 +158,12 @@ jarBuildObject = jEnv.Jar(JAR      = jarBin,
                           JARCHDIR = classesPath)
 
 # define with absolute path where built files will be copied
-installPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir,'console', 'inova', 'java')
-minstallPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir,'console', 'mercury', 'java')
+installPath = os.path.join(bo.prefix,'console', 'inova', 'java')
+minstallPath = os.path.join(bo.prefix,'console', 'mercury', 'java')
 
 # make sure the path(s) exist
-if not os.path.exists(installPath):
-   os.makedirs(installPath)
-if not os.path.exists(minstallPath):
-   os.makedirs(minstallPath)
+Execute(Mkdir(installPath))
+Execute(Mkdir(minstallPath))
 
 jEnv.AddPostAction(jarBuildObject,
                    Action(Copy(installPath, os.path.join(cwd, aptTarget))))

--- a/src/bin/SConstruct.killroboproc
+++ b/src/bin/SConstruct.killroboproc
@@ -38,7 +38,7 @@ if not os.path.exists(vnmrInstallPath):
 killEnv.AddPostAction(kill,
              Action(Copy(pass768ASPath, os.path.join(cwd, killTarget))))
 
-if boEnv['AS768'] == 'y' :
+if boEnv['AS768']:
    killEnv.AddPostAction(kill,
                 Action(Copy(vnmrInstallPath, os.path.join(cwd, killTarget))))
 

--- a/src/bin/SConstruct.killroboproc
+++ b/src/bin/SConstruct.killroboproc
@@ -9,10 +9,7 @@ cwd = os.getcwd()
 
 
 # get options settings
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # source files
 killFileList = ['killroboproc.c']

--- a/src/bin/SConstruct.lkstat
+++ b/src/bin/SConstruct.lkstat
@@ -128,10 +128,10 @@ buildMethods.symLinkNow(nvLockiCEnv, cwd, nddsPath, nddsIdlFileList)
 ## if 'nvlocki4x' in COMMAND_LINE_TARGETS:
 nvLockiCEnv.Append(CPPDEFINES = 'RTI_NDDS_4x')
 
-nvLockiCppEnv = nvLockiCEnv.Copy(CC         = 'g++',
-                                 CCFLAGS    = '-O -g -Wno-deprecated -m32',
-                                 CPPDEFINES = ['LINUX'],
-                                 LINKFLAGS  = '-O -m32 -g -Wl,-rpath,/vnmr/lib ')
+nvLockiCppEnv = nvLockiCEnv.Clone(CC         = 'g++',
+                                  CCFLAGS    = '-O -g -Wno-deprecated -m32',
+                                  CPPDEFINES = ['LINUX'],
+                                  LINKFLAGS  = '-O -m32 -g -Wl,-rpath,/vnmr/lib ')
 
 # define Builders
 # nddsBld = Builder(action = 'export NDDSHOME; NDDSHOME=' + nddsHome + '; ' + \

--- a/src/bin/SConstruct.lkstat
+++ b/src/bin/SConstruct.lkstat
@@ -20,10 +20,7 @@ javaPath = os.path.join(cwd, os.pardir, os.pardir,
 
 ## NDDS include/lib paths
 # get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 print 'lkstat  NDDS_VERSION ' + boEnv['NDDS_VERSION']
 

--- a/src/bin/SConstruct.nvlocki
+++ b/src/bin/SConstruct.nvlocki
@@ -2,31 +2,23 @@
 
 import os
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# we need to specify an absolute path so this SConstruct file
+# can be called from any other SConstruct file
+cwd = os.getcwd()
+
+# import build options 'bo'
+## NDDS include/lib paths
+# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
+import buildMethods
 
 #import variables  and environment from SConstruct
 Import("*")
 
 # targets
 nvLockiTarget = 'nvlocki'
-
-# we need to specify an absolute path so this SConstruct file
-# can be called from any other SConstruct file
-cwd = os.getcwd()
-
-javaPath = os.path.join(ovjtools, 'java', 'bin')
-
-## NDDS include/lib paths
-# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 print 'nvlocki NDDS_VERSION ' + boEnv['NDDS_VERSION']
 
@@ -123,10 +115,10 @@ nvLockiCEnv = Environment(CCFLAGS    = '-O2 -m32 -g ',
 ## if 'nvlocki4x' in COMMAND_LINE_TARGETS:
 nvLockiCEnv.Append(CPPDEFINES = 'RTI_NDDS_4x')
 
-nvLockiCppEnv = nvLockiCEnv.Copy(CC         = 'g++',
-                                 CCFLAGS    = '-O -g -Wno-deprecated -m32',
-                                 CPPDEFINES = ['LINUX'],
-                                 LINKFLAGS  = '-O -m32 -g -Wl,-rpath,/vnmr/lib ')
+nvLockiCppEnv = nvLockiCEnv.Clone(CC         = 'g++',
+                                  CCFLAGS    = '-O -g -Wno-deprecated -m32',
+                                  CPPDEFINES = ['LINUX'],
+                                  LINKFLAGS  = '-O -m32 -g -Wl,-rpath,/vnmr/lib ')
 
 # define Builders
 # nddsBld = Builder(action = 'export NDDSHOME; NDDSHOME=' + nddsHome + '; ' + \
@@ -162,7 +154,7 @@ nvlocki = nvLockiCppEnv.Program(target  = nvLockiTarget,
 
 
 # define with absolute path where built files will be copied
-ddrPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'console','ddr', 'bin')
+ddrPath = os.path.join(bo.prefix, 'console','ddr', 'bin')
 
 # make sure the path(s) exist
 if not os.path.exists(ddrPath):

--- a/src/bin/SConstruct.nvlocki
+++ b/src/bin/SConstruct.nvlocki
@@ -26,10 +26,7 @@ javaPath = os.path.join(ovjtools, 'java', 'bin')
 
 ## NDDS include/lib paths
 # get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 print 'nvlocki NDDS_VERSION ' + boEnv['NDDS_VERSION']
 

--- a/src/bin_image/SConstruct.fdf2avw
+++ b/src/bin_image/SConstruct.fdf2avw
@@ -3,19 +3,16 @@
 import os
 import sys
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
-
-# targets
-fdf2avwTarget = 'fdf2avw'
-
 # we need to specify an absolute path so this SConstruct file
 # can be called from any other SConstruct file
 cwd = os.getcwd()
+
+# import build options 'bo'
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
+
+# targets
+fdf2avwTarget = 'fdf2avw'
 
 gslLibPath = os.path.join(ovjtools, 'gsllibs')
 
@@ -39,7 +36,7 @@ fdf2avw = fdf2avwEnv.Program(target = fdf2avwTarget,
 				'm'])
 
 # define with absolute path where built files will be copied
-vnmrInstallPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'options', 'standard','IMAGE', 'bin')
+vnmrInstallPath = os.path.join(bo.prefix, 'options', 'standard','IMAGE', 'bin')
 
 # make sure the path(s) exist
 if not os.path.exists(vnmrInstallPath):

--- a/src/bin_image/SConstruct.fdf2nifti
+++ b/src/bin_image/SConstruct.fdf2nifti
@@ -3,19 +3,16 @@
 import os
 import sys
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
-
-# targets
-fdf2niftiTarget = 'fdf2nifti'
-
 # we need to specify an absolute path so this SConstruct file
 # can be called from any other SConstruct file
 cwd = os.getcwd()
+
+# import build options 'bo'
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
+
+# targets
+fdf2niftiTarget = 'fdf2nifti'
 
 gslLibPath = os.path.join(ovjtools, 'gsllibs')
 
@@ -39,7 +36,7 @@ fdf2nifti = fdf2niftiEnv.Program(target = fdf2niftiTarget,
 				'm'])
 
 # define with absolute path where built files will be copied
-vnmrInstallPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'options', 'standard', 'IMAGE', 'bin')
+vnmrInstallPath = os.path.join(bo.prefix, 'options', 'standard', 'IMAGE', 'bin')
 
 # make sure the path(s) exist
 if not os.path.exists(vnmrInstallPath):

--- a/src/biopack/SConstruct
+++ b/src/biopack/SConstruct
@@ -12,12 +12,7 @@ import myShutilsym
 cwd = os.getcwd() 
 
 # get options settings
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
-
-
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 biopackDirList = [ 'bin',
                    'BioPack.dir',

--- a/src/cgl/SConstruct
+++ b/src/cgl/SConstruct
@@ -1,19 +1,16 @@
 import os
 import sys
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
-
-# targets
-cglSharedTarget = 'libcgl.so'
-
 # we need to specify an absolute path so this SConstruct file
 # can be called from any other SConstruct file
 cwd = os.getcwd()
+
+# import build options 'bo'
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
+
+# targets
+cglSharedTarget = 'libcgl.so'
 
 # source files
 cglPath    = os.path.join(cwd, os.pardir, 'cgl')

--- a/src/cryo/SConstruct
+++ b/src/cryo/SConstruct
@@ -3,18 +3,15 @@
 import os
 import datetime
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# current working directory
+cwd = os.getcwd()
+
+# import build options 'bo'
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
 
 # target
 cryoTarget = 'cryo.jar'
-
-# current working directory
-cwd = os.getcwd()
 
 # paths
 classPath = cwd
@@ -48,12 +45,13 @@ jEnv.Java(JAVACFLAGS = '-J-mx128m',
 
 todaysDate = datetime.datetime.now().strftime("%B %e, %Y %T %Z")
 manifestFile = os.path.join(cwd, 'Manifest')
-f = open(manifestFile, 'w')
-f.write('Manifest-Version: 1.0 ')
-f.write(todaysDate)
-f.write('\n')
-f.write('Main-Class: ClientGui\n')
-f.close()
+if not GetOption('no_exec'):
+    f = open(manifestFile, 'w')
+    f.write('Manifest-Version: 1.0 ')
+    f.write(todaysDate)
+    f.write('\n')
+    f.write('Main-Class: ClientGui\n')
+    f.close()
 
 jarBuildObject = jEnv.Jar(JAR      = jarBin,
                           target   = cryoTarget,
@@ -62,7 +60,7 @@ jarBuildObject = jEnv.Jar(JAR      = jarBin,
                           JARCHDIR = classesPath)
 
 # define with absolute path where built files will be copied
-installPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'java')
+installPath = os.path.join(bo.prefix, 'vnmr', 'java')
 
 # make sure the path(s) exist
 if not os.path.exists(installPath):

--- a/src/cryomon/SConstruct
+++ b/src/cryomon/SConstruct
@@ -97,11 +97,11 @@ jEnv.AddPostAction(jarBuildObject,
                    Action(Copy(installPath, os.path.join(cwd, cryoTarget))))
 
 # actions to be performed after targets are built
-if boEnv['dasho']=='y' or boEnv['cryomon_O']=='y':
+if boEnv['dasho'] or boEnv['cryomon_O']:
    jEnv.AddPostAction(jarBuildObject,
                    Action(os.path.join(cwd,'CryomonProGuard.sh')))
 #                   Action(os.path.join(cwd,'CryomonDasho.sh')))
-if boEnv['cryomon_O']=='y':
+if boEnv['cryomon_O']:
    jEnv.AddPostAction(jarBuildObject,
                    Action(Copy(os.path.join(installPath,cryoTarget),
                                os.path.join(cwd, cryoProGuardTarget))))

--- a/src/cryomon/SConstruct
+++ b/src/cryomon/SConstruct
@@ -4,26 +4,19 @@ import os
 import shutil
 import datetime
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# current working directory
+cwd = os.getcwd()
+
+# import build options 'bo'
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
+import buildMethods
 
 # target
 cryoTarget = 'cryomon.jar'
 cryoDashOTarget = "cryomon.jar.dasho"
 cryoProGuardTarget = "cryomon.jar.pro"
-
-# current working directory
-cwd = os.getcwd()
-
-# get options environment
-execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # paths
 javaPath = os.path.join(ovjtools, 'java', 'bin')
@@ -76,12 +69,15 @@ javaBuildObj = jEnv.Java(JAVACFLAGS = '-J-mx128m',
 
 todaysDate = datetime.datetime.now().strftime("%B %e, %Y %T %Z")
 manifestFile = os.path.join(cwd,'Manifest')
-f = open(manifestFile,'w')
-f.write('Manifest-Version: 1.0 ')
-f.write(todaysDate)
-f.write('\n')
-f.write('Main-Class: Main\n')
-f.close()
+if not GetOption('no_exec'):
+    f = open(manifestFile,'w')
+    f.write('Manifest-Version: 1.0 ')
+    f.write(todaysDate)
+    f.write('\n')
+    f.write('Main-Class: Main\n')
+    f.close()
+else:
+    print 'would create:',manifestFile
 
 jarBuildObject = jEnv.Jar(JAR      = jarBin,
                           target   = cryoTarget,
@@ -90,7 +86,7 @@ jarBuildObject = jEnv.Jar(JAR      = jarBin,
                           JARCHDIR = classesPath)
 
 # define with absolute path where built files will be copied
-installPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'java')
+installPath = os.path.join(bo.prefix, 'vnmr', 'java')
 
 # make sure the path(s) exist
 if not os.path.exists(installPath):

--- a/src/cryomon/SConstruct
+++ b/src/cryomon/SConstruct
@@ -23,11 +23,7 @@ cryoProGuardTarget = "cryomon.jar.pro"
 cwd = os.getcwd()
 
 # get options environment
-boFile = os.path.join(cwd, os.pardir, os.pardir, 'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile = os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py')
-execfile(boFile)
-
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # paths
 javaPath = os.path.join(ovjtools, 'java', 'bin')

--- a/src/dicom_fdf/FdfToDcm/SConstruct
+++ b/src/dicom_fdf/FdfToDcm/SConstruct
@@ -6,19 +6,9 @@ import sys
 import glob
 
 cwd = os.getcwd()
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-#   Try default location
-    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, os.pardir, 'ovjTools')
-    if not os.path.exists(ovjtools):
-       print "OVJ_TOOLS env not found."
-       print "For bash and variants, use export OVJ_TOOLS=<path>"
-       print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-       sys.exit(1)
-
-
-sys.path.append(os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'scripts'))
+execfile(os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 import buildMethods
+ovjtools = bo.OVJ_TOOLS
 
 # MAC -> darwin, Linux -> linux2
 platform = sys.platform

--- a/src/jaccount/SConstruct
+++ b/src/jaccount/SConstruct
@@ -7,17 +7,8 @@ import shutil
 # current working directory
 cwd = os.getcwd()
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-# If not defined, try the default location
-    print "OVJ_TOOLS env not found. Trying default location."
-    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
-
-if not os.path.exists(ovjtools):
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
 
 # target
 accountTarget = 'account.jar'

--- a/src/jplot/SConstruct
+++ b/src/jplot/SConstruct
@@ -4,12 +4,12 @@ import os
 import sys
 import datetime
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# current working directory
+cwd = os.getcwd()
+
+# import build options 'bo'
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
 
 platform = sys.platform
 
@@ -26,11 +26,6 @@ def Sua2WinPath(suaPath):
 
 # target
 jplotTarget = 'jplot.jar'
-
-# current working directory
-cwd = os.getcwd()
-
-env = Environment()
 
 # paths
 if ( 'linux' in platform):

--- a/src/kpsglib/SConstruct.inova
+++ b/src/kpsglib/SConstruct.inova
@@ -9,12 +9,6 @@ Import("*")
 # can be called from any other SConstruct file
 cwd = os.getcwd()
 
-# get options settings
-# boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'buildoptions.py')
-# if not os.path.exists(boFile):
-#    boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'scripts','buildoptions.py')
-# execfile(boFile)
-
 # define target file names
 PsTargetList = glob.glob("*.c")
 PsTargetList.sort()

--- a/src/managedb/SConstruct
+++ b/src/managedb/SConstruct
@@ -4,23 +4,13 @@ import os
 import shutil
 import datetime
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
 
 # current working directory
 cwd = os.getcwd()
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-# If not defined, try the default location
-    print "OVJ_TOOLS env not found. Trying default location."
-    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
-
-if not os.path.exists(ovjtools):
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+import buildMethods
+ovjtools = bo.OVJ_TOOLS
 
 # MAC -> darwin, Linux -> linux2
 platform = sys.platform

--- a/src/nvexpproc/SConstruct
+++ b/src/nvexpproc/SConstruct
@@ -6,31 +6,23 @@
 #
 import os
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
 
 # we need to specify an absolute path so this SConstruct file
 # can be called from any other SConstruct file
 cwd = os.getcwd()
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-# If not defined, try the default location
-    print "OVJ_TOOLS env not found. Trying default location."
-    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
-
-if not os.path.exists(ovjtools):
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# import build options 'bo'
+## NDDS include/lib paths
+# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
+import buildMethods
 
 #import variables  and environment from SConstruct
 Import("*")
 
-## NDDS include/lib paths
-# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+javaPath = os.path.join(ovjtools, 'java', 'bin')
+
 
 # define target file names
 # expProcTarget = 'Expproc'

--- a/src/nvexpproc/SConstruct
+++ b/src/nvexpproc/SConstruct
@@ -30,10 +30,7 @@ Import("*")
 
 ## NDDS include/lib paths
 # get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # define target file names
 # expProcTarget = 'Expproc'

--- a/src/nvinfoproc/SConstruct
+++ b/src/nvinfoproc/SConstruct
@@ -2,15 +2,17 @@
 
 import os
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
+
+# we need to specify an absolute path so this SConstruct file
+# can be called from any other SConstruct file
+cwd = os.getcwd()
+
+## NDDS include/lib paths
+# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
 import buildMethods
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
 
 #import variables  and environment from SConstruct
 Import("*")
@@ -18,15 +20,7 @@ Import("*")
 # define target file names
 infoProcTarget = 'Infoproc'
 
-# we need to specify an absolute path so this SConstruct file
-# can be called from any other SConstruct file
-cwd = os.getcwd()
-
 javaPath = os.path.join(ovjtools, 'java', 'bin')
-
-## NDDS include/lib paths
-# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 print 'nvInfoproc NDDS_VERSION ' + boEnv['NDDS_VERSION']
 
@@ -179,7 +173,7 @@ infoproc = infoProcEnv.Program(target  = infoProcTarget,
                                LIBS    = [LibList])
 
 # define with absolute path where built files will be copied
-vnmrPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'console', 'ddr', 'acqbin')
+vnmrPath = os.path.join(bo.prefix, 'console', 'ddr', 'acqbin')
 
 # make sure the path(s) exist
 if not os.path.exists(vnmrPath):

--- a/src/nvinfoproc/SConstruct
+++ b/src/nvinfoproc/SConstruct
@@ -26,10 +26,7 @@ javaPath = os.path.join(ovjtools, 'java', 'bin')
 
 ## NDDS include/lib paths
 # get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 print 'nvInfoproc NDDS_VERSION ' + boEnv['NDDS_VERSION']
 

--- a/src/nvrecvproc/SConstruct
+++ b/src/nvrecvproc/SConstruct
@@ -2,15 +2,15 @@
 
 import os
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# we need to specify an absolute path so this SConstruct file
+# can be called from any other SConstruct file
+cwd = os.getcwd()
+
+# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+import buildMethods
+ovjtools = bo.OVJ_TOOLS
 
 #import variables  and environment from SConstruct
 Import("*")
@@ -18,14 +18,7 @@ Import("*")
 # define target file names
 nvRecvProcTarget = 'Recvproc'
 
-# we need to specify an absolute path so this SConstruct file
-# can be called from any other SConstruct file
-cwd = os.getcwd()
-
 javaPath = os.path.join(ovjtools, 'java', 'bin')
-
-# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 print 'nvRecvproc NDDS_VERSION ' + boEnv['NDDS_VERSION']
 

--- a/src/nvrecvproc/SConstruct
+++ b/src/nvrecvproc/SConstruct
@@ -25,10 +25,7 @@ cwd = os.getcwd()
 javaPath = os.path.join(ovjtools, 'java', 'bin')
 
 # get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 print 'nvRecvproc NDDS_VERSION ' + boEnv['NDDS_VERSION']
 

--- a/src/nvsendproc/SConstruct
+++ b/src/nvsendproc/SConstruct
@@ -25,13 +25,9 @@ cwd = os.getcwd()
 javaPath = os.path.join(ovjtools, 'java', 'bin')
 
 # get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 print 'nvSendproc NDDS_VERSION ' + boEnv['NDDS_VERSION']
-
 
 # binary paths
 #if 'Sendproc4x' in COMMAND_LINE_TARGETS:

--- a/src/nvsendproc/SConstruct
+++ b/src/nvsendproc/SConstruct
@@ -2,15 +2,16 @@
 
 import os
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# we need to specify an absolute path so this SConstruct file
+# can be called from any other SConstruct file
+cwd = os.getcwd()
+
+# import build options 'bo'
+# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
+import buildMethods
 
 #import variables  and environment from SConstruct
 Import("*")
@@ -18,14 +19,7 @@ Import("*")
 # define target file names
 nvSendProcTarget = 'Sendproc'
 
-# we need to specify an absolute path so this SConstruct file
-# can be called from any other SConstruct file
-cwd = os.getcwd()
-
 javaPath = os.path.join(ovjtools, 'java', 'bin')
-
-# get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
-execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 print 'nvSendproc NDDS_VERSION ' + boEnv['NDDS_VERSION']
 
@@ -201,7 +195,7 @@ nvsendproc = nvSendProcEnv.Program(target  = nvSendProcTarget,
                                    LIBS    = [ LibList ] )
 
 # define with absolute path where built files will be copied
-vnmrPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'console', 'ddr', 'acqbin')
+vnmrPath = os.path.join(bo.prefix, 'console', 'ddr', 'acqbin')
 
 # make sure the path(s) exist
 if not os.path.exists(vnmrPath):

--- a/src/passwd/SConstruct
+++ b/src/passwd/SConstruct
@@ -7,17 +7,9 @@ import datetime
 # current working directory
 cwd = os.getcwd()
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-# If not defined, try the default location
-    print "OVJ_TOOLS env not found. Trying default location."
-    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
-
-if not os.path.exists(ovjtools):
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# import build options 'bo'
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
 
 # obtain system platform
 platform = sys.platform
@@ -28,7 +20,7 @@ target = 'passwd.jar'
 # paths
 classPath = cwd
 
-env = Environment()
+#env = Environment()
 # platform = env['PLATFORM']
 
 if ( 'linux' in platform):

--- a/src/probeid/SConstruct
+++ b/src/probeid/SConstruct
@@ -23,10 +23,7 @@ probeidProGuardTarget = 'probeid.jar.pro'
 cwd = os.getcwd()
 
 # get options environment
-boFile = os.path.join(cwd, os.pardir, os.pardir, 'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile = os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # paths
 javaPath = os.path.join(ovjtools, 'java', 'bin')

--- a/src/probeid/SConstruct
+++ b/src/probeid/SConstruct
@@ -93,11 +93,11 @@ if not os.path.exists(probeidPath):
    os.makedirs(probeidPath)
 
 # actions to be performed after targets are built
-if boEnv['dasho']=='y' or boEnv['probeid_0']=='y':
+if boEnv['dasho'] or boEnv['probeid_0']:
    jEnv.AddPostAction(jarBuildObject,
                    Action(os.path.join(cwd,'ProbeIdProGuard.sh')))
 
-if boEnv['probeid_0']=='y':
+if boEnv['probeid_0']:
    jEnv.AddPostAction(jarBuildObject,
                    Action(Copy(os.path.join(installPath,probeidTarget),
                                os.path.join(cwd, probeidProGuardTarget))))

--- a/src/probeid/SConstruct
+++ b/src/probeid/SConstruct
@@ -4,26 +4,19 @@ import os
 import shutil
 import datetime
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# current working directory
+cwd = os.getcwd()
+
+# import build options 'bo'
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
+import buildMethods
 
 # target
 probeidTarget = 'probeid.jar'
 probeidDashOTarget = 'probeid.jar.dasho'
 probeidProGuardTarget = 'probeid.jar.pro'
-
-# current working directory
-cwd = os.getcwd()
-
-# get options environment
-execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # paths
 javaPath = os.path.join(ovjtools, 'java', 'bin')
@@ -73,15 +66,16 @@ javaBuildObj = jEnv.Java(JAVACFLAGS = '-J-mx128m -g',
 todaysDate = datetime.datetime.now().strftime("%B %e, %Y %T %Z")
 shortDate = datetime.datetime.now().strftime("%Y-%m-%d %T")
 manifestFile = os.path.join(cwd,'Manifest')
-f = open(manifestFile,'w')
-f.write('Manifest-Version: 1.0 ')
-f.write(todaysDate)
-f.write('\n')
-f.write('Main-Class: vnmr.probeid.ProbeIdIO\n')
-f.write('Implementation-Version: ')
-f.write(shortDate)
-f.write('\n')
-f.close()
+if not GetOption('no_exec'):
+    f = open(manifestFile,'w')
+    f.write('Manifest-Version: 1.0 ')
+    f.write(todaysDate)
+    f.write('\n')
+    f.write('Main-Class: vnmr.probeid.ProbeIdIO\n')
+    f.write('Implementation-Version: ')
+    f.write(shortDate)
+    f.write('\n')
+    f.close()
 
 jarBuildObject = jEnv.Jar(JAR      = jarBin,
                           target   = probeidTarget,
@@ -89,8 +83,8 @@ jarBuildObject = jEnv.Jar(JAR      = jarBin,
                           JARCHDIR = classesPath)
 
 # define with absolute path where built files will be copied
-installPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'java')
-probeidPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'probeid')
+installPath = os.path.join(bo.prefix, 'vnmr', 'java')
+probeidPath = os.path.join(bo.prefix, 'vnmr', 'probeid')
 
 # make sure the path(s) exist
 if not os.path.exists(installPath):

--- a/src/psglib/SConstruct
+++ b/src/psglib/SConstruct
@@ -12,20 +12,20 @@ cwd = os.getcwd()
 # library dependancies
 ncommPath = os.path.join(cwd, os.pardir, 'ncomm')
 #SConscript(os.path.join(ncommPath, 'SConstruct'))
-cmd='cd ../ncomm;scons'
+cmd='cd ../ncomm && scons'
 os.system(cmd)
 
 # dependancies
 binPath = os.path.join(cwd, os.pardir, 'bin')
 #SConscript(os.path.join(binPath, 'SConstruct'))
-cmd='cd ../bin;scons -f SConstruct.dps_ps_gen'
+cmd='cd ../bin && scons -f SConstruct.dps_ps_gen'
 os.system(cmd)
 
 psgPath = os.path.join(cwd, os.pardir, 'psg')
 
 nvpsgPath = os.path.join(cwd, os.pardir, 'nvpsg')
 #SConscript(os.path.join(nvpsgPath, 'SConstruct'))
-cmd='cd ../nvpsg;scons'
+cmd='cd ../nvpsg && scons'
 os.system(cmd)
 
 vnmrPath   = os.path.join(cwd, os.pardir, 'vnmr')

--- a/src/psglib/SConstruct.inova
+++ b/src/psglib/SConstruct.inova
@@ -11,12 +11,6 @@ Import("*")
 # can be called from any other SConstruct file
 cwd = os.getcwd()
 
-# get options settings
-# boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'buildoptions.py')
-# if not os.path.exists(boFile):
-#    boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'scripts','buildoptions.py')
-# execfile(boFile)
-
 # define target file names
 PsTargetList = glob.glob("*.c")
 PsTargetList.sort()

--- a/src/psglib/SConstruct.inova_bio
+++ b/src/psglib/SConstruct.inova_bio
@@ -11,12 +11,6 @@ Import("*")
 # can be called from any other SConstruct file
 cwd = os.getcwd()
 
-# get options settings
-# boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'buildoptions.py')
-# if not os.path.exists(boFile):
-#    boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'scripts','buildoptions.py')
-# execfile(boFile)
-
 # define target file names
 PsTargetList = glob.glob("*.c")
 PsTargetList.sort()

--- a/src/psglib/SConstruct.inova_bio
+++ b/src/psglib/SConstruct.inova_bio
@@ -23,7 +23,7 @@ Execute('rm -rf ' + psglibPath)
 os.makedirs(psglibPath)
 
 # actual builds
-bioseqLibEnv = seqLibEnv.Copy()
+bioseqLibEnv = seqLibEnv.Clone()
 bioseqLibEnv.Prepend(LIBS = os.path.join(cwd,os.pardir,os.pardir,'biopack','psg'))
 bld2 = Builder(action = os.path.join(cwd, os.pardir,os.pardir, 'bin', 'dps_ps_gen') + \
                        ' -DDPS -I$CPPPATH -I$LIBS $SOURCE  \" \" 2')

--- a/src/psglib/SConstruct.vnmrs
+++ b/src/psglib/SConstruct.vnmrs
@@ -11,12 +11,6 @@ Import("*")
 # can be called from any other SConstruct file
 cwd = os.getcwd()
 
-# get options settings
-# boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'buildoptions.py')
-# if not os.path.exists(boFile):
-#    boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'scripts','buildoptions.py')
-# execfile(boFile)
-
 # define target file names
 PsTargetList = glob.glob("*.c")
 PsTargetList.sort()

--- a/src/psglib/SConstruct.vnmrs_bio
+++ b/src/psglib/SConstruct.vnmrs_bio
@@ -11,12 +11,6 @@ Import("*")
 # can be called from any other SConstruct file
 cwd = os.getcwd()
 
-# get options settings
-# boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'buildoptions.py')
-# if not os.path.exists(boFile):
-#    boFile=os.path.join(cwd,os.pardir,os.pardir,os.pardir,'scripts','buildoptions.py')
-# execfile(boFile)
-
 # define target file names
 PsTargetList = glob.glob("*.c")
 PsTargetList.sort()

--- a/src/psglib/SConstruct.vnmrs_bio
+++ b/src/psglib/SConstruct.vnmrs_bio
@@ -23,7 +23,7 @@ Execute('rm -rf ' + psglibPath)
 os.makedirs(psglibPath)
 
 # actual builds
-bionvseqLibEnv = nvseqLibEnv.Copy()
+bionvseqLibEnv = nvseqLibEnv.Clone()
 bionvseqLibEnv.Prepend(LIBS = os.path.join(cwd,os.pardir,os.pardir,'biopack','psg'))
 bld2 = Builder(action = os.path.join(cwd, os.pardir,os.pardir, 'bin', 'dps_ps_gen') + \
                        ' -DDPS -DNVPSG -I$CPPPATH -I$LIBS $SOURCE  \" \" 2')

--- a/src/roboproc/SConstruct.roboproc
+++ b/src/roboproc/SConstruct.roboproc
@@ -2,19 +2,12 @@
 
 import os
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
-
-# we need to specify an absolute path so this SConstruct file
-# can be called from any other SConstruct file
 cwd = os.getcwd()
+# get options settings
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+import buildMethods
+ovjtools = bo.OVJ_TOOLS
 
 # library dependancies
 vnmrPath = os.path.join(cwd, os.pardir, 'vnmr')

--- a/src/scripts/SConstruct.768AS
+++ b/src/scripts/SConstruct.768AS
@@ -6,10 +6,7 @@ print 'SConstruct.768AS'
 cwd = os.getcwd()
 
 # get options settings
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # the file list fro this bunch
 fileList =     ['config_768AS',

--- a/src/scripts/SConstruct.768AS
+++ b/src/scripts/SConstruct.768AS
@@ -34,7 +34,7 @@ for i in fileList:
 
 print boEnv['AS768']
 # optionally copy it tp vnmr/bin
-if boEnv['AS768'] == 'y':
+if boEnv['AS768']:
    vnmrBinPath = os.path.join(cwd,os.pardir,os.pardir,os.pardir,'vnmr','bin')
    if not os.path.exists(vnmrBinPath) :
       os.makedirs(vnmrBinPath)

--- a/src/scripts/SConstruct.P11
+++ b/src/scripts/SConstruct.P11
@@ -36,9 +36,8 @@ for i in fileList:
    Execute(Copy(dest,i+'.sh'))
    Execute(Chmod(dest,0755))
 
-print boEnv['P11']
 # optionally copy it tp vnmr/bin
-if boEnv['P11'] == 'y':
+if boEnv['P11']:
    vnmrBinPath = os.path.join(cwd,os.pardir,os.pardir,os.pardir,'vnmr','bin')
    if not os.path.exists(vnmrBinPath) :
       os.makedirs(vnmrBinPath)

--- a/src/scripts/SConstruct.P11
+++ b/src/scripts/SConstruct.P11
@@ -4,10 +4,7 @@ import os
 cwd = os.getcwd()
 
 # get options settings
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # the file list fro this bunch
 fileList =     ['arAuditing',

--- a/src/scripts/ovjmacout.sh
+++ b/src/scripts/ovjmacout.sh
@@ -149,5 +149,13 @@ cp "${gitdir}/src/macos/sys_tmplt" profiles/system/.
 cp "${gitdir}/src/macos/user_tmplt" profiles/user/.
 
 #Following need a certificate issued by Apple to developer
-echo "Code signing requires a certificate issued by Apple. Check for any errors and fix for OS X El Capitan or macOS Sierra"
-codesign -s "3rd Party Mac Developer Application:" --entitlements "${gitdir}/src/macos/entitlement.plist" "${packagedir}/${ovjAppName}"
+if [ "x${OVJ_CODESIGN}" != "x" ] && [ "x${OVJ_CODESIGN}" != "xnone" ]
+then
+    echo "Code signing requires a certificate issued by Apple." \
+         "Check for any errors and fix for OS X El Capitan or macOS Sierra"
+    codesign -s "${OVJ_CODESIGN}" \
+             --entitlements "${gitdir}/src/macos/entitlement.plist" \
+             "${packagedir}/${ovjAppName}"
+else
+    echo "Skipping code signing, empty identity in OVJ_CODESIGN"
+fi

--- a/src/shuffler/SConstruct
+++ b/src/shuffler/SConstruct
@@ -17,15 +17,12 @@ def copyFilesRmExt(path, fileList, ext):
       shutil.copy( i, os.path.join(path, i[:-l]) )
 
 # get options settings
-boFile=os.path.join(cwd,os.pardir,os.pardir,'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile=os.path.join(cwd,os.pardir,os.pardir,'scripts','buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # define with absolute path where standard build files will be copied
-vnmrShufflerPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'shuffler')
-optImageShufflerPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'options','standard','IMAGE','imaging','shuffler')
-optP11ShufflerPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'options','standard','P11','shuffler')
+vnmrShufflerPath = os.path.join(bo.PREFIX, 'vnmr', 'shuffler')
+optImageShufflerPath = os.path.join(bo.PREFIX, 'options','standard','IMAGE','imaging','shuffler')
+optP11ShufflerPath = os.path.join(bo.PREFIX, 'options','standard','P11','shuffler')
 
 ##
 ## make sure the standard path(s) exist

--- a/src/shuffler/SConstruct
+++ b/src/shuffler/SConstruct
@@ -20,9 +20,9 @@ def copyFilesRmExt(path, fileList, ext):
 execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # define with absolute path where standard build files will be copied
-vnmrShufflerPath = os.path.join(bo.PREFIX, 'vnmr', 'shuffler')
-optImageShufflerPath = os.path.join(bo.PREFIX, 'options','standard','IMAGE','imaging','shuffler')
-optP11ShufflerPath = os.path.join(bo.PREFIX, 'options','standard','P11','shuffler')
+vnmrShufflerPath = os.path.join(bo.prefix, 'vnmr', 'shuffler')
+optImageShufflerPath = os.path.join(bo.prefix, 'options','standard','IMAGE','imaging','shuffler')
+optP11ShufflerPath = os.path.join(bo.prefix, 'options','standard','P11','shuffler')
 
 ##
 ## make sure the standard path(s) exist

--- a/src/tcl/SConstruct.vnmrwish
+++ b/src/tcl/SConstruct.vnmrwish
@@ -7,17 +7,9 @@ import sys
 # can be called from any other SConstruct file
 cwd = os.getcwd()
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-# If not defined, try the default location
-    print "OVJ_TOOLS env not found. Trying default location."
-    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
-
-if not os.path.exists(ovjtools):
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+import buildMethods
+ovjtools = bo.OVJ_TOOLS
 
 # define target file names
 vnmrwishTarget = 'vnmrwish'

--- a/src/vjclient/SConstruct
+++ b/src/vjclient/SConstruct
@@ -16,10 +16,7 @@ vjclientProGuardTarget = 'vjclient.jar.pro'
 cwd = os.getcwd()
 
 # get options environment
-boFile = os.path.join(cwd, os.pardir, os.pardir, 'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile = os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 # paths
 javaPath = os.path.join(cwd, os.pardir, os.pardir, '3rdParty', 'java', 'bin')

--- a/src/vjclient/SConstruct
+++ b/src/vjclient/SConstruct
@@ -73,11 +73,11 @@ if not os.path.exists(installPath):
 
 
 # actions to be performed after targets are built
-if boEnv['dasho']=='y' or boEnv['vjclient_0']=='y':
+if boEnv['dasho'] or boEnv['vjclient_0']:
    jEnv.AddPostAction(jarBuildObject,
                    Action(os.path.join(cwd,'vjclientProGuard.sh')))
 
-if boEnv['vjclient_0']=='y':
+if boEnv['vjclient_0']:
    jEnv.AddPostAction(jarBuildObject,
                    Action(Copy(os.path.join(installPath,vjclientTarget),
                                os.path.join(cwd, vjclientProGuardTarget))))

--- a/src/vjmol/SConstruct
+++ b/src/vjmol/SConstruct
@@ -7,18 +7,14 @@ import sys
 import shutil
 import datetime
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# current working directory
+cwd = os.getcwd()
+
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
 
 # MAC -> darwin, Linux -> linux2
 platform = sys.platform
-
-# current working directory
-cwd = os.getcwd()
 
 # target
 vjmolTarget = 'vjmol.jar'
@@ -85,7 +81,7 @@ copyFilesHere(ThirdPartyJarPath,ThirdPartyList)
 
 # actions to perform at interpretation time
 for i in jarFileList:
-   Execute('cd classes; ' + jarBin + ' -xf ' + i)
+   Execute('cd classes && ' + jarBin + ' -xf ' + i)
 
 #for i in jarHelpFileList:
 #   Execute('cd classes; ' + jarBin + ' -xf ' + i)
@@ -107,12 +103,13 @@ jEnv.Java(JAVACFLAGS = '-J-mx128m',
 
 todaysDate = datetime.datetime.now().strftime("%B %e, %Y %T %Z")
 manifestFile = os.path.join(cwd, 'Manifest')
-f = open(manifestFile, 'w')
-f.write('Manifest-Version: 1.0 ')
-f.write(todaysDate)
-f.write('\n')
-f.write('Main-Class: VJMol\n')
-f.close()
+if not GetOption('no_exec'):
+    f = open(manifestFile, 'w')
+    f.write('Manifest-Version: 1.0 ')
+    f.write(todaysDate)
+    f.write('\n')
+    f.write('Main-Class: VJMol\n')
+    f.close()
 
 jarBuildObject = jEnv.Jar(JAR      = jarBin,
                           target   = vjmolTarget,

--- a/src/vjqa/SConstruct
+++ b/src/vjqa/SConstruct
@@ -3,9 +3,11 @@
 import os
 import sys
 
-#get current working directory
+# get current working directory
 cwd = os.getcwd()
-ovjtools = os.getenv('OVJ_TOOLS')
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+ovjtools = bo.OVJ_TOOLS
+
 javaBinDir = os.path.join(ovjtools, 'java', 'bin')
 
 # get the envirionment

--- a/src/vnmrj/SConstruct
+++ b/src/vnmrj/SConstruct
@@ -15,7 +15,7 @@ execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 ovjtools = bo.OVJ_TOOLS
 platform = sys.platform
-print sys.platform
+print 'vnmrj/SConstruct sys.platform:', sys.platform
 
 #
 # define function to convert SUA paths to Windows
@@ -42,7 +42,7 @@ fbpath= cwd
 #
 # if interix then replace /dev/fs/C/ with C:/
 #
-if ( 'interix' in platform ):
+if 'interix' in platform:
    # print cwd
    # print cwd[0:8]
    #tcwd = cwd[9:]
@@ -95,7 +95,7 @@ propFileList = string.split("""
 ThirdPartyJarPath = os.path.join(ovjtools, 'JavaPackages')
 ThirdPartyList = ['jmol.jar']
 
-env = Environment()
+#env = Environment()
 #platform = env['PLATFORM']
 
 #dict = env.Dictionary()
@@ -144,10 +144,7 @@ else:
 
 # make sure the path(s) exist
 classesPath = os.path.join(cwd, 'classes')
-if not os.path.exists(classesPath):
-   os.makedirs(classesPath)
-
-
+Execute(Mkdir(classesPath))
 
 # method to copy files to remote directory
 def copyFilesHere(path, fileList):
@@ -227,7 +224,7 @@ print jEnv['ENV']
 
 
 # just a double check of which javac is being used for the build
-if ( 'interix' not in platform):
+if 'interix' not in platform:
   jEnv.Execute('which javac')
 
 # actual VJMol.jar build
@@ -239,7 +236,7 @@ findAction = 'find ' + os.path.join(cwd,'classes') + ' \( -name "*.java" -o -nam
 # print findAction
 vjmolEnv.AddPostAction(javaBuildVJMol,
                        Action(findAction))
-if ( 'interix' not in platform):
+if 'interix' not in platform:
   vjmolBuildObject = vjmolEnv.Jar(JAR      = jarBin,
                                   source   = vjmolPath,
                                   target   = vjmolTarget,
@@ -253,12 +250,15 @@ javaBuildObject = jEnv.Java(JAVACFLAGS = '-J-mx256m',
 
 todaysDate = datetime.datetime.now().strftime("%B %e, %Y %T %Z")
 manifestFile = os.path.join(cwd, 'Manifest')
-f = open(manifestFile, 'w')
-f.write('Manifest-Version: 1.0 ')
-f.write(todaysDate)
-f.write('\n')
-f.write('Main-Class: vnmr.ui.VNMRFrame\n')
-f.close()
+if not GetOption('no_exec'):
+    f = open(manifestFile, 'w')
+    f.write('Manifest-Version: 1.0 ')
+    f.write(todaysDate)
+    f.write('\n')
+    f.write('Main-Class: vnmr.ui.VNMRFrame\n')
+    f.close()
+else:
+    print 'would create ',manifestFile
 
 #jEnv.AddPostAction(javaBuildObject,
 #                   Action(os.path.join(cwd,'removeJava.sh')))
@@ -267,8 +267,8 @@ f.close()
 jEnv.AddPostAction(javaBuildObject,
                    Action(findAction))
 
-if ( 'interix' in platform):
-  cdCmd = 'cd ' + cwd + ' ; '
+if 'interix' in platform:
+  cdCmd = 'cd ' + cwd + ' && '
   jarCmd = cdCmd + jarBin + ' -cfm vnmrj.jar ' + Sua2WinPath(manifestFile) + ' -C ' + Sua2WinPath(classesPath) + ' .'
   jarBuildObject = jEnv.Command(target = vnmrjTarget,
                                 source = [ classesPath, manifestFile],
@@ -289,8 +289,8 @@ else:
 installPath = os.path.join(bo.prefix, 'vnmr', 'java')
 binPath = os.path.join(bo.prefix, 'vnmr', 'bin')
 # make sure the path(s) exist
-if not os.path.exists(installPath):
-   os.makedirs(installPath)
+Execute(Mkdir(installPath))
+Execute(Mkdir(binPath))
 
 moviePath = os.path.join(ovjtools, 'JMF-2.1.1e', 'src','simplemovie.jar')
 Execute(Copy(os.path.join(installPath,'simplemovie.jar'), moviePath))
@@ -314,7 +314,7 @@ else:
                       Action(Copy(installPath, os.path.join(cwd, vnmrjTarget))))
 
 # finally copy vjmol.jar
-if ( 'interix' not in platform):
+if 'interix' not in platform:
   vjmolEnv.AddPostAction(vjmolBuildObject,
                          Action(Copy(installPath, os.path.join(cwd, vjmolTarget))))
 else:

--- a/src/vnmrj/SConstruct
+++ b/src/vnmrj/SConstruct
@@ -48,10 +48,7 @@ fbpath= cwd
 
 
 # get options environment
-boFile = os.path.join(cwd, os.pardir, os.pardir, 'buildoptions.py')
-if not os.path.exists(boFile):
-   boFile = os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py')
-execfile(boFile)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 #
 # if interix then replace /dev/fs/C/ with C:/

--- a/src/vnmrj/SConstruct
+++ b/src/vnmrj/SConstruct
@@ -299,13 +299,13 @@ Execute(Copy(os.path.join(installPath,'simplemovie.jar'), moviePath))
 #                   Action(os.path.join(cwd,'removeJava.sh')))
 
 # actions to be performed after targets are built
-if boEnv['dasho']=='y' or boEnv['vnmrj_O']=='y':
+if boEnv['dasho'] or boEnv['vnmrj_O']:
    jEnv.AddPostAction(jarBuildObject,
                       Action(os.path.join(cwd,'VnmrJProGuard.sh')))
 
 #                   Action(os.path.join(cwd,'VnmrJDasho.sh')))
 
-if boEnv['vnmrj_O']=='y':
+if boEnv['vnmrj_O']:
    jEnv.AddPostAction(jarBuildObject,
                       Action(Copy(os.path.join(installPath,vnmrjTarget),
                                   os.path.join(cwd, vnmrjProGuardTarget))))

--- a/src/vnmrj/SConstruct
+++ b/src/vnmrj/SConstruct
@@ -9,18 +9,11 @@ import platform
 
 # current working directory
 cwd = os.getcwd()
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-# If not defined, try the default location
-    print "OVJ_TOOLS env not found. Trying default location."
-    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
 
-if not os.path.exists(ovjtools):
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+# get options environment
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
+ovjtools = bo.OVJ_TOOLS
 platform = sys.platform
 print sys.platform
 
@@ -45,10 +38,6 @@ vjmolTarget = 'vjmol.jar'
 
 # file base path , usually cwd except for interix
 fbpath= cwd
-
-
-# get options environment
-execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
 
 #
 # if interix then replace /dev/fs/C/ with C:/
@@ -179,7 +168,7 @@ for i in jarHelpFileList:
 Execute('rm -rf ' + os.path.join(classesPath, 'META-INF'))
 
 # copy properties files to classes/properties directory
-Execute('rm -rf ' + os.path.join(classesPath, 'vnmr') + ' && ' + \
+Execute('rm -rf ' + os.path.join(classesPath, 'vnmr') + ' && ' +
         'cp -r ' + os.path.join(cwd, 'src', 'vnmr') + ' ' + classesPath)
 
 # define vjmol environment
@@ -297,8 +286,8 @@ else:
                             JARCHDIR = classesPath)
 
 # define with absolute path where built files will be copied
-installPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'java')
-binPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'bin')
+installPath = os.path.join(bo.prefix, 'vnmr', 'java')
+binPath = os.path.join(bo.prefix, 'vnmr', 'bin')
 # make sure the path(s) exist
 if not os.path.exists(installPath):
    os.makedirs(installPath)

--- a/src/xrecon/SConstruct
+++ b/src/xrecon/SConstruct
@@ -3,24 +3,14 @@
 import os
 import shutil
 import sys
-sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
-import buildMethods
 
 # we need to specify an absolute path so this SConstruct file
 # can be called from any other SConstruct file
 cwd = os.getcwd()
 
-ovjtools=os.getenv('OVJ_TOOLS')
-if not ovjtools:
-# If not defined, try the default location
-    print "OVJ_TOOLS env not found. Trying default location."
-    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
-
-if not os.path.exists(ovjtools):
-    print "OVJ_TOOLS env not found."
-    print "For bash and variants, use export OVJ_TOOLS=<path>"
-    print "For csh and variants,  use setenv OVJ_TOOLS <path>"
-    sys.exit(1)
+execfile(os.path.join(cwd, os.pardir, os.pardir, 'scripts', 'buildoptions.py'))
+import buildMethods
+ovjtools = bo.OVJ_TOOLS
 
 # MAC -> darwin, Linux -> linux2
 platform = sys.platform


### PR DESCRIPTION
This is still a work in progress, but it's far enough along to solicit feedback.

There are a few goals:
- put all config options in one place (including java location, library locations, detected features, etc..)
- override options with config.py or scons command-line options
- run scons anywhere in the build tree and pass the same options to it there
- (eventually) let scons build & install, for example, into a live system,  by passing prefix=/vnmr
- not have location of ovjTools and intermediate build dir hard-coded
- change ovjTools/bin/buildovj's sconsJoption to sconsOptions to pass any/all options
- fix the `scons -n` and `scons -c` operations #39 
- cleanup scons warnings #38 
[ci skip]