### PR TITLE
Fix array display bug and add updates for a windows version

### DIFF
--- a/src/vnmr/builtin1.c
+++ b/src/vnmr/builtin1.c
@@ -450,6 +450,7 @@ int rtx(int argc, char *argv[], int retc, char *retv[] )
    {   Werrprintf("file path too long");
        ABORT;
    }
+#ifndef __CYGWIN__
    if (name[0]!='/')
    {
       pathptr = get_cwd();
@@ -458,6 +459,7 @@ int rtx(int argc, char *argv[], int retc, char *retv[] )
       strcat(filepath0,name);
    }
    else
+#endif
       strcpy(filepath0,name);
    if (find_param_file(filepath0, filepath))
    {

--- a/src/vnmr/lexjunk.c
+++ b/src/vnmr/lexjunk.c
@@ -759,7 +759,8 @@ int input()
 		  return('\004');
 	       }
 	       else
-	       {  *p = '\0';
+	       {  *p++ = '\n';
+	          *p = '\0';
 		  LPRINT0(2,"input:    ...<done>\n");
 		  break;
 	       }

--- a/src/vnmr/macro.c
+++ b/src/vnmr/macro.c
@@ -492,7 +492,12 @@ int macroLd(int argc, char *argv[], int retc, char *retv[])
 	    TPRINT1("macroLd: removing macro \"%s\"\n",argv[i]);
 	    rmMacro(argv[i]);
 	    renameAllocation("newMacro","tmpSavenewMacro");
-            if (argv[i][0] == '/')
+#ifndef __CYGWIN__
+            if   (argv[i][0] == '/')
+#else
+            if ( (argv[i][0] == '/') ||
+                 ((argv[i][1] == ':') && (argv[i][2] == '/')) )
+#endif
             {
                char *s;
                

--- a/src/vnmrbg/smagic.c
+++ b/src/vnmrbg/smagic.c
@@ -715,7 +715,7 @@ int smagicSendJvnmraddr(int portno) /* send Java vnmraddr */
     char smagicJaddr[MAXPATH];
     int val2;
     int i=1, getjfile=1;
-    char mstr[1024], kstr[64], kstr2[64], kstr3[64], kstr1[64];
+    char mstr[1024], kstr[MAXPATH+128], kstr2[64], kstr3[64], kstr1[64];
 /*  int newPort; */
 
     (void) portno;
@@ -729,7 +729,7 @@ int smagicSendJvnmraddr(int portno) /* send Java vnmraddr */
     sprintf(smagicJaddr,"%s %d %s",kstr1, newPort, kstr3);
 #endif
 **/
-    sprintf(kstr, "/tmp/vnmr%s", kstr3);
+    sprintf(kstr, "%s/tmp/vnmr%s", systemdir, kstr3);
     if (access( Jvbgname, F_OK ) == 0)
        unlink( Jvbgname );
     unlink( kstr );
@@ -3125,7 +3125,7 @@ static void jsendArrayInfo(int exnum )
 	  switch (i)
 	  {
 		case 0:
-	          strcpy(param,"ni");
+	          strcpy(param,"ni3");
 		  rank=ni_rank;
 		  break;
 		case 1:
@@ -3133,7 +3133,7 @@ static void jsendArrayInfo(int exnum )
 		  rank=ni2_rank;
 		  break;
 		case 2:
-	          strcpy(param,"ni3");
+	          strcpy(param,"ni");
 		  rank=ni3_rank;
 		  break;
 		default:

--- a/src/vnmrj/src/vnmr/ui/ExpPanel.java
+++ b/src/vnmrj/src/vnmr/ui/ExpPanel.java
@@ -1986,7 +1986,7 @@ public class ExpPanel extends JPanel
                     vnmrHostPort = a;
                     int  vnmrId = b;
                     outPort = new CanvasOutSocket(this, vnmrHostName, vnmrHostPort);
-                    String vpath = File.separator+"tmp"+File.separator+"vnmr"+vnmrId;
+                    String vpath = FileUtil.sysdir()+File.separator+"tmp"+File.separator+"vnmr"+vnmrId;
                     try {
                         PrintWriter os = new PrintWriter(new FileWriter(vpath));
                         if (os != null) {

--- a/src/vnmrj/src/vnmr/util/DisplayOptions.java
+++ b/src/vnmrj/src/vnmr/util/DisplayOptions.java
@@ -120,6 +120,7 @@ public class DisplayOptions extends ModelessDialog
     private static String m_interface_item="Default";
     private static int m_interface_type=SYSTEM;
     private static String m_interface_tab="Labels";
+    private static int screenRes=0;
     
     private static String m_graphics_item="Default";
     private static int m_graphics_type=SYSTEM;
@@ -1443,7 +1444,8 @@ public class DisplayOptions extends ModelessDialog
         path = FileUtil.savePath(getPersistenceFile(PLOT));
         writeStyles(path);
         
-        writeFonts();
+        path = FileUtil.savePath(getPersistenceFile(".Fontlist"));
+        writeFonts(path);
         m_tabsType=oldtabs;
 
     }
@@ -1677,7 +1679,8 @@ public class DisplayOptions extends ModelessDialog
             refLabel = new JLabel();
         try {
             os = new PrintWriter(new FileWriter(path));
-            int r = Toolkit.getDefaultToolkit().getScreenResolution();
+            if (screenRes == 0)
+               screenRes = Toolkit.getDefaultToolkit().getScreenResolution();
             if (defaultFont == null)
                  defaultFont = new GraphicsFont();
             else
@@ -1699,9 +1702,9 @@ public class DisplayOptions extends ModelessDialog
                      }
                  }
             }
-            if (r < 20)
-                r = 90;
-            os.println("ScreenDpi Screen "+r+" "+r+" "+r+" "+r);
+            if (screenRes < 20)
+                screenRes = 90;
+            os.println("ScreenDpi Screen "+screenRes+" "+screenRes+" "+screenRes+" "+screenRes);
         } catch(IOException er) {
             Messages.postError("DisplayOptions: can't write persistence file");
         }

--- a/src/vnmrj/src/vnmr/util/VnmrProcess.java
+++ b/src/vnmrj/src/vnmr/util/VnmrProcess.java
@@ -54,9 +54,10 @@ public class VnmrProcess implements Runnable {
            // exec and get back a Process class
            String cmd = "Vnmrbg master  -port "+socketPort+" -view "+id;
            if (Util.iswindows())
-               cmd = WGlobal.SHTOOLCMD + " " + WGlobal.SHTOOLOPTION +
-                            " \"" + FileUtil.SYS_VNMR + "/bin/Vnmrbg master -port " +
-                            socketPort + " -view " + id + "\"";
+           {
+               cmd = FileUtil.sysdir() + "/bin/Vnmrbg.exe master -port " +
+                            socketPort + " -view " + id;
+           }
            if (info != null)
                cmd = cmd + " "+info;
            chkit = rt.exec(cmd);


### PR DESCRIPTION
The rt and macrold commands handle windows-style files names
Fix bug that would hang up is a macro does not end with a carriage
return.
Move handshake file between Vnmrbg and vnmrj.jar from /tmp to
/vnmr/tmp. This means that if either Vnmrbg or vnmrj.jar is updated
on an older build, both need to be updated.
The array popup showed incorrect precedence for implict nD array
elements. (SpinSights bug)
When exiting vnmrj, a call to get the screen resolution could hangup
the exit process.