### PR TITLE
pulsetool compiled in 64bit mode. Uses 64-bit motif

### DIFF
--- a/src/bin/SConstruct.pulsetool
+++ b/src/bin/SConstruct.pulsetool
@@ -16,21 +16,17 @@ pulseChildFileList = ['pulsechild.c',
                       'pulsechild_mf.c']
 
 # build environments
-pulseEnv = Environment(CCFLAGS    = '-O2 -m32',
+pulseEnv = Environment(CCFLAGS    = '-O2',
                        CPPDEFINES = ['LINUX'],
-                       LINKFLAGS  = '-m32 -Wl,-rpath,/vnmr/lib ')
+                       LINKFLAGS  = '-Wl,-rpath,/vnmr/lib ')
 
 # actual builds
 pulsetool = pulseEnv.Program(target  = pulsetoolTarget,
                              source  = [pulseToolFileList],
-                             LIBPATH = [os.path.join(os.sep, 'usr', 'X11R6', 'lib'),
-                                        os.path.join(os.sep, 'usr', 'lib32', 'i386-linux-gnu')],
                              LIBS    = ['Xm', 'Xt', 'X11', 'm'])
 
 pulsechild = pulseEnv.Program(target  = pulsechildTarget,
                               source  = [pulseChildFileList],
-                              LIBPATH = [os.path.join(os.sep, 'usr', 'X11R6', 'lib'),
-                                        os.path.join(os.sep, 'usr', 'lib32', 'i386-linux-gnu')],
                               LIBS    = ['Xm', 'Xt', 'X11', 'm'])
 
 # define with absolute path where built files will be copied

--- a/src/tcl/SConstruct.vnmrwish
+++ b/src/tcl/SConstruct.vnmrwish
@@ -39,13 +39,12 @@ env = Environment(CCFLAGS    = '-fPIC -g -c -Wall -O -m32',
 
 # actual build
 vnmrwish = env.Program(target  = vnmrwishTarget,
-                       LIBPATH = [os.path.join(os.sep + 'usr', 'X11R6', 'lib'),
-                                  ncommPath,
+                       LIBPATH = [ncommPath,
                                   os.path.join(ovjtools, 'tcl', 'srcTk'),
                                   os.path.join(ovjtools, 'tcl', 'srcTcl'),
                                   os.path.join(os.sep, 'vnmr', 'lib' )],
                        source  = [tclCSrcFileList],
-                       LIBS    = ['tk8.4', 'tcl8.4', 'acqcomm', 'X11','m'])
+                       LIBS    = ['tk8.4', 'tcl8.4', 'acqcomm', 'm'])
 
 # define with absolute path where built files will be copied
 installPath = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'vnmr', 'tcl', 'bin')


### PR DESCRIPTION
pulsetool is the only program the uses motif. Also,
vnmrwish does not need to link X11.