### PR TITLE
suppress output from setlockfreq by calling with a return value

### DIFF
--- a/src/common/maclib/setlockfreq
+++ b/src/common/maclib/setlockfreq
@@ -22,7 +22,9 @@ lockfreq='y'
 
 lockfreq = ((sfrq*1e6) / 6.51439977668) / 1.0e6
 tof = 0
-write('line3','Lock Frequency: %g', lockfreq)
-write('alpha','Lock Frequency: %g\n', lockfreq)
+if ($## = 0) then
+  write('line3','Lock Frequency: %g', lockfreq)
+  write('alpha','Lock Frequency: %g\n', lockfreq)
+endif
 fsave(systemdir+'/conpar','systemglobal')
 vttype = $vtval

--- a/src/expproc/expQfuncs.c
+++ b/src/expproc/expQfuncs.c
@@ -80,9 +80,9 @@ int initExpQs(int clean)
 {
   int i,qSize,retstat;
   procQ *queue;
-  char *startOffset;
   SHR_MEM_ID smem;
 #ifdef EXPQ_DEBUG
+  char *startOffset;
   expQentry *Qentries;
   char *endAddr;
   int j;
@@ -111,8 +111,8 @@ int initExpQs(int clean)
      ExpPendQ[i].procQstart = queue;   /* ExpPendQ[] in priority order */
      ExpPendQ[i].shrMem = smem;   /* ExpPendQ[] in priority order */
 
-     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
 #ifdef EXPQ_DEBUG
+     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
      DPRINT4(3,"%d, ProcQ Addr: 0x%lx, len %d, End Addr: 0x%lx\n",
 	i+1, queue, sizeof(procQ), ((char*)queue + sizeof(procQ)) - (char*)1);
      DPRINT4(3,"%d, ProcQ Offset: 0x%lx, len %d, End Offset: 0x%lx\n",
@@ -163,7 +163,9 @@ int expQaddToTail(int priority, char* expidstr, char* expinfostr)
   expQentry *Qentries;
   procQ *queue;
   sigset_t    savemask;
+#ifdef EXPQ_DEBUG
   char *startOffset;
+#endif
  
   blockSignals(&savemask);
     
@@ -188,8 +190,8 @@ int expQaddToTail(int priority, char* expidstr, char* expinfostr)
     errLogRet(ErrLogOp,debugInfo,"expQaddToTail: Queue Entry pointer is NULL\n");
     return(-1);
   }
-  startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
 #ifdef EXPQ_DEBUG
+  startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
   DPRINT2(3,"\n\nprocQadd: %d, ProcQ Offset: 0x%lx, \n", priority, startOffset);
 
   DPRINT2(3,
@@ -235,7 +237,9 @@ int expQaddToHead(int priority, char* expidstr, char* expinfostr)
   expQentry *Qentries;
   procQ *queue;
   sigset_t    savemask;
+#ifdef EXPQ_DEBUG
   char *startOffset;
+#endif
  
   blockSignals(&savemask);
     
@@ -260,8 +264,8 @@ int expQaddToHead(int priority, char* expidstr, char* expinfostr)
     errLogRet(ErrLogOp,debugInfo,"expQaddToTail: Queue Entry pointer is NULL\n");
     return(-1);
   }
-  startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
 #ifdef EXPQ_DEBUG
+  startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
   DPRINT2(3,"\n\nprocQadd: %d, ProcQ Offset: 0x%lx, \n", priority, startOffset);
 
   DPRINT2(3,
@@ -314,7 +318,9 @@ int expQget(int* priority, char* expidstr)
   procQ *queue;
   int i,stat;
   sigset_t    savemask;
+#ifdef EXPQ_DEBUG
   char* startOffset;
+#endif
 
   blockSignals(&savemask);
  
@@ -332,8 +338,8 @@ int expQget(int* priority, char* expidstr)
      if (queue->numInQ == 0)	/* non in this Q, goto next */
        continue;
 
-     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
 #ifdef EXPQ_DEBUG
+     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
      DPRINT3(3,"\nexpQget: priority %d, ProcQ Addr: 0x%lx, Offset: 0x%lx, \n", 
 		i+1, queue, startOffset);
 #endif
@@ -386,8 +392,10 @@ int expQsearch(char *userName,char* expnum,int *priority,char *expidstr)
   procQ *queue;
   int i,stat,qindx;
   sigset_t    savemask;
-  char* startOffset;
   char  infostr[EXPID_LEN];
+#ifdef EXPQ_DEBUG
+  char* startOffset;
+#endif
 
 
   blockSignals(&savemask);
@@ -409,8 +417,8 @@ int expQsearch(char *userName,char* expnum,int *priority,char *expidstr)
      if (queue->numInQ == 0)	/* none in this Q, goto next */
        continue;
 
-     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
 #ifdef EXPQ_DEBUG
+     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
      DPRINT3(3,"\nexpQget: priority %d, ProcQ Addr: 0x%lx, Offset: 0x%lx, \n", 
 		i+1, queue, startOffset);
 #endif
@@ -490,7 +498,9 @@ int expQIdsearch(char *expidstr, int *priority)
   procQ *queue;
   int i,stat,qindx;
   sigset_t    savemask;
+#ifdef EXPQ_DEBUG
   char* startOffset;
+#endif
 
 
   blockSignals(&savemask);
@@ -511,8 +521,8 @@ int expQIdsearch(char *expidstr, int *priority)
      if (queue->numInQ == 0)	/* none in this Q, goto next */
        continue;
 
-     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
 #ifdef EXPQ_DEBUG
+     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
      DPRINT3(3,"\nexpQget: priority %d, ProcQ Addr: 0x%lx, Offset: 0x%lx, \n", 
 		i+1, queue, startOffset);
 #endif
@@ -560,8 +570,10 @@ int expQgetinfo(int index, char* expinfostr)
   procQ *queue;
   int i,stat;
   sigset_t    savemask;
-  char* startOffset;
   int qindex = 0;
+#ifdef EXPQ_DEBUG
+  char* startOffset;
+#endif
 
   blockSignals(&savemask);
  
@@ -579,8 +591,8 @@ int expQgetinfo(int index, char* expinfostr)
      if (queue->numInQ == 0)	/* non in this Q, goto next */
        continue;
 
-     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
 #ifdef EXPQ_DEBUG
+     startOffset = (char*) ((char*)queue - (char*)ExpPendQ[0].procQstart);
      DPRINT3(3,"\nexpQget: priority %d, ProcQ Addr: 0x%lx, Offset: 0x%lx, \n", 
 		i+1, queue, startOffset);
 #endif
@@ -786,7 +798,7 @@ void expQRelease()
 int expQshow(void )
 {
   int i,j;
-  expQentry *Qentries;
+  expQentry *Qentries __attribute__((unused));
   procQ *queue;
   int totalq = 0;
 
@@ -1107,7 +1119,7 @@ void activeExpQRelease()
 int activeExpQshow(void)
 {
   int j;
-  activeQentry *Qentries;
+  activeQentry *Qentries __attribute__((unused));
   procQ *queue;
 
   queue = activeQ.procQstart;

--- a/src/ncomm/SConstruct
+++ b/src/ncomm/SConstruct
@@ -64,7 +64,7 @@ vwacqPath    = os.path.join(cwd, os.pardir, 'vwacq')
 vwacqHdrList = ['hostAcqStructs.h']
 
 # build environment
-env = Environment(CCFLAGS    = '-fPIC -g -c -Wall -O -m32',
+env = Environment(CCFLAGS    = '-fPIC -c -Wall -O -m32',
                   CPPDEFINES = ['LINUX', 'NESSIE', 'USE_HTONS'],
                   LINKFLAGS  = '-m32',
                   CPPPATH    = [cwd])

--- a/src/procproc/procQfuncs.c
+++ b/src/procproc/procQfuncs.c
@@ -129,7 +129,9 @@ int initProcQs(int clean)
 {
   int qSize,retstat;
   procQ *queue;
+#ifdef PROC_DEBUG
   char *startOffset;
+#endif
   SHR_MEM_ID smem;
 
   retstat = 0;
@@ -153,8 +155,8 @@ int initProcQs(int clean)
      procQlist.procQstart = queue;
      procQlist.shrMem = smem;
 
-     startOffset = (char*) ((char*)queue - (char*)procQlist.procQstart);
 #ifdef PROC_DEBUG
+     startOffset = (char*) ((char*)queue - (char*)procQlist.procQstart);
      DPRINT3(3,"ProcQ Addr: 0x%lx, len %d, End Addr: 0x%lx\n",
 	queue, sizeof(procQ), ((char*)queue + sizeof(procQ)) - (char*)1);
      DPRINT3(3,"ProcQ Offset: 0x%lx, len %d, End Offset: 0x%lx\n",
@@ -206,7 +208,9 @@ int procQadd(int proctype, char* expidstr, long elemId, long ct, int dcode, int 
   procQentry *Qentries;
   procQ *queue;
   sigset_t    blockmask, savemask;
+#ifdef PROC_DEBUG
   char *startOffset;
+#endif
  
   /* --- mask to block SIGALRM, SIGIO and SIGCHLD interrupts --- */
   sigemptyset( &blockmask );
@@ -251,8 +255,8 @@ int procQadd(int proctype, char* expidstr, long elemId, long ct, int dcode, int 
     sigprocmask(SIG_SETMASK, &savemask, (sigset_t *)NULL);
     return(-1);
   }
-  startOffset = (char*) ((char*)queue - (char*)procQlist.procQstart);
 #ifdef PROC_DEBUG
+  startOffset = (char*) ((char*)queue - (char*)procQlist.procQstart);
   DPRINT2(4,"\n\nprocQadd: %d, ProcQ Offset: 0x%lx, \n", proctype+1, startOffset);
 
   DPRINT5(4,
@@ -318,7 +322,9 @@ int procQget(int* proctype, char* expidstr, long* elemId, long* ct, int* dcode, 
   procQ *queue;
   int stat;
   sigset_t    blockmask, savemask;
+#ifdef PROC_DEBUG
   char* startOffset;
+#endif
  
   /* --- mask to block SIGALRM, SIGIO and SIGCHLD interrupts --- */
   sigemptyset( &blockmask );
@@ -351,8 +357,8 @@ int procQget(int* proctype, char* expidstr, long* elemId, long* ct, int* dcode, 
      if (queue->numInQ == 0)	/* non in this Q */
        return(-1);
 
-     startOffset = (char*) ((char*)queue - (char*)procQlist.procQstart);
 #ifdef PROC_DEBUG
+     startOffset = (char*) ((char*)queue - (char*)procQlist.procQstart);
      DPRINT2(4,"\nprocQget: ProcQ Addr: 0x%lx, Offset: 0x%lx, \n", queue, startOffset);
 #endif
 

--- a/src/scripts/ins_vnmr2.sh
+++ b/src/scripts/ins_vnmr2.sh
@@ -1042,7 +1042,6 @@ then
    fi
    chmod 777   "$dest_dir"/tmp
    chmod 666   "$dest_dir"/acq/info
-   chmod 775   "$dest_dir"/tune
    # Signal to vjpostinstallaction to display final install instructions
    touch /tmp/.ovj_installed
    chmod 666 /tmp/.ovj_installed
@@ -1058,9 +1057,13 @@ then
    ${chgrp_cmd} $nmr_group "$dest_dir"/acqqueue
       fi
    fi
-   if [ ! -d "$dest_dir"/tune/OptimaFirmware ]
+   if [ -d "$dest_dir"/tune ]
    then
+      chmod 775   "$dest_dir"/tune
+      if [ ! -d "$dest_dir"/tune/OptimaFirmware ]
+      then
          mkdir "$dest_dir"/tune/OptimaFirmware
+      fi
    fi
 
 

--- a/src/vnmr/acqfuncs.c
+++ b/src/vnmr/acqfuncs.c
@@ -181,8 +181,8 @@ int acqproc_msge(int argc, char *argv[], int retc, char *retv[])
    char            user[MAXPATHL];
    char            message[MAXPATHL];
    int             cmdval;
-   int             buglevel,
-                   ival, len;
+   int             buglevel, len;
+   int             ival __attribute__((unused));
 
    if ( is_datastation() )
    {
@@ -1556,7 +1556,7 @@ int setfrq(int argc, char *argv[], int retc, char *retv[])
 static void
 get_nuctab_name(double h1freq, char rftype, char *nuctable)
 {
-    char suffix[8];
+    char suffix[16];
 
     if (fabs(h1freq - 127) < 10){
 	strcpy(suffix, "3T");
@@ -2087,9 +2087,10 @@ interact_is_alive(char *tag, char *message)
 		}
 		else
                 {
+                   int ret __attribute__((unused));
                    sprintf(cmd,"(umask 0; echo %s > %s/acqqueue/%s_info_%d)\n",
                         message, systemdir, pl->tagname, pl->pid);
-                   system(cmd);
+                   ret = system(cmd);
                    kill(pl->pid, SIGUSR2);      /* Issue  command */
                 }
 	    }
@@ -2181,6 +2182,7 @@ void interact_disconnect(char *tag)
 static void interact_disconnect_by_pid(PidList *pl)
 {
     char cmd[256];
+    int ret __attribute__((unused));
 
     if (pl && pl->pid && pl->connected){
         sigset_t        emptymask;
@@ -2188,7 +2190,7 @@ static void interact_disconnect_by_pid(PidList *pl)
         sigemptyset( &emptymask );
 	sprintf(cmd,"(umask 0; echo go > %s/acqqueue/%s_info_%d)\n",
 		systemdir, pl->tagname, pl->pid);
-	system(cmd);
+	ret = system(cmd);
 	kill(pl->pid, SIGUSR2);	/* Issue disconnect command */
 	while (pl->connected){
 	    sigsuspend( &emptymask );	/* Wait for a signal */
@@ -2246,11 +2248,12 @@ static void interact_kill_by_pid(PidList *pl)
 	    pl->pid = pl->connected = 0;
 	}else{
             sigset_t        emptymask;
+            int ret __attribute__((unused));
 
             sigemptyset( &emptymask );
 	    sprintf(cmd, "(umask 0; echo exit > %s/acqqueue/%s_info_%d)\n"
 		    ,systemdir, pl->tagname, pl->pid);
-	    system(cmd);
+	    ret = system(cmd);
 	    kill(pl->pid, SIGUSR2);
 	    while (pl->pid && pl->connected){ /* Flags changed by signal */
 		sigsuspend( &emptymask );	/* Wait for a signal */
@@ -2466,7 +2469,7 @@ int atCmd(int argc, char *argv[], int retc, char *retv[])
    int port, pid;
    int matchOnly;
    struct timeval clock;
-   struct tm *local;
+   struct tm *local __attribute__((unused));
    int repeatAt;
    char *argvTmp[1];
 

--- a/src/vnmr/bgvars.c
+++ b/src/vnmr/bgvars.c
@@ -114,13 +114,14 @@ pipeTransfer(int tree, char *name, varInfo *v, vInfo *vI, int fd)
     register int   i;
     int   size;
     register Rval *r;
+    int ret __attribute__((unused));
 
     size = strlen(name);
     sigprocmask( SIG_BLOCK, &blockMask, &saveMask );
-    write(fd,&tree,sizeof(int)); /* send out op code */
-    write(fd,&size,sizeof(int));
-    write(fd,name,size);
-    write(fd,vI,sizeof(vInfo)); 
+    ret = write(fd,&tree,sizeof(int)); /* send out op code */
+    ret = write(fd,&size,sizeof(int));
+    ret = write(fd,name,size);
+    ret = write(fd,vI,sizeof(vInfo)); 
 
     /*  write out good stuff */
     if (v->T.basicType == T_STRING)  /* send string values */
@@ -128,8 +129,8 @@ pipeTransfer(int tree, char *name, varInfo *v, vInfo *vI, int fd)
      	r = v->R;
 	while (r && i < v->T.size+1)
 	{   size = strlen(r->v.s);
-	    write(fd,&size,sizeof(int));
-	    write(fd,r->v.s,size);
+	    ret = write(fd,&size,sizeof(int));
+	    ret = write(fd,r->v.s,size);
 	    i += 1;
 	    r = r->next;
 	}
@@ -138,7 +139,7 @@ pipeTransfer(int tree, char *name, varInfo *v, vInfo *vI, int fd)
     {	i = 1; 
      	r = v->R;
 	while (r && i < v->T.size+1)
-	{   write(fd,&r->v.r,sizeof(double));
+	{   ret = write(fd,&r->v.r,sizeof(double));
 	    i += 1;
 	    r = r->next;
 	}
@@ -176,8 +177,9 @@ int P_sendTPVars(int tree, int fd)
 
 void P_endPipe(int fd)
 {   
+    int ret __attribute__((unused));
     sigprocmask( SIG_BLOCK, &blockMask, &saveMask );
-    write(fd,&endop,sizeof(int));
+    ret = write(fd,&endop,sizeof(int));
     sigprocmask( SIG_SETMASK, &saveMask, NULL );
 }
 
@@ -492,19 +494,20 @@ static void jPipeTransfer(char *name, varInfo *v, vInfo *vI, int fd)
     doubleUnion swap;
 #endif
     double dtmp;
+    int ret __attribute__((unused));
 
     size = strlen(name);
     longSwap = htonl(size);
     sigprocmask( SIG_BLOCK, &blockMask, &saveMask );
-    write(fd,&longSwap,sizeof(int));
-    write(fd,name,size);
+    ret = write(fd,&longSwap,sizeof(int));
+    ret = write(fd,name,size);
     /* write(fd,vI,sizeof(vInfo));  not for Jpsg but the following 3 items instead */
     shortSwap = htons(vI->subtype);
-    write(fd,&shortSwap,sizeof(short));
+    ret = write(fd,&shortSwap,sizeof(short));
     shortSwap = htons(vI->basicType);
-    write(fd,&shortSwap,sizeof(short));
+    ret = write(fd,&shortSwap,sizeof(short));
     shortSwap = htons(v->T.size);
-    write(fd,&shortSwap,sizeof(short));
+    ret = write(fd,&shortSwap,sizeof(short));
 
     /*  write out good stuff */
     if (v->T.basicType == T_STRING)  /* send string values */
@@ -513,8 +516,8 @@ static void jPipeTransfer(char *name, varInfo *v, vInfo *vI, int fd)
 	while (r && i < v->T.size+1)
 	{   size = strlen(r->v.s);
             longSwap = htonl(size);
-	    write(fd,&longSwap,sizeof(int));
-	    write(fd,r->v.s,size);
+	    ret = write(fd,&longSwap,sizeof(int));
+	    ret = write(fd,r->v.s,size);
 	    i += 1;
 	    r = r->next;
 	}
@@ -532,7 +535,7 @@ static void jPipeTransfer(char *name, varInfo *v, vInfo *vI, int fd)
             swap.out->s1 = htonl(swap.out->s2);
             swap.out->s2 = tmp;
 #endif
-            write(fd,&dtmp,sizeof(double));
+            ret = write(fd,&dtmp,sizeof(double));
 	    i += 1;
 	    r = r->next;
 	}


### PR DESCRIPTION
Fixed a number of compiler warning. No longer compile
ncomm with the -g option. Fixed ins_vnmr to check for /vnmr/tune
before updating files in that directory.