### PR TITLE
Improve speed of vjqa

### DIFF
--- a/src/psg/abort.c
+++ b/src/psg/abort.c
@@ -139,7 +139,7 @@ void psg_abort(int error)
     text_error("P.S.G. Aborted.");
     if (newacq)
     {
-      if (!acqiflag && !dps_flag)
+      if (!acqiflag && !dps_flag && !checkflag)
         release_console();
     }
     close_error(1);     /* 1 arg means failure/abort */
@@ -234,7 +234,7 @@ void abort_message(const char *format, ...)
      while (emessage[strlen(emessage)-1] == '\n')
         emessage[strlen(emessage)-1] = '\0';
      vnmremsg(emessage);
-     if (!acqiflag && !dps_flag)
+     if (!acqiflag && !dps_flag && !checkflag)
        release_console();
    }
    close_error(1);    /* 1 arg means fail/abort */

--- a/src/vjqa/vjtest/maclib/testExpts
+++ b/src/vjqa/vjtest/maclib/testExpts
@@ -18,6 +18,9 @@ $timefail=0
 $dpspass=0
 $dpsfail=0
 $j=0
+$addr=vnmraddr
+// This prevents PSG from sending ethernet messages back to Vnmr
+setvalue('vnmraddr','Autoproc','global')
 $faillog=curexp+'/faillog'
 write('reset',$faillog)
 $gofaillog=curexp+'/gofaillog'
@@ -85,6 +88,7 @@ while ($j < $numexpts) do
     endif
   endwhile
 endwhile
+setvalue('vnmraddr',$addr,'global')
 if ($pass) then
   write('line3','%d experiment menu items',$pass):$msg
   vvLog('Pass',$msg)


### PR DESCRIPTION
The PSG tests were timing out trying to send socket messages.
In the case of go('check'), psg should not send a release_console
message to the procs