### PR TITLE
Increased number of elements of a parameter

### DIFF
--- a/src/vnmr/variables.h
+++ b/src/vnmr/variables.h
@@ -54,8 +54,9 @@ struct _Rval { union _choice  v;
 	     };
 typedef struct _Rval Rval;
 
-struct _Tval { short size;
+struct _Tval {
 	       short basicType;
+               int size;
 	     };
 typedef struct _Tval Tval;
 
@@ -72,9 +73,9 @@ struct _vInfo   { short		active;    /* 1-active  0-not active */
 		  short		Dgroup;    /* Display group */
 		  short		group;	   /* group */
 		  short		basicType; 
-		  short		size;      /*  size of array */
 		  short		subtype;   
 		  short		Esize;     /*  size of enumeration array */
+		  int		size;      /*  size of array */
 		  int		prot;      /*  protection  bits */
 		  double	minVal;
 		  double 	maxVal;


### PR DESCRIPTION
It was limited to 32767 because of the use of a short int
to hold the size of the parameter array. Changed to int.