### PR TITLE
remove warning from Procproc

### DIFF
--- a/src/ncomm/shrMLib.c
+++ b/src/ncomm/shrMLib.c
@@ -99,7 +99,10 @@ SHR_MEM_ID  shrmCreate(char *filename,int keyid, unsigned long size)
    perm = (keyid == SHR_EXP_INFO_KEY) ? O_RDONLY : (O_RDWR | O_CREAT);
    if ( (shrmid->shrmem = mOpen(filename,size,perm)) == NULL)
    {
-      errLogRet(ErrLogOp,debugInfo,"shrmCreate: mOpen failed\n");
+// There are cases where the file may not exist and we don't want a
+// confusing error message. Calling routine should handle NULL return
+//
+//    errLogRet(ErrLogOp,debugInfo,"shrmCreate: mOpen failed\n");
       free(shrmid);
       return(NULL);
    }

--- a/src/procproc/procfuncs.c
+++ b/src/procproc/procfuncs.c
@@ -456,7 +456,7 @@ int mapInExp(ExpInfoEntry *expid)
     expid->ShrExpInfo = shrmCreate(expid->ExpId,SHR_EXP_INFO_KEY,(unsigned long)sizeof(SHR_EXP_STRUCT)); 
     if (expid->ShrExpInfo == NULL)
     {
-       errLogSysRet(LOGOPT,debugInfo,"mapInExp: shrmCreate() failed:");
+//       errLogSysRet(LOGOPT,debugInfo,"mapInExp: shrmCreate() failed:");
        return(-1);
     }
     if (expid->ShrExpInfo->shrmem->byteLen < sizeof(SHR_EXP_STRUCT))


### PR DESCRIPTION
After an error, Procproc may display warnings about
not being able to mOpen the experiment code file