### PR TITLE
Still need 32-bit X11 and Xt packages, but not 32-bit motif

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ jobs: # a collection of steps
             sudo apt-get -qq update
             sudo apt-get install -y gcc g++ gfortran gcc-multilib scons \
                 libc6-dev-i386 lib32stdc++-6-dev libglu1-mesa-dev \
-                liblapack-dev liblapacke-dev libfftw3-dev
+                liblapack-dev liblapacke-dev libfftw3-dev libmotif-dev libxt-dev
             sudo dpkg --add-architecture i386
             sudo apt-get -qq update
-            sudo apt-get install -y libmotif-dev:i386 libxt-dev:i386 libx11-dev:i386
+            sudo apt-get install -y libxt-dev:i386 libx11-dev:i386
             echo "dash dash/sh boolean false" | sudo debconf-set-selections
             DEBIAN_FRONTEND=noninteractive sudo dpkg-reconfigure dash
             java -version


### PR DESCRIPTION
This was originally PR #280 but I mistakenly asked that the
32-bit X11 and Xt packages also be removed. This broke the
"stat" category build. This is the same as Michael's first
commit in PR #280. Will delete that one.