### PR TITLE
Suppress warnings from dps if pulse sequence does not exist

### DIFF
--- a/src/common/maclib/cpsetup
+++ b/src/common/maclib/cpsetup
@@ -250,7 +250,7 @@ if (gcflg='n') then
     elseif (wds <> '') and (procdim=2) then
 	dconi
     else
-   	dps
+   	dps:$dum
     endif
 endif
 "*******************************************************"

--- a/src/vnmr/dps.c
+++ b/src/vnmr/dps.c
@@ -2426,7 +2426,8 @@ int check_args(int argc, char *argv[], int retc, char *retv[])
             {
                 strcpy(psgfile, sfile);
                 if ( ! timeFlag)
-	           Werrprintf("dps error: file '%s(.psg)' does not exist", psgfile);
+                   if (retc == 0)
+	              Werrprintf("dps error: file '%s(.psg)' does not exist", psgfile);
                 return(0);
             }
             if (cFound == 0)


### PR DESCRIPTION
Controlled by requesting a return value, as in dps:$dum