### PR TITLE
DOSY dg panels were wrong

### DIFF
--- a/src/DOSY/templates/layout/Dbppste/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dbppste/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dbppste_cc/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dbppste_cc/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dbppste_ghsqcse/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dbppste_ghsqcse/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dbppste_wg/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dbppste_wg/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dbppsteinept/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dbppsteinept/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dcosyidosy/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dcosyidosy/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Ddeptse/TextOutput.xml
+++ b/src/DOSY/templates/layout/Ddeptse/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/DgcsteSL/TextOutput.xml
+++ b/src/DOSY/templates/layout/DgcsteSL/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/DgcsteSL_cc/TextOutput.xml
+++ b/src/DOSY/templates/layout/DgcsteSL_cc/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/DgcsteSL_dpfgse/TextOutput.xml
+++ b/src/DOSY/templates/layout/DgcsteSL_dpfgse/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dgcstecosy/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dgcstecosy/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dgcstehmqc/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dgcstehmqc/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dgcstehmqc_ps/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dgcstehmqc_ps/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dghmqcidosy/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dghmqcidosy/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/DgsteSL_cc/TextOutput.xml
+++ b/src/DOSY/templates/layout/DgsteSL_cc/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dhom2djidosy/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dhom2djidosy/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Doneshot/TextOutput.xml
+++ b/src/DOSY/templates/layout/Doneshot/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Doneshot_nugmap/TextOutput.xml
+++ b/src/DOSY/templates/layout/Doneshot_nugmap/TextOutput.xml
@@ -37,7 +37,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dpfgdste/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dpfgdste/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"

--- a/src/DOSY/templates/layout/Dproject_cc/TextOutput.xml
+++ b/src/DOSY/templates/layout/Dproject_cc/TextOutput.xml
@@ -58,7 +58,7 @@
       decor1=""
       />
     <textfile loc="10 30" size="630 230"
-      style="PlainText"
+      style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="no"


### PR DESCRIPTION
They used proportional fonts instead of fixed-width.
Problem reported in SpinSights. Fixed by Bert.