### PR TITLE
Fixes for Part 11

### DIFF
--- a/src/scripts/makeP11checksums.sh
+++ b/src/scripts/makeP11checksums.sh
@@ -58,11 +58,11 @@ then
 fi
 
 sbindir="/vnmr/p11/sbin"
+nmr_adm=$("$vnmrsystem"/bin/fileowner "$vnmrsystem"/vnmrrev)
+nmr_group=nmr
 if test $1 = "/vnmr"
 then
 
-    nmr_adm=vnmr1
-    nmr_group=nmr
     if test $# -gt 2
     then
        nmr_adm=$2 
@@ -103,7 +103,7 @@ then
        mkdir $admp11dir
     fi
 
-    sysListAll=/vnmr/adm/p11/sysListAll
+    sysListAll=$admp11dir/sysListAll
     if [ -f $sysListAll ]
     then
        rm -f $sysListAll
@@ -117,7 +117,7 @@ then
     /vnmr/bin/chVJlist -l /vnmr/java >> $sysListAll
     /vnmr/bin/chVJlist -l /vnmr/maclib >> $sysListAll
 
-    sysList=/vnmr/adm/p11/sysList
+    sysList=$admp11dir/sysList
     if [ -f $sysList ]
     then
        rm -f $sysList
@@ -129,17 +129,17 @@ then
     /vnmr/bin/chVJlist -l /vnmr/acqbin >> $sysList
     /vnmr/bin/chVJlist -l /vnmr/java >> $sysList
 
-    notice=/vnmr/adm/p11/notice
+    notice=$admp11dir/notice
     if [ ! -f  $notice ]
     then
         touch $notice
     fi
 
-    syschksm=/vnmr/adm/p11/syschksm
+    syschksm=$admp11dir/syschksm
     /tmp/vnmrMD5 -l $sysList $vnmrsystem > $syschksm
     rm /tmp/vnmrMD5
 
-    chown ${nmr_adm}:${nmr_group} $sysListAll $sysList $notice $syschksm
+    chown -R ${nmr_adm}:${nmr_group} $admp11dir
     chmod 644 $sysListAll $sysList $notice $syschksm
 
 else
@@ -165,6 +165,7 @@ else
    path=$dir/checksum.$str
 
    /vnmr/bin/vnmrMD5 -f $1 $1 $path
+   chown -R ${nmr_adm}:${nmr_group} $dir
 
    echo $path
 fi

--- a/src/vnmr/chVJlist.c
+++ b/src/vnmr/chVJlist.c
@@ -12,7 +12,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 
-#define MAXSTR 1024
+#define MAXSTR 512
 #define MAXFILES 10000 
 
 typedef char string[MAXSTR];

--- a/src/vnmr/chchsums.c
+++ b/src/vnmr/chchsums.c
@@ -22,10 +22,9 @@
 #include "md5global.h"
 #include "md5.h"
 
-#define MAXSTR	1024 
+#define MAXSTR	512 
 #define MAXWORDS  32
 #define BUFSIZE 1024
-#define MAXFILE 50000
 
 typedef char string[MAXSTR];
 

--- a/src/vnmr/md5c.c
+++ b/src/vnmr/md5c.c
@@ -51,7 +51,7 @@ extern int setSafecpPath(char* safecpPath, char* dest);
 extern void getTimeString(char* timestr);
 extern int fileExist(char* path);
 
-#define MAXSTR 1024
+#define MAXSTR 512
 #define MAXWORDS 64
 #define BUFSIZE 1024
 typedef char string[MAXSTR];

--- a/src/vnmr/p11Tools.c
+++ b/src/vnmr/p11Tools.c
@@ -22,7 +22,7 @@
 
 #undef MAXSTR
 #endif
-#define MAXSTR 1024
+#define MAXSTR 512
 #define MAXWORDS 64
 #define BUFSIZE 1024
 #define PERMS 0644

--- a/src/vnmr/vnmrMD5.c
+++ b/src/vnmr/vnmrMD5.c
@@ -19,7 +19,7 @@
 #include <errno.h>
 #include <ctype.h>
 
-#define MAXSTR	1024 
+#define MAXSTR	512 
 #define MAXFILES	10000 
 #define MAXWORDS  32
 #define BUFSIZE 1024

--- a/src/vnmr/writeAaudit.c
+++ b/src/vnmr/writeAaudit.c
@@ -24,7 +24,7 @@
 #include <sys/statvfs.h>
 
 
-#define MAXSTR 1024
+#define MAXSTR 512
 #define MAXFSIZE 50000 
 #define PERMS 0644
 

--- a/src/vnmr/writeTrash.c
+++ b/src/vnmr/writeTrash.c
@@ -24,7 +24,7 @@
 #include <sys/statvfs.h>
 
 
-#define MAXSTR 1024
+#define MAXSTR 512
 #define MAXFSIZE 50000 
 #define PERMS 0644
 


### PR DESCRIPTION
The vnmrMD5 and chVJlist programs were giving segmentation
faults due to stack overflow. Reduced size of the "files"
stack variable. Also, some of the files created by Part 11 were
owned by root. Added chown to makeP11checksums script.