### PR TITLE
singleSession could fail

### DIFF
--- a/src/scripts/vnmrj.sh
+++ b/src/scripts/vnmrj.sh
@@ -99,15 +99,11 @@ else
     fi
     if [[ -d $vnmrsystem/p11 ]] || [[ -f $vnmruser/persistence/singleSession ]]
     then
-       session=$(ls $vnmruser/lock_*.primary >& /dev/null)
+       cvnmr=$(ps -fu $USER | grep "/java/vnmrj.jar" | grep -v grep)
        if [ $? -eq 0 ]
        then
-          cvnmr=$(ps -ef | grep "/java/vnmrj.jar" | grep -v grep | awk '{print $1}')
-          if [ x$cvnmr = x$id ]
-          then
-             sel=$(java -jar $vnmrsystem/java/dialog.jar "An OpenVnmrJ session is already active")
-             exit
-          fi
+          sel=$(java -jar $vnmrsystem/java/dialog.jar "An OpenVnmrJ session is already active")
+          exit
        fi
     fi
 fi


### PR DESCRIPTION
If the OpenVnmrJ icon is clicked in rapid succession, 2 sessions
could be started. This change reduces that possibility.