### PR TITLE
Updates to support Ubuntu

### DIFF
--- a/src/admin/src/LoadNmr.java
+++ b/src/admin/src/LoadNmr.java
@@ -150,6 +150,7 @@ public class LoadNmr extends JFrame {
         makeBtmPane();
         JTabbedPane tabbedPane = new JTabbedPane();
         tabbedPane.setBackground(Color.gray);
+        tabbedPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
 
 	if (dotnvExists==1) {
             String origVersion = checkPreviousVnmrVersion();
@@ -473,8 +474,8 @@ public class LoadNmr extends JFrame {
        rtPane[index] = new JPanel();
        rtPane[index].setLayout(new tabPanLayout());
        rtPane[index].add(panel1);
-       rtPane[index].add(new JSeparator());
-       rtPane[index].add(panel2);
+//       rtPane[index].add(new JSeparator());
+//       rtPane[index].add(panel2);
 
        return rtPane[index];
     }

--- a/src/admin/src/ProgressMonitor.java
+++ b/src/admin/src/ProgressMonitor.java
@@ -78,7 +78,7 @@ public class ProgressMonitor extends JFrame {
         userExist = userexist;
 	
 	if (shToolCmd == null)
-	    shToolCmd = "/bin/csh";
+	    shToolCmd = "/bin/bash";
 	if (shToolOption == null)
 	    shToolOption = "-c";
 

--- a/src/admin/src/VnmrAdmin.java
+++ b/src/admin/src/VnmrAdmin.java
@@ -50,7 +50,7 @@ public class VnmrAdmin extends JFrame {
     //                     "/export/home/chin/vadmin/group",
     //                     "/export/home/chin/vadmin/access"};
 
-    String         shToolCmd = "/bin/csh";
+    String shToolCmd  = "/bin/bash";
     String vnmrSystem = "/vnmr";
     String vnmrAdmin = "vnmr1";
     String dbUser="";

--- a/src/macos/vnmrj.sh
+++ b/src/macos/vnmrj.sh
@@ -47,7 +47,7 @@ for arg in $*; do
     arg02=$(echo $arg | cut -c1-2)
     if [ "x$debug_on" = "xyy" ]; then
         debug_on="y"
-        debugargs=$arg
+        debugargs="-Ddebug=$arg"
     elif [ "x$cmd_on" = "xy" ]; then
         cmd=$arg
         cmd_on="n"
@@ -67,7 +67,7 @@ for arg in $*; do
 done
 if [ "x$debug_on" = "xyy" ]; then
     debug_on="y"
-    debugargs="traceXML"
+    debugargs="-Ddebug=traceXML"
 fi
 if [ "x$splash" = "xy" ]; then
     splash=""
@@ -207,7 +207,7 @@ then
         -Dbatchupdates=no -Dpersona=$itype -Dsavepanels=10 -DSQAllowNesting=false \
         -Djava.library.path="/vnmr/lib" \
         -Djogamp.gluegen.UseTempJarCache="false" \
-        -Dsquish=$squish -DshowMem=$showmem -Ddebug="savedatasetup,$debugargs" -Ddbnet_server=$dbnet_server \
+        -Dsquish=$squish -DshowMem=$showmem $debugargs -Ddbnet_server=$dbnet_server \
         vnmr.ui.VNMRFrame
 
 else
@@ -223,7 +223,7 @@ else
           -Dsfudirwindows="$SFUDIR" -Dsfudirinterix="$SFUDIR_INTERIX" \
           -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption" -Dvjerrfile=custom \
           -Dbatchupdates=no -Dpersona=$itype -Dsavepanels=10 -DSQAllowNesting=false \
-          -Dsquish=$squish -Ddbnet_server=$dbnet_server -Ddebug="savedatasetup" \
+          -Dsquish=$squish -Ddbnet_server=$dbnet_server \
           -Djava.library.path="/vnmr/lib" \
           -Djogamp.gluegen.UseTempJarCache="false" \
            vnmr.ui.VNMRFrame >& /dev/null &

--- a/src/passwd/src/passwd.java
+++ b/src/passwd/src/passwd.java
@@ -10,9 +10,9 @@
 
 import java.io.*;
 import java.util.*;
+import javax.xml.bind.*;
 
 import java.security.*;
-import sun.misc.*;
 
 /**
  * <p>Title: </p>
@@ -51,7 +51,7 @@ public class passwd
         }
 
         byte raw[] = md.digest(); //step 4
-        String hash = (new BASE64Encoder()).encode(raw); //step 5
+        String hash = DatatypeConverter.printBase64Binary(raw); //step 5
         plaintext = "";
         return hash; //step 6
     }

--- a/src/scripts/create_pgsql_user.sh
+++ b/src/scripts/create_pgsql_user.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-# 
+#!/usr/bin/env bash
 #
 # Copyright (C) 2015  University of Oregon
 # 
@@ -33,7 +32,7 @@ then
     $vnmrsystem/pgsql/bin/createuser -d -a -q $1
 else
     # New one, use no path and appropriate args
-    createuser -d -S -R $1
+    createuser -d -S -R $1 2> /dev/null
 fi
 
 echo "DONE"

--- a/src/scripts/makeuser.sh
+++ b/src/scripts/makeuser.sh
@@ -1,5 +1,4 @@
-: /bin/sh
-# '@(#)makeuser.sh 1991-2009 '
+#/usr/bin/env bash
 # 
 #
 # Copyright (C) 2015  University of Oregon
@@ -552,12 +551,12 @@ else  #current user is root
                 if [ "x$name_add" = "xvnmr1" ] ; then
                     sudo /usr/sbin/useradd --create-home --home-dir "$dir_name/$name_add" \
                          --shell /bin/bash --uid $num --gid "$nmr_group" \
-                         --groups admin,cdrom,floppy,audio,video,plugdev,fuse,lpadmin,adm \
+                         --groups admin,cdrom,floppy,audio,video,plugdev,lpadmin,adm \
                          --password '$1$LEdmx.Cm$zKS4GXyvUzjNLucQBNgwR1' "$name_add"
                 else
                     sudo /usr/sbin/useradd --create-home --home-dir "$dir_name/$name_add" \
                          --shell /bin/bash --uid $num --gid "$nmr_group" \
-                         --groups cdrom,floppy,audio,video,plugdev,fuse,lpadmin \
+                         --groups cdrom,floppy,audio,video,plugdev,lpadmin \
                          --password '$1$LEdmx.Cm$zKS4GXyvUzjNLucQBNgwR1' "$name_add"
                 fi
                 sudo chmod 755 "$dir_name/$name_add"
@@ -710,9 +709,7 @@ else  #current user is root
 	fi
 	if [ x$ostype != "xInterix" ] 
 	then 
-	    su - "$name_add" -c "/vnmr/bin/makeuser '$1' '$cur_homedir' '$nmr_group' $user_update '$vnmrsystem'" << +++
-
-+++
+	    su - "$name_add" -c "/vnmr/bin/makeuser '$1' '$cur_homedir' '$nmr_group' $user_update '$vnmrsystem'" 2> /dev/null
 	    exit
 	fi
     fi

--- a/src/scripts/managedb.sh
+++ b/src/scripts/managedb.sh
@@ -19,19 +19,11 @@ if ( $id == "root" ) then
    exit
 endif
 
-set ostype=`uname -s`
-
 # USER is not correct sometimes, so fix it
 set USER = $id
 
 # HOME, vnmruser and other env variables are wrong when executed
 # from exec_asuser in Windows, so we need to fix them here.
-
-if ( x$ostype == "xInterix" ) then
-    cd ~$USER
-    set HOME = "`pwd`"
-    source .vnmrenv
-endif
 
 if ( ! "$?vnmrsystem" ) then
     set vnmrsystem = /vnmr
@@ -86,20 +78,11 @@ set shtooloption="-c"
 set sfudir=""
 set sfudir_interix=""
 set javacmd="$vnmrsystem/jre/bin/java"
+if ( ! -f $javacmd ) then
+   set javacmd="java"
+endif
 set vjclasspath="$vnmrsystem/java/managedb.jar"
 set sysdir="$vnmrsystem"
-if ( x$ostype == "xInterix" ) then
-   set vjclasspath=`/bin/unixpath2win "$vjclasspath"`
-   set sfudir="$SFUDIR"
-   set sfudir_interix="$SFUDIR_INTERIX"
-   set shtoolcmd="$SFUDIR\\common\\ksh.bat"
-   set shtooloption="-lc"
-   set javacmd="$vnmrsystem/jre/bin/java.exe" 
-   if ( ! -f "$javacmd" ) then
-    set javacmd="java.exe"
-   endif
-   set sysdir=`/bin/unixpath2win "$vnmrsystem"`
-endif
 
 $javacmd -mx256m -classpath $vjclasspath -Dsysdir="$sysdir" -Duserdir="$tmpdir" -Ddbhost=$dbhost -Ddbport=$dbport -Ddbnet_server=$dbnet_server  -Djava.compiler=sunwjit  -Dsfudirwindows="$sfudir" -Dsfudirinterix="$sfudir_interix" -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption" -Ddebug="$debugargs" -Duser.name=$id vnmr.ui.shuf.FillDBManager $argv[*]
 

--- a/src/scripts/ovjPasswd.sh
+++ b/src/scripts/ovjPasswd.sh
@@ -16,10 +16,18 @@ then
    vnmrsystem=/vnmr
 fi
 
+modsArg=""
+vers=$(java -fullversion 2>&1 | awk 'BEGIN {FS="\""} {print $2}' | awk 'BEGIN {FS="."} {print $1}')
+if [[ $vers > 8 ]]
+then
+  modsArg="--add-modules java.xml.bind"
+fi
+
+
 if [[ $# -eq 1 ]] ; then
-   ovjPasswd=$(java -jar ${vnmrsystem}/java/passwd.jar $1)
+   ovjPasswd=$(java $modsArg -jar ${vnmrsystem}/java/passwd.jar $1)
 else
-   ovjPasswd=$(java -jar ${vnmrsystem}/java/passwd.jar)
+   ovjPasswd=$(java $modsArg -jar ${vnmrsystem}/java/passwd.jar)
 fi
 
 echo ${ovjPasswd}

--- a/src/scripts/setupbashenv.sh
+++ b/src/scripts/setupbashenv.sh
@@ -1,4 +1,4 @@
-: /bin/sh
+#!/usr/bin/env bash
 #
 # script to modify the .profile and .bashrc to source the
 # .vnmrenvbash file

--- a/src/scripts/vnmrj.sh
+++ b/src/scripts/vnmrj.sh
@@ -47,7 +47,7 @@ for arg in $*; do
     arg02=$(echo $arg | cut -c1-2)
     if [ "x$debug_on" = "xyy" ]; then
         debug_on="y"
-        debugargs=$arg
+        debugargs="-Ddebug=$arg"
     elif [ "x$cmd_on" = "xy" ]; then
         cmd=$arg
         cmd_on="n"
@@ -67,7 +67,7 @@ for arg in $*; do
 done
 if [ "x$debug_on" = "xyy" ]; then
     debug_on="y"
-    debugargs="traceXML"
+    debugargs="-Ddebug=traceXML"
 fi
 if [ "x$splash" = "xy" ]; then
     splash=""
@@ -207,7 +207,7 @@ then
         -Dbatchupdates=no -Dpersona=$itype -Dsavepanels=10 -DSQAllowNesting=false \
         -Djava.library.path="/vnmr/lib" \
         -Djogamp.gluegen.UseTempJarCache="false" \
-        -Dsquish=$squish -DshowMem=$showmem -Ddebug="savedatasetup,$debugargs" -Ddbnet_server=$dbnet_server \
+        -Dsquish=$squish -DshowMem=$showmem $debugargs -Ddbnet_server=$dbnet_server \
         vnmr.ui.VNMRFrame
 
 else
@@ -221,7 +221,7 @@ else
           -Dsfudirwindows="$SFUDIR" -Dsfudirinterix="$SFUDIR_INTERIX" \
           -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption" -Dvjerrfile=custom \
           -Dbatchupdates=no -Dpersona=$itype -Dsavepanels=10 -DSQAllowNesting=false \
-          -Dsquish=$squish -Ddbnet_server=$dbnet_server -Ddebug="savedatasetup" \
+          -Dsquish=$squish -Ddbnet_server=$dbnet_server \
           -Djava.library.path="/vnmr/lib" \
           -Djogamp.gluegen.UseTempJarCache="false" \
            vnmr.ui.VNMRFrame >& /dev/null &

--- a/src/vnmrj/src/vnmr/ui/PasswordService.java
+++ b/src/vnmrj/src/vnmr/ui/PasswordService.java
@@ -11,9 +11,9 @@ package vnmr.ui;
 
 import java.io.*;
 import java.util.*;
+import javax.xml.bind.*;
 
 import java.security.*;
-import sun.misc.*;
 
 /**
  * <p>Title: </p>
@@ -54,7 +54,7 @@ public class PasswordService
         }
 
         byte raw[] = md.digest(); //step 4
-        String hash = (new BASE64Encoder()).encode(raw); //step 5
+        String hash = DatatypeConverter.printBase64Binary(raw); //step 5
         plaintext = "";
         return hash; //step 6
     }


### PR DESCRIPTION
When running java 1.6 from /vnmr/jre, vnmrj errored with "cannot load system
cursor". Switching to use the java 9 installed on ubuntu resulted in error
NoClassDefFoundError for sum.misc.BASE64Encoder, which has been deprecated.
Switched to DatatypeConverter (javax.xml.bind).
Replace csh to bash in vnmrj installer. Fixed several scripts used during
installation.