### PR TITLE
Fixed several bugs reported in SpinSights

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,5 +1,21 @@
 OpenVnmrJ Release Notes.
 
+Dec 2018
+    Fixed several bugs reported in SpinSights:
+       Hononuclear sw1 shows wrong ppm value in "Acquisition" panel.
+       For T1 and T2 experiments. The "ProcPlotAdv" panel is missing.
+       psGshim did not call gmapsolv
+       mz did not work between spectrometers
+       mtune and trtune could fail due to missing hfmode parameter
+       addprobe gives an error if probe name not supplied as an argument.
+       For the "Calibrate pw90" function,  it supports an optional userpw90proc macro
+         to allow for additional parameter adjustments.
+       pw90proc could fail with a division by zero.
+       VeriPulse was missing P31 pw calibrations for ID probes.
+       protune could cause automation to stop even if the "Skip sample if protune fails"
+         is set to "no"
+       
+
 Nov 2018
     New options to the makefid command (see manual/makefid)
     New sendMessage macro to control a background OpenVnmrJ process (see manual/sendMessage)

--- a/src/common/maclib/addprobe
+++ b/src/common/maclib/addprobe
@@ -6,6 +6,10 @@
 // Usage:  addprobe(probename, <<destination appdir>,existingProbeFilePath,ProbeID>)
 //	The default value of arg2 is userdir
 
+    if ($# < 1) then
+       write('error','%s requires a probe name as the first argument',$0)
+       return(0,'')
+    endif
     if ($# < 2) then $2=userdir endif
     if ($2='') then $2=userdir endif
     if ($#<3) then $3='' endif

--- a/src/common/maclib/mtune_ddr
+++ b/src/common/maclib/mtune_ddr
@@ -82,6 +82,12 @@ if ($action = 'setup') then
   endif
 
   if ($hfmode <> 'n') then
+    exists('hfmode','parameter'):$e
+    if ($e <= 0.5) then
+      create('hfmode','flag')
+      setprotect('hfmode','on',1)
+      hfmode=''
+    endif
     hfmode=$hfmode
   endif
 

--- a/src/common/maclib/mz
+++ b/src/common/maclib/mz
@@ -32,14 +32,29 @@ endif
 
 " remember integration parameters "
 on('lifrq') on('liamp')
-$lifrq=lifrq $liamp=liamp
+$lifrq=lifrq $liamp=liamp $reffrq=reffrq $tn=tn $rfl=rfl
 
 " read in parameters from target experiment "
 fread(userdir+'/exp'+$t+'/curpar','current','reset')
 
-" transfer integration poarameters "
-lifrq=$lifrq off('lifrq')
-liamp=$liamp off('liamp')
+" transfer integration parameters "
+if $tn<>tn then
+  write('error','Cannot move resets between different nuclei!')
+  if $curexp<>$t then fread(curexp+'/curpar','current','reset') endif
+else
+  lifrq=0
+  liamp=0
+  $drfl=$rfl*(reffrq/$reffrq)-rfl
+  $size=size('$lifrq')
+  $i=1
+  repeat
+    setvalue('lifrq',$lifrq[$i]*(reffrq/$reffrq)-$drfl,$i)
+    setvalue('liamp',$liamp[$i],$i)
+    $i=$i+1
+  until $i>$size
+  off('lifrq')
+  off('liamp')
+endif
 
 " if necessary, save target data and restore current experiment params "
 if $curexp<>$t then

--- a/src/common/maclib/protune
+++ b/src/common/maclib/protune
@@ -686,17 +686,18 @@ elseif ($action = 'reset') then
       endif
       protune('quit','failure')
       shell('protune -quitgui'):$x  /*Quit protune gui before start next one*/
-      return
+      return('done')
   endif
 
   // normal protune operation, reset freq or quit
   if (tuneTiming[11]) then
+      $ret=''
       if (tuneTiming[11] = 1) then
-        protune('quit')
+        protune('quit'):$ret
       else
-        protune('quit','failed')
-        return('abort')  // return abort to psTune
+        protune('quit','failed'):$ret
       endif
+      return($ret)  // return abort to psTune
   else
       protune('start')
   endif
@@ -1244,14 +1245,15 @@ elseif ($action = 'quit') then
   shell('chmod 666 '+systemdir+'/tmp/ptune* 2>/dev/null'):$x
 
   psCmd('active'):$psActive
+  $ret=''
   if ($psActive) then
     if ($# < 2) then $2='' endif
     if ($2='failure') or ($2='failed') then
-      psTune('abort')
+      psTune('abort'):$ret
     else
-      psTune('done')
+      psTune('done'):$ret
     endif
-    return
+    return($ret)
   endif
 
   if auto='y' then

--- a/src/common/maclib/psGshim
+++ b/src/common/maclib/psGshim
@@ -1,4 +1,4 @@
-// Chempacker macro
+"macro psGshim"
 "prescan macro for gradient shimming"
 
 if ($# = 0) then
@@ -104,6 +104,7 @@ if ($action = 'init') then
   gmaplistfunc('unarray'):$ok,$exec
   exec($exec)
   array = 'd3'
+  gmapsolv
   exists('gzsize','parameter'):$ez
   if $ez>0.5 then
     $bsize=gzsize

--- a/src/common/maclib/psTune
+++ b/src/common/maclib/psTune
@@ -1,5 +1,4 @@
 "macro psTune"
-"macro psTune"
 if ($# = 0) then
   write('error','Do not call %s directly. Use prescan.',$0)
   abort
@@ -74,25 +73,25 @@ elseif ($action = 'done') or ($action = 'quit') or ($action= 'abort') then
 "*********************************************************************"
         checkprotune('write','lasttunepar')
     endif
-    $abortpterror='no'
-    getadminfo('abortpterror'):$abortpterror
     if ($action = 'abort') then
+        $abortpterror='no'
+        getadminfo('abortpterror'):$abortpterror
         if ($abortpterror='yes') then
-                write('error','Protune reported a Failure')
+                write('error','Protune reported a failure')
                 if (auto='y') then
                    wexp='AutoSKIP'
                    psCmd('record','wexp=\'AutoSKIP\'')
                 endif
+                return('abort') // Return abort to psMain
         else
-                write('line3','Protune reported a Failure')
+                write('line3','Protune reported a failure, continue nontheless')
 		if (auto='y') then
                    $loc='' $locdir='' $when=''
                    getlocid:$loc,$locdir,$when
                    $errlog=autodir+'/enterQ.macdir/'+$locdir+'/errorlog_'+$when
-                   write('file',$errlog,'Protune reported a Failure')
+                   write('file',$errlog,'Protune reported a failure, but queue runs anyway')
 		endif
         endif
-        return('abort') // Return abort to psMain
     endif
 
   return('done')

--- a/src/common/maclib/pw90proc
+++ b/src/common/maclib/pw90proc
@@ -139,8 +139,12 @@ ELSEIF ($1='est90') THEN
 	fread($tmpfile+'2')
 	shell('rm -f '+$tmpfile+'2'):$dum
   endif
-    vsadj(100) thadj th=th*2 dc
+	// Set thadj to a maximum of 10 peaks via thadj
+  dc vsadj(100) thadj(10)
+//    vsadj(100) thadj th=th*2 dc
   if ($wpspex=0) then
+	// wpsp are not defined. So find at least
+	//  5 peaks starting from middle 10% of the sepctrum
     $done=0
     $wp=wp/10 $sp=sp+wp/2-$wp/2 
     $i=1
@@ -152,7 +156,26 @@ ELSEIF ($1='est90') THEN
 	$i=$i+1
     endwhile
   else
+	// Let us make sure we use a maximum of 5 tallest peaks
+	// just to avoid too many noise peaks
     nll:$peaks
+    if $peaks>5 then
+	// If we have more than 5 peaks, increase th and try again
+	$done=0
+	while $done<1 do
+	    th=th+10
+	    nll:$peaks
+	    if $peaks=0 then
+		// No peaks, go back to the previous step
+		th=th-10 
+		nll:$peaks 
+		$done=1
+	    elseif $peaks<=5 then
+		// Found 5 or less peaks
+		$done=1
+	    endif
+	endwhile
+    endif
   endif
     if ($peaks>0) then
 	select(1) dc select(2) dc fp
@@ -162,6 +185,7 @@ ELSEIF ($1='est90') THEN
 	pw90=$pw90
 	write('line3','%s pw90 set to %0.2f',pslabel,pw90)
 	Studyprobecal(tn,'pw90',pw90)
+	dousermacro($0)
       else
 	$pw90=trunc(10*$pw90 + 0.5)/10
 	array('pw',9,4*$pw90-3.2,0.8)
@@ -206,6 +230,7 @@ ELSEIF ($1='est360') THEN
 	pw90=$pw90
 	write('line3','%s pw90 set to %0.2f',pslabel,pw90)
         Studyprobecal(tn,'pw90',pw90)
+	dousermacro($0)
     endif
     pw90proc('done')
     if ($GO='go') then cpgo endif

--- a/src/common/maclib/trtune
+++ b/src/common/maclib/trtune
@@ -60,6 +60,12 @@ if $action = 'setup' then
   endif
 
   if ($hfmode <> 'n') then
+    exists('hfmode','parameter'):$e
+    if ($e <= 0.5) then
+      create('hfmode','flag')
+      setprotect('hfmode','on',1)
+      hfmode=''
+    endif
     hfmode=$hfmode
   endif
 

--- a/src/common/maclib/vnmrunits
+++ b/src/common/maclib/vnmrunits
@@ -26,6 +26,22 @@ endif
 "  $tree=$3"
 "endif"
 
+$k=0 $s1='' $ext=''
+strstr($param,'sw'):$k,$s1,$ext
+format($ext,'isreal'):$real
+if $k=1 and $real then
+    $ok=0
+	// $retval could be real or string
+    if $# > 2 then
+	vnmrunits1($getset,$param,$3):$ok,$retval
+    else
+	vnmrunits1($getset,$param):$ok,$retval
+    endif
+	// if vnmrunits1 succeeded then return
+	//  else proceed
+    if $ok then return($retval) endif
+endif
+
 "could loop through all trees"
 getdgroup($param,$tree):$dgroup
 gettype($param,$tree):$type

--- a/src/common/maclib/vnmrunits1
+++ b/src/common/maclib/vnmrunits1
@@ -1,0 +1,41 @@
+// Chempacker macro
+
+// This is a branch point of vnmrunits macro
+// At this time sw1/sw2/sw3 are handled
+
+$param=$2
+$getset=$1
+
+if ($getset<>'set') and ($getset<>'get') then
+    return(0)
+endif
+$k=0 $s1='' $ext=''
+strstr($param,'sw'):$k,$s1,$ext
+format($ext,'isreal'):$real
+if $k<>1 or not $real then return(0) endif
+
+$refsource='refsource'+$ext
+$reffrq='reffrq'+$ext
+$k1=0 $k2=0
+exists($refsource,'parameter'):$k1
+exists($reffrq,'parameter'):$k2
+if not $k1 or not $k2 then return(0) endif
+
+getdgroup($param,'current'):$dgroup
+if $dgroup=1 then $ref=1 else $ref={$reffrq} endif
+
+if $getset='get' then
+    $num=size($param)
+    if $num>1 then
+	return(1,'array')
+    endif
+    $pval={$param}[1]
+    $pval=$pval/$ref
+    return(1,$pval)
+endif
+
+if $getset='set' then
+    $pval=$3*$ref
+    {$param}=$pval
+    return(1,0)
+endif

--- a/src/layouts/layout/CPMGT2/acq.xml
+++ b/src/layouts/layout/CPMGT2/acq.xml
@@ -20,6 +20,22 @@
   </group>
   <group loc="0 0" size="850 350"
     style="Heading1"
+    label="ProcPlotAdv"
+    vq="personaType customflag"
+    show="$S=1 PersonaManager('showInPanel','acquire','procplotadv'):$S $SHOW=((customflag='y') and ($S&gt;0.5))"
+    border="None"
+    side="Top"
+    justify="Left"
+    tab="yes"
+    enable="no"
+    reference="Quickprpl"
+    useref="yes"
+    subtype="Basic"
+    expanded="no"
+    >
+  </group>
+  <group loc="0 0" size="850 350"
+    style="Heading1"
     label="Acquisition"
     bg=""
     vq="personaType"

--- a/src/layouts/layout/INVREC/acq.xml
+++ b/src/layouts/layout/INVREC/acq.xml
@@ -20,6 +20,22 @@
   </group>
   <group loc="0 0" size="850 350"
     style="Heading1"
+    label="ProcPlotAdv"
+    vq="personaType customflag"
+    show="$S=1 PersonaManager('showInPanel','acquire','procplotadv'):$S $SHOW=((customflag='y') and ($S&gt;0.5))"
+    border="None"
+    side="Top"
+    justify="Left"
+    tab="yes"
+    enable="no"
+    reference="Quickprpl"
+    useref="yes"
+    subtype="Basic"
+    expanded="no"
+    >
+  </group>
+  <group loc="0 0" size="850 350"
+    style="Heading1"
     label="Acquisition"
     bg=""
     vq="personaType"

--- a/src/veripulse/veripulse/VPtests_id
+++ b/src/veripulse/veripulse/VPtests_id
@@ -28,6 +28,7 @@ Label  RF calibrations
 Test1  H1_pw90Cal 1H 90-degree pulse width and RF homogeneity
 Test3  $pw90=0 getparam('pw90','H1'):$pw90 if ($pw90=0) then return('HC_ProbeCal') else return('H1_ProbeCal') endif;1H 90-degree pulse width and decoupling
 Test3  $pw90=0 getparam('pw90','C13'):$pw90 if ($pw90=0) then return('HC_ProbeCal') else return('C13_ProbeCal') endif;13C 90-degree pulse width and RF homogeneity
+Test1  P31_ProbeCal4 31P 90-degree pulse widths and decoupling
 Test2  N15_ProbeCalAT,N15_ProbeCal 15N 90-degree pulse width CHECKBOX Ind Det #2
 
 Label  Gradient tests
@@ -73,6 +74,7 @@ Info  H1_Lshp_spinning     	        H1_Lshp_spinning     		   lineshape  H1_Lshp
 Info  H1_ProbeCal          	        H1_ProbeCal          		   id1        H1_calibrate         50   a     e     pfg    H1,C13
 Info  C13_ProbeCal         	        C13_ProbeCal         		   id1        C13_calibrate        90   a     e     pfg    H1,C13
 Info  HC_ProbeCal          	        HC_ProbeCal          		   id1        H1C13_calibrate      120  a     e     pfg    H1,C13
+Info  P31_ProbeCal4        	        P31_ProbeCal4        		   id1        P31_calibrate        45   a     e     pfg    H1,P31
 Info  H1sens               	        H1sens               		   h1sn       H1sensitivity        40   a     e     pfg    H1,C13
 Info  H1_qNMR_Cal          	        H1_qNMR_Cal          		   p31sn      H1_qNMR_Cal           5   a     e     pfg    H1,NA
 Info  N15_ProbeCal         	        N15_ProbeCal         		   id2        N15_calibrate        30   a     e     pfg    H1,N15
@@ -92,6 +94,7 @@ Report H1_ProbeCal          		H1pw90
 Report H1sens               		H1SN
 Report C13_ProbeCal         		C13pw90,C13pwx90,C13rfhomo
 Report HC_ProbeCal          		H1pw90,C13pw90,C13pwx90,C13rfhomo
+Report P31_ProbeCal4        		P31pw90,P31pwx90
 Report H1_qNMR_Cal          		QuantCal
 Report N15_ProbeCalAT       		N15pwx90
 Report N15_ProbeCal         		N15pwx90,N15rfhomo
@@ -137,6 +140,10 @@ Spec C13pw90_2 none N/A      1 ;Pulse power level
 Spec C13pwx90 2        ;13C 90-degree pulse width (indirect)
 Spec C13pwx90_1 min C13pw90 1 ;pwx90
 Spec C13pwx90_2 none N/A      1 ;Pulse power level
+
+Spec P31pwx90 2        ;31P 90-degree pulse width (indirect)
+Spec P31pwx90_1 min P31pw90 1 ;pwx90
+Spec P31pwx90_2 none N/A      1 ;Pulse power level
 
 Spec C13rfhomo 2       ;13C RF homogeneity
 Spec C13rfhomo_1  max C13RFHomogeneity360pw0 1 ;RF homogeneity (360/0)

--- a/src/vnmrj/src/vnmr/bo/VCheck.java
+++ b/src/vnmrj/src/vnmr/bo/VCheck.java
@@ -834,7 +834,7 @@ public class VCheck extends JCheckBox
                             // Try up to 3 levels of group above this.
                             if(helpstr==null){
                                 Container group = getParent();
-                                helpstr = CSH_Util.getHelpFromGroupParent((VGroup)group, label, LABEL, HELPLINK);           
+                                helpstr = CSH_Util.getHelpFromGroupParent(group, label, LABEL, HELPLINK);           
                             }
 
                             // Get the ID and display the help content

--- a/src/vnmrj/src/vnmr/bo/VGroup.java
+++ b/src/vnmrj/src/vnmr/bo/VGroup.java
@@ -1954,7 +1954,7 @@ to be done in setEditMode()
                             // Try up to 3 levels of group above this.
                             if(helpstr==null){
                                   Container group = getParent();
-                                  helpstr = CSH_Util.getHelpFromGroupParent((VGroup)group, title, LABEL, HELPLINK);    
+                                  helpstr = CSH_Util.getHelpFromGroupParent(group, title, LABEL, HELPLINK);    
                             }
 
                             // Get the ID and display the help content


### PR DESCRIPTION
Hononuclear sw1 shows wrong ppm value in "Acquisition" panel.
For T1 and T2 experiments. The "ProcPlotAdv" panel is missing.
psGshim did not call gmapsolv
mz did not work between spectrometers
mtune and trtune could fail due to missing hfmode parameter
addprobe gives an error if probe name not supplied as an argument.
VCheck.java and VGroup.java could give a java exception from an illegal cast.
For the "Calibrate pw90" function,  it supports an optional userpw90proc macro
  to allow for additional parameter adjustments.
pw90proc could fail with a division by zero
VeriPulse was missing P31 pw calibrations for ID probes.
protune "skip sample if protune fails" set to no option not working