### PR TITLE
Updates from Krish

### DIFF
--- a/src/common/maclib/rotateannos
+++ b/src/common/maclib/rotateannos
@@ -1,14 +1,71 @@
 "macro rotateannos"
 // Chempacker macro
 
+// Optional one argument.  
+//	BOX - rotate only boxes
+//	OVAL - rotate only ovals
+//  By default both BOX and OVAL annotations are rotated
+
+$oval=1 $box=1
+if $# > 0 then
+    $oval=0 $box=0
+    if $1='OVAL' then $oval=1
+    elseif $1='BOX' then $box=1 endif
+endif
+$e=0 $n=0
+aspAnno:$e,$n
+if $e and $n then
     $annos=curexp+'/tmpannos'
     aspAnno('save',$annos)
     aspAnno('clear')
-    shell('(cat '+$annos+' | grep -w BOX | awk \'{print $1" "$2" "$6" "$5" "$4" "$3}\' > '+$annos+'2)'):$devnull
-    shell('(cat '+$annos+' | grep -v \'^#\' | grep -vw BOX >> '+$annos+'2)'):$devnull
-    rename($annos+'2',$annos)
-    if trace='f2' then trace='f1' else trace='f2' endif
-    dconi
+    $annos2=$annos+'2'
+    $annos3=$annos+'3'
+
+    write('reset',$annos2)
+    if $box then
+    	append($annos,'grep -w','BOX',$annos2)
+    endif
+    if $oval then
+	append($annos,'grep -w','OVAL',$annos2)
+    endif
+    $s1='' readfile($annos2,'$s1','','','local'):$total
+    write('reset',$annos2)
+    $i=1
+    while $i<=$total do
+	substr($s1[$i],'squeeze',' '):$s1[$i]
+	write('file',$annos2,'%s',$s1[$i])
+	$i=$i+1
+    endwhile
+    $s1='' readfile($annos2,'$s1','','','local'):$total
+    write('reset',$annos3)
+    append($annos2,'awk','$1 $2 $3 $4 $5 $6',$annos3)
+    $s2='' readfile($annos3,'$s2','','','local')
+    write('reset',$annos3)
+    append($annos2,'awk','$1 $2 $6 $5 $4 $3',$annos3)
+    $s3='' readfile($annos3,'$s3','','','local')
+    rm('-f',$annos3):$dum
+
+    write('reset',$annos2)
+    $i=1
+    while $i<=$total do
+	$sx='' $sy=''
+	strstr($s1[$i],$s2[$i]):$ret,$sx,$sy
+	write('file',$annos2,'%s %s',$s3[$i],$sy)
+	$i=$i+1
+    endwhile
+    if $box then
+        append($annos,'grep -vw','BOX',$annos2)
+	rename($annos2,$annos)
+    endif
+    if $oval then
+	append($annos,'grep -vw','OVAL',$annos2)
+	rename($annos2,$annos)
+    endif
+    rm('-f',$annos2):$dum
+    rm('-f',$annos3):$dum
+		// Load new annotations
     aspAnno('load',$annos)
     rm('-f',$annos):$dum
+
+endif
 

--- a/src/common/maclib/rt
+++ b/src/common/maclib/rt
@@ -2,7 +2,17 @@
 " rt - retrieve data set"
 
 if ($# > 0.5) then
-  $args = 'RT(\''+$1
+  length($1):$len
+  if $len>220 then
+      $curdir=''
+      pwd:$curdir
+      $rtdir='' $rtbase=''
+      substr($1,'dirname'):$rtdir,$rtbase
+      cd($rtdir):$dum
+      $args = 'RT(\''+$rtbase
+  else
+      $args = 'RT(\''+$1
+  endif
   $i = 1
   while ($i<$#) do
     $i = $i + 1
@@ -10,6 +20,9 @@ if ($# > 0.5) then
   endwhile
   $args = $args+'\')'
   exec($args):$ret
+  if $len>220 then
+      cd($curdir):$dum
+  endif
   if (not $ret) then abort endif
 else
   RT

--- a/src/common/maclib/rtp
+++ b/src/common/maclib/rtp
@@ -2,7 +2,17 @@
 " rtp - retrieve parameter set"
 
 if ($# > 0.5) then
-  $args = 'RTP(\''+$1
+  length($1):$len
+  if $len>220 then
+      $curdir=''
+      pwd:$curdir
+      $rtpdir='' $rtpbase=''
+      substr($1,'dirname'):$rtpdir,$rtpbase
+      cd($rtpdir):$dum
+      $args = 'RTP(\''+$rtpbase
+  else
+      $args = 'RTP(\''+$1
+  endif
   $i = 1
   while ($i<$#) do
     $i = $i + 1
@@ -10,6 +20,9 @@ if ($# > 0.5) then
   endwhile
   $args = $args+'\')'
   exec($args):$ret
+  if $len>220 then
+      cd($curdir):$dum
+  endif
   if (not $ret) then abort endif
 else
   RTP

--- a/src/common/maclib/svp
+++ b/src/common/maclib/svp
@@ -2,7 +2,17 @@
 " svp - save parameter set"
 
 if ($# > 0.5) then
-  $args = 'SVP(\''+$1
+  length($1):$len
+  if $len>220 then
+      $curdir=''
+      pwd:$curdir
+      $svpdir='' $svpbase=''
+      substr($1,'dirname'):$svpdir,$svpbase
+      cd($svpdir):$dum
+      $args = 'SVP(\''+$svpbase
+  else
+      $args = 'SVP(\''+$1
+  endif
   $i = 1
   while ($i<$#) do
     $i = $i + 1
@@ -10,6 +20,9 @@ if ($# > 0.5) then
   endwhile
   $args = $args+'\')'
   exec($args)
+  if $len>220 then
+      cd($curdir):$dum
+  endif
 else
   SVP
 endif

--- a/src/scripts/vnmr_open.sh
+++ b/src/scripts/vnmr_open.sh
@@ -1,14 +1,13 @@
-#! /bin/sh
+#! /bin/bash
 #
 # open a file based on type and default application for that type
-# e.g. open a pdf bring up Acroreader, a html file the browser
 #
 if [ -z "$vnmrsystem" ] ; then
    vnmrsystem="/vnmr"
 fi
-ostype=`uname -s`
+ostype=$(uname -s)
 path="$1"
-url=`perl $vnmrsystem/bin/addhttp.pl $1`
+url=$(perl $vnmrsystem/bin/addhttp.pl $1)
 if [ ! -z "$url" ] ; then
    path=$url
 fi
@@ -16,14 +15,16 @@ case "$ostype" in
    cygwin | Interix )
       opencmd="cmd /c start"
       if [ -z "$url" ]; then 
-         path=`unixpath2win "$1"`
+         path=$(unixpath2win "$1")
       fi
         ;;
    *inux*)   # Linux, linux, etc.
       # echo "linux"
-      # opencmd="gnome-open"  depricated
+      # opencmd="gnome-open"  deprecated
       # check for the replacement, if not present fail-back to gnome-open
-      if [ -x /usr/bin/xdg-open ]; then
+      if [ -x /usr/bin/gio ]; then
+         opencmd="gio open"
+      elif [ -x /usr/bin/xdg-open ]; then
          opencmd="xdg-open"
       else 
          opencmd="gnome-open"
@@ -35,7 +36,9 @@ case "$ostype" in
         ;;
       *)
        # echo "default"
-       if [ -x /usr/bin/xdg-open ]; then
+       if [ -x /usr/bin/gio ]; then
+         opencmd="gio open"
+       elif [ -x /usr/bin/xdg-open ]; then
          opencmd="xdg-open"
        else 
          opencmd="gnome-open"


### PR DESCRIPTION
Fixes to macros for pathnames longer than 256 characters.
rotateannos did not honor changes to trace equal f1 or f2.
vnmr_open complained of deprecated function.