### PR TITLE
gxyzmapsys could fail

### DIFF
--- a/src/gxyzshim/maclib/gxyzmapsys
+++ b/src/gxyzshim/maclib/gxyzmapsys
@@ -53,7 +53,13 @@ if (seqfil <> 'gmapxyz') then
 	else
 		//Instead use gxyzrtmap
 		lookup('file',$jstr,'mapname','read'):$jmap
-		gxyzrtmap($jmap)
+		exists(userdir+'/3Dshimlib/shimmaps/'+$jmap+'/'+$jmap+'.fid','file'):$emap
+		if $emap then 
+			gxyzrtmap($jmap)
+		else
+			write('error','Previous map does not exist! Starting without map')
+			gmapxyz
+		endif
 	endif
         exists('gcalx','parameter'):$e
         if ($e<0.5) then


### PR DESCRIPTION
Fix provided by Bert Heise. His comments:
The problem is that if a previous map doesn't exist (maybe it got interrupted
before it could be saved or whatever - the map in quesiton is in the list of
available maps but the file isn't there…), gxyzmapsys has nowhere to
go - gxyzrtmap aborts and mapsys has no chance of launching normally in this state.
Modified gxyzmapsys to check for the presence of the map before calling rtmap
and when not finding a map, call gmapxyz directly instead.