### PR TITLE
Fixed the add command (see PR #202 )

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -5,6 +5,7 @@ Oct 2018
       Bug reported in SpinSights
     The SE option had problems saving a secure copy if the template for
       the 2nd copy contained a parameter.  Bug and work-around reported in SpinSights
+    Added options to clradd command (see manual/clradd)
     
 Aug 2018
     Added options to add command (see manual/add)

--- a/src/common/manual/add
+++ b/src/common/manual/add
@@ -1,7 +1,12 @@
 
 *******************************************************************************
 clradd<:$stat,$message>	-	clear the add/subtract experiment
+clradd<('keep',numFid)><:$stat,$message> - clear the add/subtract experiment
+                                           but keeping the specified number
+                                           of FIDs
+
 jaddsub -       join the add/subtract experiment
+
 add<(multiplier <,'new'>)>  - add the current FID to the add/subtract experiment
 sub<(multiplier <,'new'>)>  - subtract the current FID from the add/subtract
                               experiment
@@ -23,6 +28,22 @@ number is defined by the global addsubexp parameter. The clradd program uses
 the delexp command to delete the add-subtract experiment. It takes the same
 return values as the delexp command. These can be used to suppress messages.
 See the manual for delexp to a description of the return values.
+
+clradd('keep',numFids) will remove FIDs from the addsub experiment, keeping
+the number specified. For example, if the addsub experiment was an arrayed
+data set with 10 FIDs, clradd('keep',1) would delete FIDs 2-10. If, for example,
+you wanted to keep FIDs 4 and 6 from the original 10, the following would
+be required
+  select(4)
+  add('newtrace',1)   // this replaces FID 1 with FID 4
+  select(6)
+  add('newtrace',2)   // this replaces FID 2 with FID 6
+  clradd('keep',2)    // this keeps the first 2 FIDs, deleting 3-10
+clradd('keep',numFIDs):$stat,$msg will set $stat=1 if it succeeds, 0 if it fails.
+The $msg will contain the message.  The 'keep' option has the side-effect
+of scaling the FID data and converting it to floating point. This removes the
+need to do the scaling and conversion every time an add/sub operation is done.
+The command clradd('keep',arraydim) will convert the entire FID data set.
 
 Note that the addsubexp parameter can be the same as the currently joined
 experiment. In this case, the clradd command cannot be used since that
@@ -74,10 +95,14 @@ it to the sixth FID in the add/subtract experiment.  When using the 'trace'
 argument, the index must be between 1 and one greater than the current
 number of FIDs in the add/subtract experiment. If the 'trace' index is
 one greater than the current number of FIDs in the add/subtract experiment,
-it is equivalent to using the 'add' argument.
+it is equivalent to using the 'new' argument.
 
 The 'newtrace' argument is same same as the 'trace' argument except that
 the data in the current trace is replaced with the new data.
+
+If the target FID is a link to another file, which happens if the data are
+returned to an experiment with the rt command, the links will be removed so
+that the previously linked FID file is not modified.
 
 
 Examples

--- a/src/common/manual/averag
+++ b/src/common/manual/averag
@@ -22,6 +22,10 @@ ddf,ddff,ddfp:
       If the numerical index first is replaced by a keyword 'max', the
       maximum absolute value data point is displayed instead.  If a return
       argument is given, the maximum value is returned, and is not displayed.  
+      For FID's, the maximum value in the block is scaled by the values of
+      of scale and ctcount in the block header. A second return argument will
+      to be to this scaled value.
+      
 
 noise:
   If two input arguments are added, they are used  	      

--- a/src/common/manual/makefid
+++ b/src/common/manual/makefid
@@ -9,7 +9,7 @@ writefid( output text file <, element number > )
 	-  write numeric text file using a FID element.
 ****************************************************************************
 
-The `makefid' command lets you introduce computed data into your experiment.
+The makefid command lets you introduce computed data into your experiment.
 The input files contains numeric values, 2 per line.  The first value is
 assigned to the X (or real) channel; the second value on the line is
 assigned to the Y (or imaginary) channel.
@@ -44,30 +44,23 @@ Use one of the following character strings to specify the format:
 	'float'		        floating point   (32-bit) data
 
 The number of points comes from the number of numeric values read from the
-file.  `makefid' reads only 2 values per line.
+file.  makefid reads only 2 values per line.
 
 If the current experiment already contains a FID, you will not be able to
 change either the format or the number of points from that present in the
-FID file.  Use this command to remove the FID:
+FID file.  As noted above, you can use an index of zero to delete the
+existing FID file.
 
-	rm(curexp+'/acqfil/fid')
-
-Be aware that `makefid' does not look at parameter values when establishing
+Be aware that makefid does not look at parameter values when establishing
 the format of the data or the number of points in an element.  Thus if the
-FID file is not present it is possible for `makefid' to write a FID file
-with a header that does not match the value of `dp' or `np'.  Since the
-active value is in the processed tree, you will need to use the `setvalue'
+FID file is not present it is possible for makefid to write a FID file
+with a header that does not match the value of dp or np.  Since the
+active value is in the processed tree, you will need to use the setvalue
 command if any changes are needed.
 
-Be aware that `makefid' can modify saved data; that is, data returned to an
-experiment with the `rt' command.  Either supply 0 as the element number or
-execute this sequence of VNMR commands to avoid this:
-
-	cp(curexp+'/acqfil/fid',curexp+'/acqfil/fidtmp')
-	rm(curexp+'/acqfil/fid')
-	mv(curexp+'/acqfil/fidtmp',curexp+'/acqfil/fid')
-
-
+If the target FID is a link to another file, which happens if the data are
+returned to an experiment with the rt command, the links will be removed so
+that the previously linked FID file is not modified.
 
 An alternative form of makefid will calculate an FID based on the frequency,
 amplitude, decay rate, and phase of a spectral line. The first argument,
@@ -134,7 +127,7 @@ makefid('calcstr','2000.0 20.0 0.1 0.0',2,'add')  // Add another component to th
 
 writefid
 --------
-The `writefid' command writes a text file using data from the selected FID
+The writefid command writes a text file using data from the selected FID
 element.  The default element number is 1.  The program writes 2 values
 per line.  The first is the value from the X (or real) channel; the second
 is the value from the Y (or imaginary) channel.

--- a/src/vnmr/data.c
+++ b/src/vnmr/data.c
@@ -2375,6 +2375,35 @@ void D_error(int errnum)
       Wscrprintf("  Last function called = D_%s\n", lastfunc);
 }
 
+char *D_geterror(int errnum)
+{
+   static char msg[64];
+   switch (errnum)
+   {
+      case D_IS_OPEN:  strcpy(msg,"Data file is already open"); break;
+      case D_NOTOPEN:  strcpy(msg,"Data file is not open currently"); break;
+      case D_READERR:  strcpy(msg,"File read error"); break;
+      case D_WRITERR:  strcpy(msg,"File write error"); break;
+      case D_INCONSI:  strcpy(msg,"Inconsistent data file header"); break;
+      case D_NOALLOC:  strcpy(msg,"Buffer not allocated, out of memory"); break;
+      case D_NOBLOCK:  strcpy(msg,"Too many blocked blocks in memory"); break;
+      case D_NOTFOUND: strcpy(msg,"Requested block not in memory"); break;
+      case D_SEEKERR:  strcpy(msg,"File seek error"); break;
+      case D_BLINDEX:  strcpy(msg,"Illegal block index"); break;
+      case D_FLINDEX:  strcpy(msg,"Illegal file index"); break;
+      case D_BUFERR:   strcpy(msg,"Internal buffer too small"); break;
+      case D_TRERR:    strcpy(msg,"Cannot transpose block"); break;
+      case D_READONLY: strcpy(msg,"No write permission"); break;
+      case D_INVNBHDR: strcpy(msg,"Invalid number of block headers"); break;
+      case D_INVOP:    strcpy(msg,"Invalid file operation"); break;
+      case D_TRUNCERR: strcpy(msg,"File truncation error"); break;
+      case D_OPENERR:  strcpy(msg,"Cannot open data file"); break;
+      case ERROR:      break;
+      default:         strcpy(msg,"D_error: unknown error number"); break;
+   }
+   return(msg);
+}
+
 
 /*---------------------------------------
 |					|

--- a/src/vnmr/data.h
+++ b/src/vnmr/data.h
@@ -790,6 +790,7 @@ extern int D_foldt(int fileindex, float *datapntr, int seekmode,
 
 /**************************/
 extern void D_error(int errnum);
+extern char *D_geterror(int errnum);
 /**************************/
 /*-----------------------------------------------
 |  Display an error message for a data handler	|
@@ -820,6 +821,7 @@ extern void setfilepaths(int datano);
 /*************************************/
 /*************************************/
 extern int D_getLastVendorId();
+extern int D_fidversion();
 /*************************************/
 #endif
 

--- a/src/vnmr/df2d.c
+++ b/src/vnmr/df2d.c
@@ -481,8 +481,8 @@ int getfid(int curfid, float *outp, ftparInfo *ftpar, dfilehead *fidhead, int *l
          {
             if (inblock.head->status != 0)
             {
-               Wscrprintf("status of FID %d incorrect, status = %d\n",
-                     curfid + 1, inblock.head->status);
+               Wscrprintf("status of FID %d incorrect, status = %d (0x%x)\n",
+                     curfid + 1, inblock.head->status, inblock.head->status);
             }
  
             zerofill(outp, ftpar->fn0);

--- a/src/vnmr/jexp.c
+++ b/src/vnmr/jexp.c
@@ -1116,10 +1116,9 @@ int svprocpar(int fidflag, char *filepath)
 
 // this command will downsize fid by a factor (0 < factor < 1.0) 
 // curexp/acqfil/fid and curexp/acqfil/procpar will be overwriten
-// if fid is linked, the linki, make_copy_fidfile will be called to
+// if fid is linked, make_copy_fidfile will be called to
 // replace the link with a copy, so the original fid won;t be overwriten.
 // If the first argument is > 1, it is treated as the new np value.
-extern int make_copy_fidfile();
 extern int D_downsizefid(int newnp, char *datapath);
 extern int D_zerofillfid(int newnp, char *datapath);
 extern int D_leftshiftfid(int lsfid, char *datapath, int *newnp);
@@ -1159,7 +1158,7 @@ int downsizefid(int argc, char *argv[], int retc, char *retv[])
     if (curexpFid)
     {
     // this will copy the fid if acqfil/fid is linked
-       make_copy_fidfile();
+       make_copy_fidfile(argv[0], curexpdir, NULL);
  
        if ( (res = D_getfilepath(D_USERFILE, filepath, curexpdir)) )
        {
@@ -1254,7 +1253,7 @@ int zerofillfid(int argc, char *argv[], int retc, char *retv[])
     if (curexpFid)
     {
        // this will copy the fid if acqfil/fid is linked
-       make_copy_fidfile();
+       make_copy_fidfile(argv[0], curexpdir, NULL);
  
       if ( (res = D_getfilepath(D_USERFILE, filepath, curexpdir)) )
       {
@@ -1354,7 +1353,7 @@ int leftshiftfid(int argc, char *argv[], int retc, char *retv[])
    if (curexpFid)
    {
        // this will copy the fid if acqfil/fid is linked
-       make_copy_fidfile();
+       make_copy_fidfile(argv[0], curexpdir, NULL);
  
       if ( (res = D_getfilepath(D_USERFILE, filepath, curexpdir)) )
       {
@@ -1445,7 +1444,7 @@ int scalefid(int argc, char *argv[], int retc, char *retv[])
    if (curexpFid)
    {
        // this will copy the fid if acqfil/fid is linked
-       make_copy_fidfile();
+       make_copy_fidfile(argv[0], curexpdir, NULL);
  
       if ( (res = D_getfilepath(D_USERFILE, filepath, curexpdir)) )
       {

--- a/src/vnmr/tools.h
+++ b/src/vnmr/tools.h
@@ -41,7 +41,7 @@ extern int     verify_fname(char *fnptr);
 extern int     isHardLink(char *lptr);
 extern int     isSymLink(char *lptr);
 extern int     copy_file_verify(char *file_a, char *file_b );
-extern int     move_file(char *file_a, char *file_b );
+extern int     make_copy_fidfile(char *prog, char *dir, char *msg);
 extern char *strwrd(char *s, char *buf, size_t len, char *delim);
 
 #endif


### PR DESCRIPTION
The add command, when using the current experiment as the addsub experiment,
would fail for integer FID data and for scaled FID data.  The add command
will copy fid file if it is linked to another.
Added 'keep' option to clradd.