### PR TITLE
Fix Circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs: # a collection of steps
           name: Install System Dependencies
           command: |
             lsb_release -a
+            sudo apt-get -qq update
             sudo apt-get install -y gcc g++ gfortran gcc-multilib scons \
                 libc6-dev-i386 lib32stdc++-6-dev libglu1-mesa-dev \
                 liblapack-dev liblapacke-dev libfftw3-dev


### PR DESCRIPTION
The CircleCI docker image needed to have a packages update before trying to install our packages.