### PR TITLE
Made ACQPROC_strucs.h compatible with 32 and 64 bit compiles

### DIFF
--- a/src/acqproc/ACQPROC_strucs.h
+++ b/src/acqproc/ACQPROC_strucs.h
@@ -8,59 +8,26 @@
  */
 /*
 */
-/*------------------------------------------------------------------------
-|
-|	The AcqProc Queue structure 
-|	  This information is passed to the Acq. process by PSG.
-|
-|   Modified   Author     Purpose
-|   --------   ------     -------
-|   2/22/89   Greg B.    1. Added int CurrentElem and int CompleteElem to
-|			    struct _value for Resume Acquistion (RA)
-+-----------------------------------------------------------------------*/
-struct _value    { 
-		    char *Acqfile;	/* acqfile path */
-		    char *Codefile;	/* acqqueue path */
-		    char *RF_Patfile;	/* RF Obs. & Dec. pattern file */
-		    char *Gradfile;	/* Gradient file */
-		    char *Xpanfile;	/* Future Expansion file */
-		    char *MachineID;	/* Host name of INET socket */
-		    int   InetPort;	/* Inter-Net Port Number */
-		    int   InetPid;	/* Inter-Net Port Process ID Number */
-		    int   SuFlag;	/* suflag sets go, shim, spin, etc.*/
-		    int   ExpFlags;	/* Experiment Flags */
-		    int   AcqPos;	/* index in Acq system,a status also */
-		    int   HalID;	/* Acq. system's Exper. ID  0-1024 */
-		    long  DatSub;       /* Date & Time of day of submission.*/
-		    long  DatAct;	/* Date & Time became active in Acq */
-		    long  DatFin;       /* Date & Time of day of completion.*/
-		    double  ExpDuration;/* Approx. time duration of Exp (sec)*/
-	   unsigned long  CurrentElem;	/* Current Element, Exp to Start at  (RA)*/
-	   unsigned long  CompleteElem;/* Total Complete Elements of Exp. (RA) */
-		};
-typedef struct _value Value;
-
 /*---------------------------------------------------------------------
 |	This the acquisition information maintain by the Acq. process
 |	and sent to the Acquisition display program for user consumption.
-|	mod 6/8/88 to be consistent on both sun3 & sun4
 +---------------------------------------------------------------------*/
 #ifndef MAX_SHIMS_CONFIGURED
 #define MAX_SHIMS_CONFIGURED (48) /* Match define in hostAcqStructs.h */
 #endif
 struct _acqstat {
 
-                    long  AcqCT;
-                    long  AcqCmpltTime;
-                    long  AcqRemTime;
-                    long  AcqDataTime;
-		    long  AcqSuFlag;
-                    long  AcqSpinSet;
-                    long  AcqSpinAct;
-                    long  AcqSpinSpeedLimit;
+                    int  AcqCT;
+                    int  AcqCmpltTime;
+                    int  AcqRemTime;
+                    int  AcqDataTime;
+		    int  AcqSuFlag;
+                    int  AcqSpinSet;
+                    int  AcqSpinAct;
+                    int  AcqSpinSpeedLimit;
                     short Acqstate;
                     short AcqExpInQue;
-           unsigned long  AcqFidElem;
+           unsigned int  AcqFidElem;
                     short AcqLSDV;
                     short AcqLockLevel;
 		    short AcqSpinSpan;
@@ -81,10 +48,10 @@ struct _acqstat {
 		    short AcqLockGain;
 		    short AcqLockPower;
 		    short AcqLockPhase;
-    	   unsigned long  AcqShortRfPower[4]; /* microwatts */
-    	   unsigned long  AcqShortRfLimit[4];
-    	   unsigned long  AcqLongRfPower[4];
-    	   unsigned long  AcqLongRfLimit[4];
+    	   unsigned int  AcqShortRfPower[4]; /* microwatts */
+    	   unsigned int  AcqShortRfLimit[4];
+    	   unsigned int  AcqLongRfPower[4];
+    	   unsigned int  AcqLongRfLimit[4];
                     short AcqZone;
                     short AcqRack;
                 };
@@ -96,14 +63,15 @@ typedef struct _acqstat AcqStatBlock;
 |	sent to acquisition and have not finshed yet (includes processing).
 +---------------------------------------------------------------------*/
 struct _elemvar {
-	   unsigned long ElemNum;/* Element (FID) number of this data */
-		    long   PCt;		/* CT for this FID */
-		    long   PGain;	/* reciver gain for this FID */
-		    long   PSpin;	/* spinner rate for this FID */
+	   unsigned int ElemNum;/* Element (FID) number of this data */
+		    int   PCt;		/* CT for this FID */
+		    int   PGain;	/* reciver gain for this FID */
+		    int   PSpin;	/* spinner rate for this FID */
 		};
 
 typedef struct _elemvar Expelemstruc;
 
+#ifdef XXX
 /*---------------------------------------------------------------------
 |	Experiment Data that is used or updated during acquisition 
 |	This is addition information on any experiments that have been
@@ -144,6 +112,7 @@ struct _expvar {
 		    mode_t umask4Vnmr;  /* umask as set by PSG */
 		};
 typedef struct _expvar Expparmstruc;
+#endif
 
 /*---------------------------------------------------------------------
 |	Message packet from external task to AcqProc


### PR DESCRIPTION
Convert all long declarations to int. Removed unused structure.