### PR TITLE
Changes to improve the speed of OpenVnmrJ

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,11 +1,33 @@
 OpenVnmrJ Release Notes.
 
-Feb 2019
-    Fixed bugs reported in SpinSights:
+Aug 2019
+    An installpkgs script to install required CentOS packages. This means
+      that a "CentOS kickstart" is not needed. 
+    MacOS version is 64-bit
+    As a datastation, OpenVnmrJ can be installed on Ubuntu 14, 16, and 18.
+    Added new command paramcopy (see manual/paramcopy)
+    Added new command flush2 (see manual/flush2)
+    Added new command append (see manual/append)
+    Added new command sortCmd (see manual/sortCmd)
+    Added new command touch (see manual/touch)
+    Added new command chmod (see manual/chmod)
+    New 'link' and 'symlink' options to the cp command (see manual/cp)
+    New options for readfile (see manual/readfile)
+    New options for getfile (see manual/getfile)
+    New 'parfile' option for exists (see manual/exists)
+    New 'expand' option for format (see manual/format)
+    New 'tr' option for substr (see manual/substr)
+    New '-R' option for rm (see manual/rm)
+    New phasing option for ds (see manual/ds)
+    Toggle and Button XML widgets support label justification
+    Fixed bugs and feature requests reported in SpinSights: (thanks to Bert Heise)
        trtune could fail due to expanded spectral region (require f command)
        Hdec calibration may plot WALTZ profile with wrong phases
        Fobs_Hdec doesn't work (makeFHdecshape)
        VeriPulse may produce text-only report
+       Ndec autocalibration may not work
+       mtune enhancement
+       Could not set FTS to negative temperture
 
 Dec 2018
     Fixed several bugs reported in SpinSights:
@@ -15,13 +37,12 @@ Dec 2018
        mz did not work between spectrometers
        mtune and trtune could fail due to missing hfmode parameter
        addprobe gives an error if probe name not supplied as an argument.
-       For the "Calibrate pw90" function,  it supports an optional userpw90proc macro
-         to allow for additional parameter adjustments.
+       For the "Calibrate pw90" function,  it supports an optional
+         userpw90proc macro to allow for additional parameter adjustments.
        pw90proc could fail with a division by zero.
        VeriPulse was missing P31 pw calibrations for ID probes.
-       protune could cause automation to stop even if the "Skip sample if protune fails"
-         is set to "no"
-       
+       protune could cause automation to stop even if the "Skip sample
+         if protune fails" is set to "no"
 
 Nov 2018
     New options to the makefid command (see manual/makefid)

--- a/src/common/maclib/loadcolors
+++ b/src/common/maclib/loadcolors
@@ -32,13 +32,13 @@ if ($e > 0.5) then
   $vp=''
   format(jviewport,0,0):$vp
   $pFile='PlOtTeR'+$vp
-  shell('rm -f /vnmr/tmp/'+$pFile):$e
-  shell('(ln -s "'+$colorfile+'" /vnmr/tmp/'+$pFile+' 2>/dev/null)'):$e
-
-  macrold('/vnmr/tmp/'+$pFile):$dummy
+  $pPath=userdir+'/persistence/'+$pFile
+  delete($pPath,''):$dummy
+  copy($colorfile,$pPath,'symlink'):$e
+  macrold($pPath):$dummy
   exec($pFile):$e
   purge($pFile)
-  shell('rm -f /vnmr/tmp/'+$pFile):$e
+  delete($pPath):$dummy
   if (maxpen > 1) then
      setcolor('plotter',1,3)
   else

--- a/src/common/maclib/newdg
+++ b/src/common/maclib/newdg
@@ -1,9 +1,2 @@
-"macro newdg"
-" newdg - updates new dg panels"
-isvnmrj:$j
-if ($j<0.5) then
-  if ($# < 1) then $1=seqfil endif
-  tcl('set seqfil '+$1+';set curexp '+curexp)
-else
-  vnmrjcmd('pnew','seqfil','layout')
-endif
+"macro newdg updates panels"
+vnmrjcmd('pnew','seqfil','layout')

--- a/src/common/maclib/tmpreturn
+++ b/src/common/maclib/tmpreturn
@@ -14,7 +14,7 @@ else
    exists(curexp + '/' + $1 + '/fid', 'file'):$isthere
    if ($isthere > 0.5) then
       if ($# < 2) then
-         flush
+         flush2
       endif
       $type = 'fid'
       mv('-f',curexp+'/' + $1 + '/fid',curexp+'/acqfil/fid')

--- a/src/common/maclib/tmpsqcopy
+++ b/src/common/maclib/tmpsqcopy
@@ -5,15 +5,15 @@ if ($# < 1) then return endif
    $dir=cursqexp+'/'+$1
    exists($dir,'file'):$isthere
    if ($isthere > 0.5) then
-	shell('rm -rf '+$dir):$dum
+	rm('-rf',$dir):$dum
    endif
-   shell('mkdir -p '+$dir):$dum
-   shell('cp -p '+curexp+'/acqfil/fid '+$dir+'/fid >& /dev/null'):$dum
-   shell('cp -p '+curexp+'/datdir/data '+$dir+'/data >& /dev/null'):$dum
-   shell('cp -p '+curexp+'/datdir/phasefile '+$dir+'/phasefile >& /dev/null'):$dum
-   shell('cp -p '+curexp+'/procpar '+$dir+'/procpar >& /dev/null'):$dum
-   shell('cp -p '+curexp+'/curpar '+$dir+'/curpar >& /dev/null'):$dum
-   shell('cp -p '+curexp+'/text '+$dir+'/text >& /dev/null'):$dum
-   shell('cp -p '+curexp+'/sampling.sch '+$dir+'/cur_sampling.sch >& /dev/null'):$dum
-   shell('cp -p '+curexp+'/acqfil/sampling.sch '+$dir+'/sampling.sch >& /dev/null'):$dum
+   mkdir('-p',$dir):$dum
+   cp('-p',curexp+'/acqfil/fid',$dir+'/fid'):$dum
+   cp('-p',curexp+'/datdir/data',$dir+'/data'):$dum
+   cp('-p',curexp+'/datdir/phasefile',$dir+'/phasefile'):$dum
+   cp('-p',curexp+'/procpar',$dir+'/procpar'):$dum
+   cp('-p',curexp+'/curpar',$dir+'/curpar'):$dum
+   cp('-p',curexp+'/text',$dir+'/text'):$dum
+   cp('-p',curexp+'/sampling.sch',$dir+'/cur_sampling.sch'):$dum
+   cp('-p',curexp+'/acqfil/sampling.sch',$dir+'/sampling.sch'):$dum
    clear(2)

--- a/src/common/maclib/tmpsqreturn
+++ b/src/common/maclib/tmpsqreturn
@@ -8,55 +8,52 @@ walkupQ_init
 //      before copying from the temporary directory
 //      Similar approach is taken for all files in curexp
 
-   flush
+   flush2
    $oldseq=seqfil
    exists($dir+'/fid','file'):$isthere
    if ($isthere>0.5) then
-      shell('rm -f '+curexp+'/acqfil/fid'):$dum
-      shell('cp -p '+$dir+'/fid '+curexp+'/acqfil/fid'):$dum
+     mv($dir+'/fid',curexp+'/acqfil/fid')
    endif
 
-   rm('-f',curexp+'/acqfil/sampling.sch'):$dum
+   delete(curexp+'/acqfil/sampling.sch',''):$dum
    exists($dir+'/sampling.sch','file'):$isthere
    if ($isthere>0.5) then
-        shell('cp -p '+$dir+'/sampling.sch '+curexp+'/acqfil/sampling.sch'):$dum
+     mv($dir+'/sampling.sch',curexp+'/acqfil/sampling.sch')
    endif
 
    exists($dir+'/data','file'):$isthere
    if ($isthere>0.5) then
-      shell('rm -f '+curexp+'/datdir/data'):$dum
-      shell('cp -p '+$dir+'/data '+curexp+'/datdir/data'):$dum
+      mv($dir+'/data',curexp+'/datdir/data')
    endif
 
    exists($dir+'/phasefile','file'):$isthere
    if ($isthere>0.5) then
-      shell('rm -f '+curexp+'/datdir/phasefile'):$dum
-      shell('cp -p '+$dir+'/phasefile '+curexp+'/datdir/phasefile'):$dum
+      mv($dir+'/phasefile',curexp+'/datdir/phasefile')
    endif
 
    exists($dir+'/procpar','file'):$isthere
    if ($isthere>0.5) then
-      shell('cp -p '+$dir+'/procpar '+curexp+'/procpar'):$dum
+      mv($dir+'/procpar',curexp+'/procpar')
       fread(curexp+'/procpar','processed','reset')
    endif
 
    exists($dir+'/curpar','file'):$isthere
    if ($isthere>0.5) then
-      shell('cp -p '+$dir+'/curpar '+curexp+'/curpar'):$dum
+      mv($dir+'/curpar',curexp+'/curpar')
       fread(curexp+'/curpar','current','reset')
    endif
 
    exists($dir+'/text','file'):$isthere
    if ($isthere>0.5) then
-      shell('cp -p '+$dir+'/text '+curexp+'/text'):$dum
+      mv($dir+'/text',curexp+'/text')
    endif
 
-   rm('-f',curexp+'/sampling.sch'):$dum
+   delete(curexp+'/sampling.sch',''):$dum
    exists($dir+'/cur_sampling.sch','file'):$isthere
    if ($isthere>0.5) then
-        shell('cp -p '+$dir+'/cur_sampling.sch '+curexp+'/sampling.sch'):$dum
+        mv($dir+'/cur_sampling.sch',curexp+'/sampling.sch')
    endif
 
-   shell('rm -rf '+$dir):$dum
+   rm('-rf',$dir):$dum
 
    if ($oldseq<>seqfil) then dg newdg endif

--- a/src/common/maclib/updaterev
+++ b/src/common/maclib/updaterev
@@ -13,6 +13,8 @@ $sav=saveglobal
 fread(userdir+'/global','global','value')
 saveglobal=$sav
 fread(userdir+'/global','global','newonly')
+destroy('probeid','global'):$e
+destroy('probeiden','global'):$e
 
 if (dsp='i' or dsp='r') then
   exists(systemdir+'/psg/psmain.cpp','file'):$e

--- a/src/common/manual/append
+++ b/src/common/manual/append
@@ -1,0 +1,108 @@
+
+*******************************************************************************
+append(fromFile,<filters>,toFile)  - append the contents of fromFile to toFile.
+*******************************************************************************
+
+The append command will append the contents of "fromFile" to "toFile".
+The fromFile and toFile cannot be the same file. If toFile does not exist,
+it will be created.
+
+There can be optional tests to determine if a given line from fromFile will be
+appended. These filters take the form of a keyword test and a test phase.
+In the case of 'sed', 'sed g', and 'tr', two arguments are required.
+The following filters are available
+
+'grep',<search phrase>       - if a given line contains the <search phrase>, it
+                             will be appended to toFile
+
+'grep -v',<search phrase>    - if a given line contains the <search phrase>, it
+                             will not be appended to toFile
+
+'grep -w',<search word>      - if a given line contains the <search word>, it
+                             will be appended to toFile
+
+'grep -vw',<search word>     - if a given line contains the <search word>, it
+                             will not be appended to toFile
+
+'awk',<format>               - replace the line with the format string. Words
+                             from the original line are available at $1, etc.
+                             $0 represents the entire line.
+
+'sed',<regexp>,<replacement> - Match <regexp> and replace it with the <replacement>
+                               This is like the sed -e 's/regexp/replacement/' command
+                               in Linux.
+
+'sed g',<regexp>,<replacement> - Globally match <regexp> and replace it with the
+                               <replacement>
+                               This is like the sed -e 's/regexp/replacement/g' command
+                               in Linux.
+
+'tr',<chars>,<replacement> -   Translate or delete the characters that match
+                               those in <chars>.  The newline, linefeed, or tab characters
+                               may be specified in <chars> by using \n, \r, or \t
+                               respectively.  If <replacement> is a single character,
+                               the characters matching those in <chars> will be replaced.
+                               If <replacement>  is a null string, the characters
+                               matching those in <chars> will be deleted.
+                               This is similar to the "tr" command in Linux.
+
+'head',<count>               - Only append the top <count> number of lines
+
+'tail',<count>               - Only append the last <count> number of lines
+
+'tail','+<count>'            - Append lines starting from line <count>. If the
+                             +<count> is used, it must be enclosed in single
+                             quotes, as in '+5'
+
+If the <search phase> or <search word> starts with the '^' character, the match
+must occur at the beginning of the line.
+
+The 'head' and 'tail' filters can each only be used once in a single call to append.
+The awk, sed, grep filters may be used multiple times.
+
+If toFile is '|wc', instead of appending the lines at a file, the number of
+lines that would have been written can be returned to the calling macro. This is a
+way of getting line counts. If additional return variables are given,  then one
+can return to the calling macro the lines that would have been appended. For example,
+append(<fromFile>,'grep','something','grep -v'.'something else','|wc'):$num,$line1,$line2,...
+
+Following are some examples of shell calls and the
+equivalent append calls. If lines are appended to toFile, then append will return
+either a 1 or 0 for success or failure, respectively.
+
+shell('cat <fromFile> >> <toFile>')
+can be replaced with
+append(<fromFile>,<toFile>)
+
+shell('cat <fromFile> | wc -l'):$num
+can be replaced with
+append(<fromFile>,'|wc'):$num
+
+shell('cat <fromFile> | grep "test a" | grep -v "test b" >> <toFile>')
+can be replaced with
+append(<fromFile>,'grep','test a','grep -v','test b',<toFile>)
+
+shell('cat <fromFile> | grep "test a" | grep -v "test b" | wc -l'):$num
+can be replaced with
+append(<fromFile>,'grep','test a','grep -v','test b','|wc'):$num
+
+shell('cat <fromFile> | grep "test a" | head -n 10 | tail -n 3 >>  <toFile>')
+can be replaced with
+append(<fromFile>,'grep','test a','head','10','tail','3',<toFile>):$ok
+
+If a file contained lines with two numbers on each line, the following would swap
+the order of the two numbers on each line.
+
+append(<fromFile>,'awk','$2  $1',<toFile>)
+
+If <fromFile> contained the phrase "here and here"
+append(<fromFile>,'sed','her.','there',<toFile>)
+would write "there and here" to <toFile>
+append(<fromFile>,'sed g','her.','there',<toFile>)
+would write "there and there" to <toFile>
+See Linux "man -s 7 regex" for a description of regular expressions that can be used.
+
+If a file is in "dos" format, where lines are terminated with the characters
+linefeed - newline, the following behaves effectively like the "dos2unix" command.
+
+append(<fromFile>,'tr','\r','',<toFile>)

--- a/src/common/manual/copy
+++ b/src/common/manual/copy
@@ -8,14 +8,19 @@ cp 	-
   All arguments are passed.  If a return argument is used, it will be set to
   1 or 0, for success or failure, respectively.  If an illegal file name is
   used, the command will abort. It will not set the return value.
-  An optional third argument is symlink. In this is used, the copy will be a
-  symbolic link to the first file.
+  An optional third argument can be link or symlink. If this is used, the copy
+  will be a hard link or symbolic link to the first file.
+
+  If the first argument is '-r', copy will do a recursive copy of a directory.
+  If the first argument is '-p', copy will preserve the "mode" bits of the file.
 
   Usage --  cp('fromfile','tofile')
+            cp('fromfile','tofile','link')
             cp('fromfile','tofile','symlink')
   Examples;
 
       cp('fromfile','tofile')
       cp('-r','fromdir','todir')         This will do a recursive copy
       copy('fromfile','tofile'):$res     will set $res to 1 (success) or 0 (failure)
+      copy('fromfile','tofile','link'):$res     will set $res to 1 (success) or 0 (failure)
       copy('fromfile','tofile','symlink'):$res     will set $res to 1 (success) or 0 (failure)

--- a/src/common/manual/delete
+++ b/src/common/manual/delete
@@ -5,12 +5,25 @@ rm		-       implementation of the UNIX rm command
 *******************************************************************************
 
   The rm command removes one or more files from the file system. 
-  It works like the unix rm command.   All arguments and options
-  are passed.  This command is very powerful and its use is not
-  recommended.
+  It works like the Linux rm command with the exception of the -R
+  option. The -R option removes the contents of the directory but not
+  the directory itself. It is like the Linux command
+    rm -rf directory/*
+  If the -R is used, the directory name cannot contain the wildcard (*)
+  and the directory must exist. Otherwise, the rm command will abort.
+  By returning an argument to the calling macro, as in
+     rm('-R','directory'):$dum
+  the rm command will not abort.
+  If only a single file name is given, it does not contain wildcards, it
+  exists,  and only zero or one of the options '-f', '-rf', '-fr', or
+  '-R' are given, the rm command uses fast built-in functions. Otherwise,
+  the actual /bin/rm Linux command is called, which is slower than the
+  built-in functions. 
 
   Usage  -  rm('filename')
-	    rm('filename1','filename2')
+            rm('-rf','directory1')
+            rm('-R','directory1')
+	    rm('filename1','filename2')  // calls slower external /bin/rm
 
   The delete command is a safer command than rm.  It will not allow
   "wildcard" characters nor the -r option.  It will, however, delete
@@ -22,7 +35,11 @@ rm		-       implementation of the UNIX rm command
   it will be deleted.  If the file is not found,  a .fid is appended
   to the file name.  If that directory is found, it will be removed.
   If the .fid file does not exist, a .par is appended and that file
-  will be removed if it is found.
+  will be removed if it is found. If the filename is following be a
+  null string, then files with .fid or .par will not be searched for.
 
   Usage  -  delete('filename')
 	    delete('filename1','filename2')
+            delete('filea','')   // useful if you are not sure 'filea' exists
+                                 // but do not want to delete filea.fid or
+                                 // filea.par

--- a/src/common/manual/exists
+++ b/src/common/manual/exists
@@ -2,6 +2,7 @@
 *******************************************************************************
 exists(name,'parameter'[,tree]):$x	- does a parameter exist?
 exists(name,'file'<,perm>):$x		- does a file exist?
+exists(name,'parfile'):$x		- does a file exist and is it a parameter file?
 exists(name,'ascii'):$x			- is a file an ASCII text file
 exists(name,'directory'):$x		- is a file a directory
 exists(name,'parlib'):$x,$path		- does a parlib entry exist
@@ -29,7 +30,8 @@ exists(name,directory<,'errval'>):$x	- does a file or directory exist in
   exists, but also that the current user has read and write access to that file.
 
   The ascii option checks if the named file is an ascii file. The directory
-  option checks if the named file is a directory.
+  option checks if the named file is a directory. The parfile option checks
+  if the named file exists and if it is a parameter file.
 
   The parlib name will be searched for. If it is not found,  a .par will
   be appended and the appended name will be searched for.  The parlib option

--- a/src/common/manual/getfile
+++ b/src/common/manual/getfile
@@ -1,42 +1,105 @@
 
 *******************************************************************************
-getfile('directory'):$x  	           - how many files are in a directory?
-getfile('directory',i<,'alphasort'>):$name,$ext - return the name and extension
-                                                - of the ith file.
+getfile('directory'<,OPTIONS>):$num  	    - how many files are in a directory?
+getfile('directory',i<,OPTIONS>):$name,$ext - return the name and extension
+                                              of the ith file.
+
+getfile('directory','RETURNPAR','$par'<,OPTIONS>):$num - return files into local
+                                                         parameter. 
 *******************************************************************************
 
-  Allows one to determine the number of files within a directory.
-  The names of each of these files can then be successively returned.
-  Files which begin with a "." are ignored.  The last file extension is
-  returned as a second argument.  With the 'alphasort' argument, the
-  filenames will be returned in alphabetic order, at some cost in speed.
-  Without it the order is random and dependent on the underlying
-  filesystem.  For example:
+  There are two ways to use getfile. The first is to get the number of files
+  in a directory and then use getfile to access each in turn. 
+  When getfile is called without an index, it returns the number of files
+  to the calling macro. When getfile is called with an index, the file name
+  is returned to the calling macro.  The file extension is returned as a
+  second argument.
 
-    filename		first argument		second argument
+  The second way to use getfile is with the 'RETURNPAR' keyword, which will return
+  all of the file names in the supplied local parameter. The name of the local
+  parameter must follow the 'RETURNPAR' keyword. The local parameter must already
+  exist as a string parameter. In this case, getfile returns the number of files
+  to the calling macro.
+
+  A number of options control the behavior of getfile. These options can be given
+  in any order following the required parameters.
+
+  With the 'alphasort' option, the file names will be returned in alphabetic
+  order, at some cost in speed.  Without 'alphasort', the order is random and
+  dependent on the underlying filesystem.
+
+  With the '-R' option, the 'directory' will be searched recursively. When
+  the '-R' option is used, the paths relative to the supplied directory name
+  are returned.
+
+  A comparison string may be provided for matching the file name. The comparison
+  string can be an ordinary string. Any occurrence of that string within the
+  file name will be identified as a match. Alternatively, if the 'regex' option
+  is present, the comparison string will be interpreted as a "regular expression"
+  and "regular expression" rules will be used to determine if the file name is a
+  match. File names that begin with a "." are ignored except in the case
+  of the 'regexdot' option. In all other ways, the 'regexdot' option is the
+  same as the 'regex' option.
+
+  When the file names are returned to the calling macro, the extension 
+  returned as the second argument are all characters after the final
+  dot (.) in the file name.
+
+    file name		first argument		second argument
     s2pul.fid		s2pul			fid
     tmp_01.dat		tmp_01			dat
     dummy		dummy
-    fid.tmp.par		fid.tmp			par
+    some.tmp.par	some.tmp		par
 
-  Example:
-    getfile('dir'):$entrys
-    $temp = 0
-    while ($temp < $entrys)
-      $temp = $temp + 1
-      getfile('dir',$temp):$filename,$ext
+  Example of the first way of using getfile:
+    getfile($dir):$entrys
+    $index = 0
+    while ($index < $entrys)
+      $index = $index + 1
+      getfile($dir,$index,'alphasort'):$file,$ext
       .
       .
       .
     endwhile
 
-  Complete pathnames can be reconstructed as
+  Complete file names can be reconstructed as
     if ($ext = '') then
-      $path = 'dir' + $filename
+      $filename = $file
     else
-      $path = 'dir' + $filename + '.' + $ext
+      $filename = $file + '.' + $ext
     endif
 
-  Pathnames for the rt command would always be reconstructed as
-    $path = 'dir' + '/' + $filename
+  Path names for the rt command would be reconstructed as
+    $path = $dir + '/' + $filename
 
+  To get only the files with a .fid in their name, one could use
+
+  getfile('dir','.fid'):$entrys
+
+  Note however that this would match the file name my.fid.file. To
+  match only file names that end in .fid, use the 'regex' option.
+
+  getfile(<dir>,'regex','\\.fid$'):$entrys
+
+  The dot (.) must be "escaped" with the backslash or the "regular expression"
+  rules would match it with any character. Also note that two backslashes must
+  be used since the magical interpreter also treats the backslash as an escape
+  character.
+
+  When file names are returned in a supplied local parameter, they are not
+  broken into file names and extensions.
+
+  Example of the second way of using getfile:
+    $filename=''
+    getfile($dir,'RETURNPAR','$filename','-R','regex','\\.fid$'):$entrys
+    $index = 0
+    while ($index < $entrys)
+      $index = $index + 1
+      write('line3','file %d: %s',$index,$filename[$index])
+      .
+      .
+      .
+    endwhile
+
+  The path names for the rt command would be reconstructed as
+    $path = $dir + '/' + $filename[$index]

--- a/src/common/manual/groupcopy
+++ b/src/common/manual/groupcopy
@@ -4,9 +4,13 @@ groupcopy	-   copy variables from a group from one tree to another
 *******************************************************************************
 
   This command copies a set of variables of a group from one variable
-  tree to another.  The three variable trees are 'current', 'global' 
+  tree to another.  The variable trees are 'current', 'global', 'usertree', 
   and 'processed'.  The group type can be 'all', 'sample', 'acquisition',
   'processing', and 'display'.
+
+  If the group is not supplied as the third argument. The entire tree
+  is copied. All the parameters in the 'totree' are first removed. The
+  parameters from the 'fromtree' are then copied to the 'totree'
 
   Usage -- groupcopy(fromtree,totree,group)
 	Note: can not copy to the same tree.
@@ -14,3 +18,9 @@ groupcopy	-   copy variables from a group from one tree to another
   Example:
 
     groupcopy('current','global','sample')  
+
+  Usage -- groupcopy(fromtree,totree)
+
+  Example:
+
+    groupcopy('current','processed')  

--- a/src/common/manual/nextexp
+++ b/src/common/manual/nextexp
@@ -7,6 +7,11 @@ The nextexp will also skip an experiment number that matches
 the addsubexp value. if that parameter does not exist, the
 addsub experiment is assumed to be exp5.
 
+If an argument is supplied, as in nextexp(12), then the
+command will return the next experiment larger than the supplied
+index. By default, nextexp looks for an available experiment
+larger than exp5.
+
 For example, assume exp1 - exp5 exist, 
 nextexp:$num,$name
 would set $num=6 and $name='exp6'

--- a/src/common/manual/readfile
+++ b/src/common/manual/readfile
@@ -7,12 +7,12 @@ readfile reads the contents of a file and puts the contents into two
 supplied parameters.  The first word on each line in the file is placed in the
 first parameter.  The remainder of the line is placed in the second parameter.
 An optional fourth argument specifies a string which is used to match the
-first word of the line.  For example, if the file contained
+beginning of the line.  For example, if the file contained
 H1pw   10
 H1pwr  55
 C13pw  14
 C13pwr 50
-and the comparison string was set to H1, only the lines starting with H1
+and the comparison string was set to 'H1', only the lines starting with H1
 would be put into the parameters.  Namely, H1pw and H1pwr.
 
 Arguments:
@@ -21,7 +21,13 @@ Arguments:
  par2 is the name of the parameter to hold the remainder of each line.
  If par2 is supplied as '', the entire line will be put into par1.
 
- cmpstr is the optional comparison string for matching the first word.
+ cmpstr is the optional comparison string for matching the beginning
+ of the line.  Unless the first character of the cmpstr is '^', any
+ white space at the beginning of the line will be skipped before the
+ comparison is made. Also, the cmpstr may contain white space. For
+ example, if cmpstr is 'H1pw ', it will only match the first line in
+ the example above.
+ 
  tree is an optional parameter to select the tree for par1 and par2.
     The possibilities are current, global, and local.  Current is the
     default.  Local is used if the parameters are $ macro parameters.

--- a/src/common/manual/sortCmd
+++ b/src/common/manual/sortCmd
@@ -1,0 +1,47 @@
+sortCmd('fromFile',<flags>,'toFile'):$ok - sort lines from fromFile to toFile
+
+The sortCmd command will sort the contents of "fromFile" to "toFile".
+The fromFile and toFile cannot be the same file. If toFile does not exist,
+it will be created.
+
+There can be optional flags to determine the ordering options. All flags
+are concatenated into a single argument. The order of the flags does not matter.
+The default is an alphanumeric sort in ascending order.  The sort command will
+return either a 1 or 0 for success or failure, respectively.
+
+  n     - compare according to string numerical value
+  r     - reverse the result of comparisons
+  u     - output only the first of an equal run
+  k#    - sort starting from the #th field
+  k#,#2 - sort starting from the #th field until the end of the #2 field
+
+A field is defined as characters separated by a space or tab. Field numbering
+starts with 1. For example, the second field in
+line1:  20 values
+is 20
+When using the 'u' flag, the "uniqueness" of a line depends only on the parts
+of the line being compared. For example, with the following four lines
+
+1: 20.0
+2: 21.0
+3: 20.0
+4: 20.0  alpha
+
+using flags 'u' would give all four lines. Using 'uk2'  would give lines 1, 2, and 4.
+Using 'uk2,2' would give lines 1 and 2 only.  The k2 flag compares from the beginning
+of word 2 to the end of the line. The k2,2 flag compares from the beginning of word 2
+to the end of word 2.
+
+Examples:
+
+sortCmd(<fromFile>,<toFile>)          // alphanumeric sort
+sortCmd(<fromFile>,'nr',<toFile>)     // numeric sort in descending order
+sortCmd(<fromFile>,'k2',<toFile>)     // alphanumeric sort starting from the 2nd field
+                                      // to the end of the line
+sortCmd(<fromFile>,'k2,2',<toFile>)   // alphanumeric sort starting from the 2nd field
+                                      // to the end of 2nd field
+sortCmd(<fromFile>,'unk2,2',<toFile>) // numeric sort starting from the 2nd field
+                                      // to the end of 2nd field and removing lines with
+                                      // non-unique 2nd fields.
+
+

--- a/src/common/manual/substr
+++ b/src/common/manual/substr
@@ -7,6 +7,8 @@ substr	-	pick a substring or word out of a string
   from a string.  It can also count the number of words in a string.
   It can also treat a string as a filename an separate it into a
   'dirname' and a 'basename'.
+  It can also replace a set of characters with a replacement character,
+  similar to the Linux "tr" command.
 
   Case 1. Get a word from a string.
 
@@ -301,3 +303,21 @@ substr	-	pick a substring or word out of a string
         string n2 = 'leading whitespace'
     substr('   /home/vnmr','trim','/ \t'):n2 
         string n2 = 'home/vnmr'
+
+  Case 9. Translate or delete characters from a string
+    substr('string','tr','characters','replacement'):$newstring
+       where string is the string or a string variable
+       'tr' is a keyword for this case. The third argument
+       is a set of characters that will be replaced by the
+       fourth argument. The newline, linefeed, and tab characters may be
+       specified by using \n, \r, and \t, respectively, in the third argument.
+       If the fourth argument is a single character, then characters
+       that match those in 'characters' will be replaced with 'replacement'.
+       If the fourth argument is a null string, characters that match
+       those in 'characters' will be deleted from 'string'.
+
+  Example
+    substr('a string:^ with funny &% # characters','tr','^%&#','_'):n2 
+        string n2 = 'a string:_ with funny __ _  characters'
+    substr('a string:^ with funny &% # characters','tr','^%&#',''):n2 
+        string n2 = 'a string: with funny   characters'

--- a/src/common/manual/touch
+++ b/src/common/manual/touch
@@ -1,0 +1,15 @@
+
+*******************************************************************************
+touch(<fileName>):$res	- 	touch a file
+*******************************************************************************
+
+  This command is the equivalent of the Linux touch command.
+  If fileName does not exist, it will be created.
+
+  Usage  -  touch('xxx')  			create file xxx if it does
+                                                not exist
+	    touch('/vnmr/tmp/debug'):$res 	create file /vnmr/tmp/debug if
+						it does not exist.
+
+  The touch command will return a 1 for success.
+  The touch command will return a 0 for failure.

--- a/src/vnmr/go.c
+++ b/src/vnmr/go.c
@@ -154,6 +154,7 @@ extern int p11_saveFDAfiles_raw(char* func, char* orig, char* dest);
 extern int setfrq(int argc, char *argv[], int retc, char *retv[]);
 extern int verify_fnameChar(char tchar);
 extern int check_ShimPowerPars();
+extern int do_mkdir(char *dir, int psub, mode_t mode);
 extern int Rmdir(char *dirname, int rmParent);
 
 extern int psg_pid;
@@ -1229,8 +1230,7 @@ int acq(int argc, char *argv[], int retc, char *retv[])
        {
           sprintf(dirpath,"%s/acqqueue/acq/%s",systemdir, tmpStr);
        }
-       sprintf(tmpStr,"mkdir -p %s; chmod %o %s\n",dirpath,0777,dirpath);
-       system(tmpStr);
+       do_mkdir(dirpath, 1, 0777);
     }
     GPRINT1(1,"Acqfile to use: '%s' \n",dirpath);
 
@@ -4373,7 +4373,6 @@ int makeautoname(char *cmdname, char *a_name, char *sif_name, char *dirname,
 char	*ptr;
 char	*aptr;
 char	*sptr;
-char	buffer[MAXPATH*2 + 40];
 char	filea[MAXPATH];
 char	fileb[MAXPATH];
 char	search_str[MAXSTR];
@@ -4383,7 +4382,7 @@ char	tmpSuffix[MAXPATH];
 char	tmp2Str[MAXSTR];
 char	revision[20];
 double	rval;
-int	filemode;
+mode_t	filemode;
 int	itemp;
 int	dlen,len;
 int	R_speced,R_start,R_width,rev;
@@ -4705,10 +4704,9 @@ char    recDir[MAXPATH];
 #endif 
 
    strcat(tmp,suffix);
-   sprintf(buffer,"mkdir -p %s; chmod %o %s\n",tmp,filemode,tmp);
-   itemp=system(buffer);
+   itemp = do_mkdir(tmp, 1, filemode);
    if (itemp)
-   {  printf("Cannot create directory '%s',return=%d\n",tmp,itemp);
+   {  Werrprintf("Cannot create directory '%s',return=%d\n",tmp,itemp);
       ABORT;
    }
 

--- a/src/vnmr/pvars.c
+++ b/src/vnmr/pvars.c
@@ -587,7 +587,86 @@ void copyVar(const char *n, varInfo *v, symbol **root)
 	newv->ET.basicType = v->T.basicType;
     }
     else
+    {
 	newv = RcreateVar(n,root,v->T.basicType);     /*  create the variable */
+    }
+    newv->active = v->active;
+    newv->subtype= v->subtype;
+    newv->Dgroup = v->Dgroup;
+    newv->Ggroup = v->Ggroup;
+    newv->prot   = v->prot;
+    newv->minVal = v->minVal;
+    newv->maxVal = v->maxVal;
+    newv->step   = v->step;
+    if (v->T.basicType == T_STRING)  /* copy over string values */
+    {	i = 1; 
+     	r = v->R;
+	while (r && i < v->T.size+1)
+	{   assignString(r->v.s,newv,i);
+	    i += 1;
+	    r = r->next;
+	}
+	/*  copy over enumeral values */
+     	i = 1; 
+     	r = v->E;
+	while (r && i < v->ET.size+1)
+	{   assignEString(r->v.s,newv,i);
+	    i += 1;
+	    r = r->next;
+	}
+    }
+    else  /* copy over all reals */
+    {	i = 1; 
+     	r = v->R;
+	while (r && i < v->T.size+1)
+	{   assignReal(r->v.r,newv,i);
+	    i += 1;
+	    r = r->next;
+	}
+	/*  copy over enumeral values */
+     	i = 1; 
+     	r = v->E;
+	while (r && i < v->ET.size+1)
+	{   assignEReal(r->v.r,newv,i);
+	    i += 1;
+	    r = r->next;
+	}
+    }
+}
+
+/*------------------------------------------------------------------------------
+|
+|	copyVarNB/2
+|
+|	This function copies one variable from one tree to another.
+|	It first deletes the existing variable and copies over the new one.
+|       It is the same as copyVar except the tree is not "balanced"
+|       after adding each new variable. It uses RcreateUVar.
+|
++-----------------------------------------------------------------------------*/
+
+static void copyVarNB(char *n, varInfo *v, symbol **root)
+{   int      i; 
+    Rval    *r;
+    varInfo *newv;
+    
+    if ( (newv=rfindVar(n,root)) ) /* if variable exists, get rid of its values */
+    {	if (newv->T.basicType == T_STRING)  
+	{   disposeStringRvals(newv->R);
+	    disposeStringRvals(newv->E);
+	}
+	else
+	{   disposeRealRvals(newv->R);
+	    disposeRealRvals(newv->E);
+	}
+	newv->R = NULL;
+	newv->E = NULL;
+	newv->T.size = newv->ET.size = 0;
+	newv->T.basicType = v->T.basicType;
+	newv->ET.basicType = v->T.basicType;
+    }
+    else
+	newv = RcreateUVar(n,root,v->T.basicType);     /*  create the variable */
     newv->active = v->active;
     newv->subtype= v->subtype;
     newv->Dgroup = v->Dgroup;
@@ -640,7 +719,7 @@ void copyVar(const char *n, varInfo *v, symbol **root)
 |
 +-----------------------------------------------------------------------------*/
 
-void copyAllVars(symbol **fp, symbol **tp)
+static void copyAllVars(symbol **fp, symbol **tp)
 {  symbol  *p;
    varInfo *v;
  
@@ -649,7 +728,7 @@ void copyAllVars(symbol **fp, symbol **tp)
       {
 	 DPRINT1(3,"copyAllVars:  working on var \"%s\"\n",p->name);
 	 if ( (v=(varInfo *)(p->val)) )
-	    copyVar(p->name,v,tp);
+	    copyVarNB(p->name,v,tp);
       }
       if (p->left)
 	 copyAllVars(&(p->left),tp);
@@ -700,7 +779,7 @@ void copyGVars(symbol **fp, symbol **tp, int group)
 		   diffval = compareVar(p->name,v,tp);
 #endif 
 		DPRINT1(3,"copyGVars: copying \"%s\"\n",p->name);
-	     	copyVar(p->name,v,tp);
+	     	copyVarNB(p->name,v,tp);
 #ifdef VNMRJ
 		if ((vjcopyflag > -1) && (diffval == 1))
 		   appendvarlist(p->name);
@@ -710,6 +789,10 @@ void copyGVars(symbol **fp, symbol **tp, int group)
     }
 }
 
+void P_balance(symbol **tp)
+{
+   balance(tp);  /* rebalance tree */
+}
 /*------------------------------------------------------------------------------
 |
 |	P_pruneTree/2
@@ -874,6 +957,7 @@ int P_copy(int fromtree, int totree)
        (troot = getTreeRoot(getRoot(totree))))
     {	copyAllVars(froot,troot);
 /* don't appendvarlist("seqfil") for VNMRJ - doesn't work within parameter trees? */
+	balance(troot);
 	return(0);
     }
     else
@@ -908,6 +992,7 @@ int P_copygroup(int fromtree, int totree, int group)
 	  jsetcopyGVars( 0 );
 #endif 
 	copyGVars(froot,troot,group);
+        balance(troot);
 #ifdef VNMRJ
         if (totree == CURRENT)
 	  jsetcopyGVars( -1 );
@@ -1031,7 +1116,8 @@ int P_creatvar(int tree, const char *name, int type)
 
     if ( (root = getTreeRoot(getRoot(tree))) )
     {	if (goodName(name))
-	{   RcreateVar(name,root,type);
+	{
+            RcreateVar(name,root,type);
 	    return(0);
 	}
 	else
@@ -2407,6 +2493,120 @@ int readGroupfromdisk(symbol **root, FILE *stream, int groupIndex)
 	}
     }
     return -1;
+}
+
+/*------------------------------------------------------------------------------
+|
+|	worker function for P_ispar
+|
+|	This function determines if the open file contains parameters
+|       Returns 1 is true, 0 if not
+|
++-----------------------------------------------------------------------------*/
+
+static int readParsFromDisk(FILE *stream)
+{
+    char        buf[1025];
+    char        name[256];
+    double      doub;
+    short       sval;
+    int         ival;
+    short       basicType;
+    int         i;
+    int         intptr;
+    int         num;
+    int         ret = 0;
+
+    for(;;)
+    {	if(fscanf(stream,"%s",name)==EOF)
+	    break;
+        ret = 1;
+	TPRINT1(2,"P_ispar: reading variable \"%s\"\n",name);
+	num =fscanf(stream,"%hd %hd %lf %lf %lf %hd %hd %d %hd %x",
+	    &sval,&basicType,&doub,&doub,&doub,&sval,&sval,&ival,&sval,&intptr);
+        if ((num == EOF) || (num != 10))
+           return(0);
+	TPRINT1(2,"P_ispar: we read  %d things \n",ret);
+	if (fscanf(stream,"%d",&num)== EOF)
+           return(0);
+	TPRINT1(2,"P_ispar: num of values =%d\n",num);
+	switch (basicType)
+	{ case T_REAL:
+		/*  Read the values */
+		for (i=1; i<num+1; i++)
+		{
+		    if (fscanf(stream,"%lg",&doub)==EOF)
+                       return(0);
+		}
+		/*  Read the enumeration values */
+		if (fscanf(stream,"%d",&num)== EOF)
+                    return(0);
+		TPRINT1(2,"P_ispar: num of enums =%d\n",num);
+		for (i=1; i<num+1; i++)
+		{
+		    if (fscanf(stream,"%lg",&doub)==EOF)
+                       return(0);
+		}
+		break;
+	  case T_STRING:
+		/*  Read values */
+		for (i=1; i<num+1; i++)
+		{   if (rscanf(stream,buf,1024)<0)
+		    {	Werrprintf("P_ispar: premature EOF\n");
+			return(0);
+		    }
+		}
+		/*  Read the enumeration values */
+		if (fscanf(stream,"%d",&num)== EOF)
+		    return(0);
+		TPRINT1(2,"P_ispar: num of enums =%d\n",num);
+		for (i=1; i<num+1; i++)
+		{   if (rscanf(stream,buf,1024)<0)
+		    {	Werrprintf("readNamesFromDisk: premature EOF\n");
+			return(0);
+		    }
+		}
+		break;
+	  default:
+		Werrprintf("P_ispar: %s has nonexistent type\n", name);
+		return(0);
+	}
+    }
+    return(ret);
+}
+
+/*------------------------------------------------------------------------------
+|
+|	P_ispar/1
+|
+|	This function determines if the open file contains parameters
+|       Returns 1 is true, 0 if not
+|
++-----------------------------------------------------------------------------*/
+
+int P_ispar(const char *filename)
+{   FILE    *stream;
+
+/*
+ * The fopen call is sometimes interrupted.  This following will
+ * retry the call.
+ */
+   errno = 0;
+   while ( ((stream = fopen(filename,"r")) == NULL) && (errno == EINTR) )
+   {
+      errno = 0;
+   }
+   if (stream)
+   {
+       int ret;
+       ret = readParsFromDisk(stream);
+       fclose(stream);
+       return(ret);
+   }
+   else
+   {
+      return(0); /* not such file */
+   }
 }
 
 /*------------------------------------------------------------------------------

--- a/src/vnmr/pvars.h
+++ b/src/vnmr/pvars.h
@@ -41,6 +41,7 @@ int P_saveUnsharedGlobal(const char *filename);
 int P_rtx(int tree, const char *filename, int key1IsRt, int key2IsClear);
 int P_read(int tree, const char *filename);
 int P_testread(int tree);
+int P_ispar(const char *filename);
 int P_readnames(const char *filename, char **names);
 int P_getparinfo(int tree, const char *pname, double *pval, int *pstatus);
 int P_getmax(int tree, const char *pname, double *pval);

--- a/src/vnmr/table.c
+++ b/src/vnmr/table.c
@@ -101,6 +101,7 @@ extern int annotation();
 
 extern int aph();
 extern int appdir();
+extern int appendCmd(int argc, char *argv[], int retc, char *retv[]);
 extern int atCmd();
 extern int auargs(int argc, char *argv[], int retc, char *retv[]);
 extern int autocmd();
@@ -435,6 +436,7 @@ extern int show_remote_files();		/* magnetom */
 extern int showbuf();
 extern int small();
 extern int solvinfo();
+extern int sortCmd(int argc, char *argv[], int retc, char *retv[]);
 extern int spa();
 extern int spins();
 extern int splmodprepare();
@@ -589,6 +591,7 @@ static cmd_t vnmr_table[] = {
 	{"aphb"       , aph,		NO_REEXEC, 10},
 	{"aphold"     , aph,		NO_REEXEC, 10},
 	{"appdir"     , appdir,		NO_REEXEC, 0},
+	{"append"     , appendCmd,	NO_REEXEC, 0},
 	{"asin"       , ln,		NO_REEXEC, 10},
 	{"atan"       , ln,		NO_REEXEC, 10},
 	{"atan2"      , ln,		NO_REEXEC, 10},
@@ -1073,6 +1076,7 @@ static cmd_t vnmr_table[] = {
 	{"sleep"      , vnmrSleep,	NO_REEXEC, 0},
 	{"small"      , small,		NO_REEXEC, 0},
 	{"solvinfo"   , solvinfo,	NO_REEXEC, 0},
+	{"sortCmd"    , sortCmd,	NO_REEXEC, 0},
 	{"spa"        , spa,		NO_REEXEC, 0},
 	{"spadd"      , addsub,		NO_REEXEC, 10},
 	{"spin"       , acq,		NO_REEXEC, 0},
@@ -1112,6 +1116,7 @@ static cmd_t vnmr_table[] = {
 	{"teststr"    , teststr,   	NO_REEXEC, 0},
 	{"text"       , text,		NO_REEXEC, 0},
 	{"textis"     , text_is,	NO_REEXEC, 0},
+	{"touch"      , shellcmds,	NO_REEXEC, 0},
 	{"tune"       , tune,	        NO_REEXEC, 0},
 #ifdef VNMRJ
 	{"trackCursor", trackCursor,    NO_REEXEC, 0},

--- a/src/vnmrbg/smagic.c
+++ b/src/vnmrbg/smagic.c
@@ -152,7 +152,7 @@ extern int   acqflag;
 extern int        doThisCmdHistory;
 int          JgetPid;
 extern int autoDelExp;
-extern int nextexp_d(int *expi, char *expn );
+extern int nextexp_d(int *expi, char *expn);
 extern int cexpCmd(int argc, char *argv[], int retc, char *retv[]);
 
 extern varInfo *findVar(char *name);
@@ -238,7 +238,7 @@ extern void set_bootup_gfcn_ptrs();
 extern void setUpWin(int windowRetain, int noUi);
 extern void jgraphics_init();
 extern void nmr_exit(char *modeptr);
-extern void bootup(char *modeptr, int enumber);
+extern void bootup(int enumber);
 extern void setWissun(int val);
 extern int merge_command_table(void *aipCmd);
 extern void *aipGetCommandTable();
@@ -291,6 +291,7 @@ int 	     working     = 0;
 int	     jShowInput  = 0;
 int	     jShowArray  = 0;
 int	     jParent  = 0;
+int	     doingAutoJexp  = 0;
 
 static int  expnum;
 static int  graphics_window = 0;
@@ -1109,7 +1110,9 @@ int vnmr(int argc, char *argv[])
         }
     }
 
+#ifndef NOACQ
     INIT_ACQ_COMM(systemdir);
+#endif
 
     merge_command_table(aipGetCommandTable());
 
@@ -1138,16 +1141,17 @@ int vnmr(int argc, char *argv[])
 	setupdirs( "background" );
         if (expnum < 0)
         {
-           int expi;
+           int expi=5;
            char expn[32];
            if (nextexp_d( &expi, expn))
            {
               char *argv2[3];
               char *retv2[2];
-                    
+
               if (expnum == -2)
                  autoDelExp=1;
               expnum = expi;
+              doingAutoJexp = 1;
               sprintf(expn,"%d",expi);
               argv2[0] = "cexp";
               argv2[1] = expn;
@@ -1155,7 +1159,6 @@ int vnmr(int argc, char *argv[])
               strcpy( curexpdir, userdir );
               strcat( curexpdir, "/exp0" );
               cexpCmd(2, argv2, 1, retv2);
-   
            }
            else
            {
@@ -1163,7 +1166,7 @@ int vnmr(int argc, char *argv[])
            }
         }
         jgraphics_init();
-	bootup(vnMode,expnum);
+	bootup(expnum);
 	if (initCommand)
 	{
             char tmpStr[2048];
@@ -1216,7 +1219,7 @@ int vnmr(int argc, char *argv[])
 	jvnmr_init();
         if (!noUI)
 	    init_win_info();
-	bootup(vnMode,expnum);
+	bootup(expnum);
 /*	setWissun(1); */
 	JgetPid = getpid();
         smagicLoop();
@@ -1228,7 +1231,7 @@ int vnmr(int argc, char *argv[])
     {	setupdirs( "terminal" );
 	graphics_window = 0;
 	Wsetupterm(); /* setup windows */
-	bootup(vnMode,expnum);
+	bootup(expnum);
 	terminal_main_loop();
     }
     return(0);

--- a/src/vnmrj/src/vnmr/bo/VSubFileMenu.java
+++ b/src/vnmrj/src/vnmr/bo/VSubFileMenu.java
@@ -88,6 +88,7 @@ public class VSubFileMenu extends VSubMenu
                 Messages.writeStackTrace(e);
             }
         }
+/*
         updateChild = true;
         int m = getMenuComponentCount();
         for (int k = 0; k < m; k++) {
@@ -101,6 +102,7 @@ public class VSubFileMenu extends VSubMenu
                 obj.updateValue();
             }
         }
+ */
     }
 }
 


### PR DESCRIPTION
Replaced calls to external programs mv and rm with library calls rename and unlink.
Wrote simple fileCopy procedure to replace call to cp.
Updated some macros to use faster function calls
Added 'link' option to copy command.
Added tree copy option to groupcopy command. A slow step in this was rebalancing the
parameter tree after every parameter addition. Now, add all parameters and then
do a single rebalance.
Added option to nextexp to find exp larger than given index.
Updated Notes.txt with new commands and bug fixes.