### PR TITLE
Fixed bugs reported in SpinSights

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,5 +1,11 @@
 OpenVnmrJ Release Notes.
 
+Feb 2019
+    Fixed bugs reported in SpinSights:
+       trtune could fail due to expanded spectral region (require f command)
+       Hdec calibration may plot WALTZ profile with wrong phases
+       Fobs_Hdec doesn't work (makeFHdecshape)
+
 Dec 2018
     Fixed several bugs reported in SpinSights:
        Hononuclear sw1 shows wrong ppm value in "Acquisition" panel.

--- a/src/common/maclib/Hdec
+++ b/src/common/maclib/Hdec
@@ -253,7 +253,7 @@ IF ($1 = 3) or ($1=4) THEN
     	$dof=dof+(8*dfrq)
     	array('dof',33,$dof,-0.5*dfrq)
     	vp=0 wnt='wft(`acq`) select(1) aph0 vsadj(20) dssh'
-	$ep='' write('line3','wft wp=%0.1f sp=%0.1f select(17) vsadj(100) dssh',wp,sp):$ep
+	$ep='' write('line3','wft wp=%0.1f sp=%0.1f select(17) aph0 vsadj(100) dssh',wp,sp):$ep
     	execprocess=$ep+' darray(\'CalibrationResults\')'
     	execplot='cpplss'
     	$text='WALTZ-16 H1 decoupling profile:'

--- a/src/common/maclib/makeFHdecshape
+++ b/src/common/maclib/makeFHdecshape
@@ -29,9 +29,15 @@ endif
  $amp_cf=0
  $ref_pw90=0
  $ref_pwr=0
- getparam('pwx',dn):$ref_pw90
- getparam('pwxlvl',dn):$ref_pwr
- getparam('pwxlvl_cf',dn):$amp_cf
+ if dn='H1' then
+  getparam('pp',dn):$ref_pw90
+  getparam('pplvl',dn):$ref_pwr
+  getparam('tpwr_cf',dn):$amp_cf
+ else
+  getparam('pwx',dn):$ref_pw90
+  getparam('pwxlvl',dn):$ref_pwr
+  getparam('pwxlvl_cf',dn):$amp_cf
+ endif
  if ($amp_cf = 0) then $amp_cf=1 endif
    $ref_pw90 = $ref_pw90*$amp_cf
 

--- a/src/common/maclib/trtune
+++ b/src/common/maclib/trtune
@@ -69,7 +69,7 @@ if $action = 'setup' then
     hfmode=$hfmode
   endif
 
-  full
+  f full
   in='n' 
   spin = 'n'
   ss = 0


### PR DESCRIPTION
trtune could fail due to expanded spectral region (require f command)
Hdec calibration may plot WALTZ profile with wrong phases
Fobs_Hdec doesn't work (makeFHdecshape)