### PR TITLE
Modal popup fpBrowser forced to front of other windows.

### DIFF
--- a/src/vnmrj/src/vnmr/ui/ExpPanel.java
+++ b/src/vnmrj/src/vnmr/ui/ExpPanel.java
@@ -3772,6 +3772,7 @@ public class ExpPanel extends JPanel
     private static VJOpenPopup openPanel=null;
     private static VJSavePopup savePanel=null;
     private static VJFileBrowser browserPanel=null;
+    private static JDialog fpDialog = null;
     private static JFileChooser fpPanel = null;
     
     // static method to reset browsers and profile panel to null.  This
@@ -3827,11 +3828,15 @@ public class ExpPanel extends JPanel
     private void openFpBrowser(String cmd) {
         File dir;
 
-        if (fpPanel == null) {
+        if (fpDialog == null) {
+             fpDialog = new JDialog();
              fpPanel = new JFileChooser();
+             fpDialog.add(fpPanel);
              fpPanel.setApproveButtonText("OK");
              fpPanel.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
              fpPanel.setMultiSelectionEnabled(true);
+             fpDialog.setAlwaysOnTop(true);
+             fpDialog.toFront();
              String f = (String)sshare.getProperty("fpDir");
              if (f == null) {
                  f = FileUtil.openPath("USER"+File.separator+"fingerprintlib");
@@ -3845,7 +3850,7 @@ public class ExpPanel extends JPanel
              }
              SwingUtilities.updateComponentTreeUI(fpPanel);
         }
-        int ret = fpPanel.showOpenDialog(null);
+        int ret = fpPanel.showOpenDialog(ModelessPopup.getContainer() );
         if (ret != JFileChooser.APPROVE_OPTION)
              return;
         File[] files = fpPanel.getSelectedFiles();

--- a/src/vnmrj/src/vnmr/ui/shuf/UpdateDatabase.java
+++ b/src/vnmrj/src/vnmr/ui/shuf/UpdateDatabase.java
@@ -20,7 +20,7 @@ import java.awt.image.*;
 import java.awt.event.*;
 import java.lang.reflect.*;
 import java.awt.*;
-import sun.awt.SunToolkit;
+// import sun.awt.SunToolkit;
 import java.text.*;
 
 
@@ -264,6 +264,7 @@ public class UpdateDatabase extends Thread {
      *  other processes like vnmrbg running and needing time.
      </pre> **************************************************/
 
+/*
     public synchronized void waitForIdle() {
 
         // ** Perhaps move this to a higher level so it is not called so much
@@ -292,5 +293,6 @@ public class UpdateDatabase extends Thread {
                                                 "the event dispatcher thread");
         }
     }
+ */
 
 }

--- a/src/vnmrj/src/vnmr/util/ModelessPopup.java
+++ b/src/vnmrj/src/vnmr/util/ModelessPopup.java
@@ -26,11 +26,12 @@ public class ModelessPopup extends ModelessDialog
     protected AppIF appIf;
     protected SessionShare sshare;
 //
-    protected JPanel            panel=null;
+    protected static JPanel            panel=null;
     private JScrollPane       scrollPane=null;
 
     protected boolean m_bRebuild = false;
     protected boolean m_bNewXml = false;
+    protected static boolean visible = false;
     protected int m_nWidth;
     private String m_strXmlFile;
     protected String m_closeCmd="";
@@ -49,6 +50,12 @@ public class ModelessPopup extends ModelessDialog
                          String helpFile, String closeCmd) {
         super(title);
         buildUi(ss,vif,aif,xmlfile,width,height,bRebuild, helpFile,closeCmd);
+    }
+
+    public static JPanel getContainer() {
+       if ( (panel == null) || (visible == false ) )
+          return null;
+       return panel;
     }
 
     private void buildUi(SessionShare ss, ButtonIF vif, AppIF aif,
@@ -117,6 +124,7 @@ public class ModelessPopup extends ModelessDialog
     public void setVisible(boolean bVisible)
     {
         boolean bUpdate = false;
+        visible = bVisible;
 
         if (!isVisible() && bVisible)
             bUpdate = true;


### PR DESCRIPTION
Since fpBrowser is modal, if it is behind other OVJ windows,
one cannot bring it forward.  This fixes that problem.
Also removed unused code that was giving deprecation warnings.