### PR TITLE
macrovi and macroedit no longer save macro to memory

### DIFF
--- a/src/common/maclib/macroedit
+++ b/src/common/maclib/macroedit
@@ -10,5 +10,6 @@ shelli('vnmredit','"'+$macropath+'"'):$dum
 $e=0
 exists($1,'maclib'):$e
 if ($e = 1) then
-    macrold($1)
+    macrold($1):$e
+    purge($1)
 endif

--- a/src/common/maclib/macrovi
+++ b/src/common/maclib/macrovi
@@ -8,9 +8,9 @@ endif
 $macropath=userdir+'/maclib/'+$1
 exists($macropath,'file'):$e
 if (not $e) then
-  shell('touch '+$macropath):$dum
+  touch($macropath):$dum
 endif
-shell('uname -s'):$osname
+uname:$osname
 if ($osname = 'Darwin') then
   write('line3','You must Quit TextEdit to resume VnmrJ')
 endif
@@ -21,7 +21,10 @@ if ($e = 1) then
     shell('wc -w '+$macropath):$ans
     substr($ans,1):$e
     if ($e > 0) then
-      macrold($1)
+      // check macro syntax
+      macrold($1):$e
+      // remove macro from memory
+      purge($1)
     else
       delete($macropath)
     endif

--- a/src/common/manual/purge
+++ b/src/common/manual/purge
@@ -6,9 +6,12 @@ purge('macroname') - 	remove the macro 'macroname' from memory.
   The macrold command loads a macro into memory. The purge('macroname')
   will remove a macro called macroname from memory.  The purge
   command with no arguments will remove all macros which have
-  been loaded into memory. The command purge with no arguments should never
-  be called from a macro. The command purge with an argument should never
-  be called by the macro which is being purged.
+  been loaded into memory.
+  The command purge with no arguments can be called from macros but
+  its action will be delayed until all macros have completed. If purge
+  with no arguments is called from a background process, it is ignored.
+  The command purge with an argument should never be called by the
+  macro which is being purged.
 
   Usage  -  purge			remove all macros from memory
             purge('_sw')                remove macro _sw from memory

--- a/src/vnmr/macro.c
+++ b/src/vnmr/macro.c
@@ -260,8 +260,13 @@ void showMacros()
 
 int purgeCache(int argc, char *argv[], int retc, char *retv[])
 {  if (argc == 1)
+   {
+      // Schedule purge to run after all macros exit.
+      if ( ! Bnmr )
+         sendTripleEscToMaster( 'C',"purge(0,0,0,0)");
+   }
+   else if (argc == 5)
    {  purgeAllMacros();
-      ABORT;
    }
    else if (argc == 2)
    {


### PR DESCRIPTION
They still do a macrold in order to syntax check the macro
but they then purge the macro from memory. Also fixed purge
with no arguments so that it can be called from a macro.
See updated man page for details