### PR TITLE
chkname would incorrectly remove allowed characters

### DIFF
--- a/src/common/manual/autoname
+++ b/src/common/manual/autoname
@@ -170,6 +170,10 @@ The alnum keyword can be followed by a list of other allowable characters.
   'none' disables the character substitutions.
 Supplying a list of characters is interpreted as disallowed characters.
 An example may be ' .,;:*!?()[]{}<>~#$%&/'
+Successive disallowed characters will be replaced by a single replacement
+character. For example
+chkname('a     lot  of    spaces'):$res
+will set $res='a_lot_of_spaces' and not $res='a_____lot__of____spaces'
 
 A special incantation of the chkname command will set the non-alphanumeric
 characters selected by the 'file' and 'dir' keywords. The command


### PR DESCRIPTION
If the replacement character is also an allowed character,
successive one were being removed.