### PR TITLE
update for OpenVnmrJ loss of /usr/varian, keep old log files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs: # a collection of steps
             export OVJ_TOOLS=${OVJ_BUILDDIR}/ovjTools
             chmod a+xr ${OVJ_BUILDDIR}
             chmod a+xr ${OVJ_BUILDDIR}/dvdimageOVJ*
-            sudo ${OVJ_ROOT}/scripts/install_test.sh -f install
+            sudo ${OVJ_ROOT}/scripts/install_test.sh -f install -v
       - run:
           name: Install Failed
           when: on_fail
@@ -81,6 +81,7 @@ jobs: # a collection of steps
           name: Tests Failed
           when: on_fail
           command: |
+            sudo tail -180 ${OVJ_BUILDDIR}/logs/install_test.log*
             sudo cat ~vnmr1/vnmrsys/ovj_qa/ovjtest/reports/20*
       - store_artifacts:
           name: Store VJQA Results

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -199,14 +199,21 @@ vnmr_cmd() {
 }
 
 is_ovj_installed() {
+    local errcnt=$ERRCOUNT
+    local numerr=1
     # does ovj appear to be installed already?
     # todo: could check more thoroughly!
-    [ -d /vnmr ] && [ -d /usr/varian ] && \
-        [ -d "${OVJ_HOME}/${OVJ_VERSION}" ] && \
-        [ -d ~vnmr1 ] && \
-        [ -d ~testuser ] && \
-        getent passwd testuser && \
-        getent passwd vnmr1 > /dev/null 2>&1
+    [ -d /vnmr ] || log_error "Missing /vnmr"
+    [ -d /vnmr/templates ] || log_error "Missing /vnmr/templates"
+    #[ -d /vnmr/p11/sbin ] || log_error "Missing /vnmr/p11/sbin (pre-OpenVnmrJ2 installation?)"
+    [ -d "${OVJ_HOME}/${OVJ_VERSION}" ] || log_error "Missing '${OVJ_HOME}/${OVJ_VERSION}'"
+    [ -d ~vnmr1 ] || log_error "Missing ~vnmr1/"
+    [ -d ~testuser ] || log_error "Missing ~testuser/"
+    getent passwd vnmr1 || log_error "'vnmr1' missing passwd entry via getent"
+    getent passwd testuser || log_error "'testuser' missing passwd entry via getent"
+    numerr=$(( ERRCOUNT - errcnt ))
+    ERRCOUNT=$errcnt
+    return $numerr
 }
 
 join_by() { local IFS="$1"; shift; echo "$*"; }
@@ -352,7 +359,7 @@ for ACTION in $ACTIONS ; do
         # make sure there's an installation
         if ! is_ovj_installed ; then
             log_error "Cant run tests without OpenVnmrJ installation"
-            return 1
+            break
         fi
 
         # The test suite is in OpenVnmrJ/src/vjqa. This is not included in

--- a/scripts/loglib.sh
+++ b/scripts/loglib.sh
@@ -70,6 +70,17 @@ log_setup () {
     trap 'exec 1>&3 2>&4' 0
     trap 'exec 1>&3 2>&4; exit 1' 1 2 3
     #trap 'onerror' 0 1 2 3
+    # move old LOGFILE
+    if [ -f "${LOGFILE}" ]; then
+        for SEQ in $(seq -w 1 10); do
+            if [ ! -f "${LOGFILE}.${SEQ}" ] || [ $SEQ -eq 10 ]; then
+                echo "Moving old logfile ${LOGFILE} to ${LOGFILE}.${SEQ}"
+                mv "${LOGFILE}" "${LOGFILE}.${SEQ}"
+                break
+            fi
+        done
+    fi
+    # redirect output to LOGFILE
     if [ ${VERBOSE} -gt 3 ]; then
         # at VERBOSE >= DEBUG level, also send cmd output to terminal
         exec 1> >(tee -a "${LOGFILE}") 2>&1


### PR DESCRIPTION
This fixes #294.  It was checking for existence of /usr/varian to
verify that ovj had been installed, but since that's gone, now
checks for existence of /vnmr/p11/sbin.

Also added some code to roll log files instead of over-writing,
up to 10, then just keep over-writing 10.  Good enough for now,
but true rolling would be better.