### PR TITLE
OVJ did not build on mint19 system and gcc 7.3.0

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -226,13 +226,11 @@ if os.path.exists(javaLink) or 'linux' not in platform:
 else:
    print "java link in "+ovjtools+" not found. Skipping java compiles"
 
-if ( os.path.exists(os.path.join('/usr','lib','libgsl.so')) or
-     os.path.exists(os.path.join('/usr','lib64','libgsl.so')) or
-     os.path.exists(os.path.join('/usr','lib','libgsl.a')) ):
+if ( os.path.exists(os.path.join('/usr','include','gsl')) ):
    for i in gslBuildList:
       SConscript(os.path.join('src',i, 'SConstruct'))
 else:
-   print "gsl library not found. Skipping compiles requiring that library"
+   print "gsl includes not found. Skipping compiles requiring gsl"
 
 vnmrPath    = os.path.join(cwd, os.pardir,'vnmr')
 

--- a/src/lcpeaks/GeneralLibrary.h
+++ b/src/lcpeaks/GeneralLibrary.h
@@ -48,8 +48,8 @@
 // TO BE CHANGED INTO INLINE TEMPLATE FUNCTIONS
 //----------------------------------------------
 
-#define max(a,b) ((a)>(b)?(a):(b))
-#define min(a,b) ((a)<(b)?(a):(b))
+// #define max(a,b) ((a)>(b)?(a):(b))
+// #define min(a,b) ((a)<(b)?(a):(b))
 #define round(x) ( (int)( ((x) < 0) ? ((x) - 0.5) : ((x) + 0.5) ) )
 
 template<class T> int sign(T x) {if (x>0) return 1 ;  else if (x<0) return -1 ; else return 0 ;}

--- a/src/xrecon/SConstruct
+++ b/src/xrecon/SConstruct
@@ -130,6 +130,7 @@ if not os.path.exists(optionsSensePath):
 
 # actual builds
 if (tiffWriter=="true"):
+   env.Append(CPPDEFINES = 'DOTIFF')
    xreconBuildObj = env.Program(target = XreconTarget,
                              source = senseSrcFilesList + XreconSrcFilesList + tifFileList,
                              LIBS   = [libffts, 'gsl', 'gslcblas', 'tiff', 'm'])

--- a/src/xrecon/Xrecon.h
+++ b/src/xrecon/Xrecon.h
@@ -81,11 +81,12 @@
 /* We will wait for C99 standard to become a bit more standard */
 //#include <complex.h>
 
-
+#ifdef DOTIFF
 /*---------------------------------*/
 /*---- Include tiff I/O header ----*/
 /*---------------------------------*/
 #include <tiffio.h>
+#endif
 
 
 /*------------------------------------------*/


### PR DESCRIPTION
lcpeaks did not compile because max and min were defined as local macros. Newer g++ has std::max and std::min.  xrecon did not compile because of a missing include file and the libfftw3.a library was not compiled with -fPIC. Need latest ovjTools to get the updated library.

On the standard Mint 19 install, I had to add the following
packages with "sudo apt install <package name>"
csh
g++
gfortran
gcc-multilib
g++-multilib
libx11-dev:i386
libxt-dev:i386
libgsl-dev
libmotif-dev:i386
mesa-common-dev
libglu1-mesa-dev

To find which package provides a certain file, I used
sudo apt install apt-file
sudo apt-file update
apt-file search <filename>
e.g.
 apt-file search GL/glu.h

Finally, I am not sure if it is a problem, but the default shell
is dash and not bash. This can be reconfigured with the tool
sudo dpkg-reconfigure dash