### PR TITLE
Updates to vnmrj.jar

### DIFF
--- a/src/vnmrj/src/vnmr/bo/VGroup.java
+++ b/src/vnmrj/src/vnmr/bo/VGroup.java
@@ -381,6 +381,18 @@ to be done in setEditMode()
         if (inEditMode)
            return;
 
+        if (reference != null && expanded != null && expanded.equals("rebuild") )
+        {
+            if (hasVariable(this, params) != null)
+            {
+               Util.dorebuild = true;
+               setvisible(false);
+               removeAll();
+               invalidate();
+               return;
+            }
+        }
+
         if (showVal != null && hasVariable(this, params) != null) {
             bNeedUpdate = true;
             vnmrIf.asyncQueryShow(this, showVal);

--- a/src/vnmrj/src/vnmr/ui/ExpPanel.java
+++ b/src/vnmrj/src/vnmr/ui/ExpPanel.java
@@ -969,7 +969,6 @@ public class ExpPanel extends JPanel
          updateTools(true);
          queryPanelInfo();
          if (active) {
-             Messages.postDebug("start UI  ");
              setParamPanels();
              VTabbedToolPanel vToolPanel = Util.getVTabbedToolPanel();
              if(vToolPanel != null) vToolPanel.updateValue();
@@ -1210,6 +1209,7 @@ public class ExpPanel extends JPanel
         if ( bSuspendPnew ) {
             return;
         }
+        Util.dorebuild = false;
 
         // Messages.postDebug("pnew", "ExpPanel.processPnew(): " + str);
         queryCount = 0;
@@ -1360,6 +1360,11 @@ public class ExpPanel extends JPanel
                    break;
                }
             }
+        }
+        if (Util.dorebuild)
+        {
+           Util.rebuildUI();
+           Util.dorebuild = false;
         }
         if (bVerbose)
             System.out.println("Exp "+winId+":  total pnew query count "+queryCount);

--- a/src/vnmrj/src/vnmr/ui/VNMRFrame.java
+++ b/src/vnmrj/src/vnmr/ui/VNMRFrame.java
@@ -809,6 +809,9 @@ public class VNMRFrame extends JFrame implements AppInstaller {
     public static boolean usesDatabase() {
     	return useDatabase;
     }
+    public static void setNoDatabase() {
+    	useDatabase = false;
+    }
 
     private void initAppDirs(String path, ArrayList appDirectories, ArrayList appDirLabels) {
         // read persistence file

--- a/src/vnmrj/src/vnmr/ui/VnmrjUI.java
+++ b/src/vnmrj/src/vnmr/ui/VnmrjUI.java
@@ -184,10 +184,13 @@ public class VnmrjUI extends AppIF implements VnmrjIF, VnmrKey, DockConstants, V
         if (sshare == null) {
             sshare = new SessionShare(appInstaller, user);
         }
+        if (FillDBManager.locatorOff())
+            VNMRFrame.setNoDatabase();
         if (!bReBuild) {
             sshare.setAppInstaller(appInstaller);
             sshare.setUser(user);
-            sshare.FillLocatorHistoryList();
+            if (!FillDBManager.locatorOff())
+               sshare.FillLocatorHistoryList();
         }
         Util.setAppIF(this);
         Util.setUser(user);

--- a/src/vnmrj/src/vnmr/util/Util.java
+++ b/src/vnmrj/src/vnmr/util/Util.java
@@ -51,6 +51,7 @@ public class Util implements VnmrKey {
     public static String OSNAME = System.getProperty("os.name");
     public static final String SFUDIR_WINDOWS = System.getProperty("sfudirwindows");
     public static final String SFUDIR_INTERIX = System.getProperty("sfudirinterix");
+    public static boolean dorebuild = false;
     /** cache for image icons */
     private static final Hashtable<String,ImageIcon> iconCache
             = new Hashtable<String,ImageIcon>();
@@ -1799,7 +1800,7 @@ public class Util implements VnmrKey {
 	    Messages.postDebug("### appDir "+i+" "+(String)appDirs.get(i));
 	
         if(user.setAppDirs(appDirs, labels) && rebuild) {
-            Messages.postDebug("### rebuildUI");
+                // Messages.postDebug("### rebuildUI");
                 rebuildUI();
         }
 


### PR DESCRIPTION
Added "rebuild" option to xml popups. If the text file on which the popup is based
is changed, setting the "expanded" field to rebuild and changing a parameter
it is watching (vq field) will cause the popup to re-read the text file.
Also, avoid doing unneeded work it the Locator is turned off.