### PR TITLE
Replace method of starting the acquisition communications

### DIFF
--- a/src/bin/SConstruct.bin
+++ b/src/bin/SConstruct.bin
@@ -43,8 +43,7 @@ bit32FileList = ['convertbru.c',
                       'phcor5.c',
                       'spins.c']
 
-acqStandAloneFileList = ['cptoconpar.c',
-                         'startmekillme.c']
+acqStandAloneFileList = ['cptoconpar.c']
 
 imageStandAloneFileList = ['read_raw_data.c']
 

--- a/src/common/adm/acq/verifyCntlrsFlash.py
+++ b/src/common/adm/acq/verifyCntlrsFlash.py
@@ -14,7 +14,7 @@
       Before running this script.
 
            Besure the Acquisition processes are stopped
-           i.e. su acqproc
+           i.e. acqcomm stop
 
            Close all remote logins to any controllers
    
@@ -1265,7 +1265,7 @@ if __name__ == "__main__":
     procs = check4Procs()
     if ( procs == True ):
        logger.info(" ")
-       logger.info("The Acqusition Processes are running, \r\nPlease stop them (e.g. su acqproc) then rerun this script")
+       logger.info("The Acqusition Processes are running, \r\nPlease stop them (e.g. acqcomm stop) then rerun this script")
        logger.info(" ")
        os._exit(0)
 

--- a/src/common/manual/acqcomm
+++ b/src/common/manual/acqcomm
@@ -1,0 +1,27 @@
+************************************************************************
+acqcomm  - script to start and stop the acquisition communication system
+************************************************************************
+
+
+acqcomm will start and stop the acquisition communication system.
+It replaces the previous "su acqproc" method.
+It needs to be run from a terminal window, not the OpenVnmrJ command line.
+
+Options:
+
+    acqcomm
+       will start the acquisition communication system if
+       it is not running and stop it if it is running
+
+    acqcomm start
+       will start the acqisition communication system
+
+    acqcomm stop
+       will stop the acqisition communication system
+
+    acqcomm status
+       will display whether the acqisition communication system
+       is stopped or started
+
+    acqcomm help
+       will display this help message

--- a/src/common/manual/readhw
+++ b/src/common/manual/readhw
@@ -54,7 +54,7 @@ error values. These are
 -1    available on spectrometer only (ie system = 'datastation')
 -2    acquisition not active  (Acquisition communication programs
                                are not running. Probably needs
-                               su acqproc)
+                               acqcomm)
 -7    console powered down or not connected
 
 readhw accepts the keyword 'temp' to return the temperature.

--- a/src/common/openvnmrj-utils/bin/switchVJ.sh
+++ b/src/common/openvnmrj-utils/bin/switchVJ.sh
@@ -73,9 +73,8 @@ then
         PID=$(pgrep Expproc)
         if [[ ! -z ${PID} ]]
         then
-            echo "Stopping Acquisition communications."
             PROCS=1
-            /vnmr/bin/execkillacqproc >/dev/null 2>&1
+            /vnmr/bin/acqcomm stop
         fi
 
         # Stop the locator database daemon
@@ -102,8 +101,7 @@ then
     # Restart the procs if they were running before
     if [[ ${PROCS} -eq 1 ]]
     then
-        echo "Starting Acquisition communications."
-        /vnmr/bin/execkillacqproc >/dev/null 2>&1
+        /vnmr/bin/acqcomm start
     fi
 fi
 

--- a/src/scripts/SConstruct.common
+++ b/src/scripts/SConstruct.common
@@ -5,18 +5,6 @@ import sys
 # MAC -> darwin, Linux -> linux2
 platform = sys.platform
 
-
-#
-# define function to convert SUA paths to Windows
-
-def Sua2WinPath(suaPath):
-   if ( '/dev/fs/' in suaPath ):
-     dLetter = suaPath[8:9]
-     # print(dLetter)
-     return dLetter + ':' + suaPath[9:]
-   else:
-      return suaPath
-
 print('SConstruct.common')
 #get current working directory
 cwd = os.getcwd()
@@ -31,6 +19,7 @@ obsoleteList = 	['isjpsgup',
                'vnmr']
 
 acqList    = 	['bootr',
+                'acqcomm',
                 'cryoclient',
                 'cryomon',
                 'execkillacqproc',
@@ -91,7 +80,6 @@ fileList    = 	['adddevices',
                 'ovjUpdate',
                 'ovjUser',
                 'ovjWallPaper',
-                'patchinstall_ver1',
                 'patchinstall',
                 'patchmake',
                 'patchuninstall',
@@ -158,8 +146,6 @@ scriptFiles = [ 'vwScript',
              'vwScriptPPC',
              'vwAutoScript' ]
 
-InterixScriptFiles = [ 'makeuser_interix' ]
-
 vnmrBinPath = os.path.join(cwd,os.pardir,os.pardir,os.pardir,'vnmr','bin')
 if not os.path.exists(vnmrBinPath) :
     os.makedirs(vnmrBinPath)
@@ -190,7 +176,7 @@ if ('darwin' in platform):
    Execute(Copy(dest,i))
    Execute(Chmod(dest,0o755))
 
-if ( ('darwin' not in platform) and ('interix' not in platform) ):
+if ('darwin' not in platform):
    for i in acqList:
       dest = os.path.join(vnmrBinPath,i)
       Execute(Copy(dest,i+'.sh'))
@@ -251,72 +237,3 @@ if ( ('darwin' not in platform) and ('interix' not in platform) ):
       dest = os.path.join(acq2Path,i)
       Execute(Copy(dest,i+'.sh'))
       Execute(Chmod(dest,0o755))
-
-if ('interix' in platform):
-   # copy isADmin for Intgerix systems
-   dest = os.path.join(vnmrBinPath,'isAdmin')
-   src = os.path.join(cwd,'isAdmin.sh')
-   Execute(Copy(dest,src))
-   Execute(Chmod(dest,0o755))
-   dest = os.path.join(vnmrBinPath,'makeuser')
-   src = os.path.join(cwd,'makeuser_interix.sh')
-   Execute(Copy(dest,src))
-   Execute(Chmod(dest,0o755))
-   #
-   # option to the batch to exec application
-   #
-   #  -icon [filename]   The icon file of your application 
-   #   -invisible   Create an invisible application 
-   #   -temp   Use the temporary directory on execution 
-   #   -nodelete   Do not delete the temporary files 
-   #   -encrypt [Password]   Encrypt the program with a password 
-   #   -admin   Add an administrador manifest to the program 
-   #   -overwrite   Overwrite existing files 
-   #   -decompiler [String]   Add a decompiler to the program 
-   #   -include [filename]   Include additional files to the program 
-   #   -fileversion [String]   File version number 
-   #   -productversion [String]   Product version number 
-   #   -company [String]   Company name 
-   #   -productname [String]   Product name 
-   #   -internalname [String]   Internal name 
-   #   -description [String]   Product description 
-   #   -copyright [String]   Copyright 
-   
-   bat2exe=os.path.join(cwd,os.pardir,os.pardir,'3rdParty','winBatch2Exe','Bat_To_Exe_Converter.exe')
-   company=' -company "Agilent LSG-RPD"'
-   product=' -productname "VnmrJ"'
-   iconpath= os.path.join(cwd,os.pardir,'iconlib','vnmrbg_iconlib')
-   batpath=Sua2WinPath(os.path.join(cwd,'vnmrj.bat'))
-   exepath=Sua2WinPath(os.path.join(cwd,'VnmrJb.exe'))
-   icon=Sua2WinPath(os.path.join(iconpath,'vnmrj_classic.ico'))
-
-   rmcmd='rm ' + 'VnmrJ*.exe'
-   cmdaction=bat2exe + ' -overwrite  -bat ' + batpath + ' -save ' + exepath + ' -icon ' + icon  + company + product
-   #Execute(Action(cmdaction))   doesn't work, windows app gives error so use the os.system call directly
-   print(rmcmd)
-   print(cmdaction)
-   os.system(rmcmd) 
-   os.system(cmdaction)
-   dest = os.path.join(vnmrBinPath,'VnmrJb.exe')
-   Execute(Copy(dest, os.path.join(cwd,'VnmrJb.exe')))
-   Execute(Chmod(dest,0o755))
-   dest = os.path.join(vnmrBinPath,'vnmrj.bat')
-   Execute(Copy(dest, os.path.join(cwd,'vnmrj.bat')))
-   Execute(Chmod(dest,0o755))
-
-   dest = os.path.join(vnmrBinPath,'convert')
-   Execute(Copy(dest,'convert.sh'))
-   Execute(Chmod(dest,0o755))
-
-   batpath=Sua2WinPath(os.path.join(cwd,'vnmrjadmin.bat'))
-   exepath=Sua2WinPath(os.path.join(cwd,'VnmrJ_Adminb.exe'))
-   icon=Sua2WinPath(os.path.join(iconpath,'vnmrjadmin.ico'))
-   cmdaction=bat2exe + ' -overwrite  -bat ' + batpath + ' -save ' + exepath + ' -icon ' + icon  + company + product
-   print(cmdaction)
-   os.system(cmdaction)
-   dest = os.path.join(vnmrBinPath,'VnmrJ_Adminb.exe')
-   Execute(Copy(dest, os.path.join(cwd,'VnmrJ_Adminb.exe')))
-   Execute(Chmod(dest,0o755))
-   dest = os.path.join(vnmrBinPath,'vnmrjadmin.bat')
-   Execute(Copy(dest, os.path.join(cwd,'vnmrjadmin.bat')))
-   Execute(Chmod(dest,0o755))

--- a/src/scripts/acqcomm.sh
+++ b/src/scripts/acqcomm.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# 
+#
+# Copyright (C) 2015  University of Oregon
+# 
+# You may distribute under the terms of either the GNU General Public
+# License or the Apache License, as specified in the LICENSE file.
+# 
+# For more information, see the LICENSE file.
+# 
+#
+#
+#  acqcomm - run startStopProcs with sudo
+#            On newer systems with systemd in use, unless the
+#            procs are started by the systemd system, they will
+#            be terminated when the user that starts them logs out.
+#
+#  acqcomm        - start the acquisition communication system if
+#                   it is not running and stop it if it is running
+#  acqcomm start  - start the acquisition communication system
+#  acqcomm stop   - stop  the acquisition communication system
+#  acqcomm status - report status of acquisition communication system
+#  acqcomm help   - display usage of acqcomm
+#
+# set -x
+
+if [[ $# -gt 0 ]]; then
+   npids=$(pgrep Expproc)
+   if [[ $1 = "help" ]]; then
+      echo ""
+      cat /vnmr/manual/acqcomm
+      echo ""
+      exit
+   elif [[ $1 = "status" ]]; then
+      if [[ -z $npids ]]; then
+         echo "Acquisition communication system is stopped"
+      else
+         echo "Acquisition communication system is started"
+      fi
+      exit
+   elif [[ $1 = "start" ]] && [[ ! -z $npids ]]; then
+      echo "Acquisition communication system is already started"
+      exit
+   elif [[ $1 = "stop" ]] && [[ -z $npids ]]; then
+      echo "Acquisition communication system is already stopped"
+      exit
+   fi
+fi
+
+sudo /vnmr/acqbin/startStopProcs

--- a/src/scripts/execkillacqproc.sh
+++ b/src/scripts/execkillacqproc.sh
@@ -16,4 +16,11 @@
 #                    be terminated when the user that starts them logs out.
 #
 
+echo "The \"su acqproc\" method of starting and stopping the acquisition"
+echo "communication system is being deprecated."
+echo "Use the acqcomm script instead"
+echo ""
+/vnmr/bin/acqcomm help
+echo ""
+
 sudo /vnmr/acqbin/startStopProcs

--- a/src/scripts/ins_vnmr2.sh
+++ b/src/scripts/ins_vnmr2.sh
@@ -1728,11 +1728,11 @@ home yes no '${nmr_home}'/$accname' > "$dest_dir"/adm/users/userDefaults.bak
    # cptoconpar so everyone can update sysgcoil in conpar
    if [ x$lflvr != "xdebian" ]
    then
-      chmod 4775 "$dest_dir"/bin/execkillacqproc
+      chmod 775 "$dest_dir"/bin/execkillacqproc
       chmod 4755 "$dest_dir"/bin/loginvjpassword
       chmod 4755 "$dest_dir"/bin/cptoconpar
    else
-      sudo chmod 4775 "$dest_dir"/bin/execkillacqproc
+      sudo chmod 775 "$dest_dir"/bin/execkillacqproc
       sudo chmod 4755 "$dest_dir"/bin/loginvjpassword
       sudo chmod 4755 "$dest_dir"/bin/cptoconpar
    fi
@@ -1773,6 +1773,7 @@ home yes no '${nmr_home}'/$accname' > "$dest_dir"/adm/users/userDefaults.bak
         cp -p "$dest_dir"/bin/S99pgsql /etc/init.d/pgsql
      else
         sudo cp -p "$dest_dir"/bin/S99pgsql /etc/init.d/pgsql
+        sudo chown root:root /etc/init.d/pgsql
      fi
      
      r_levl="rc3.d"

--- a/src/scripts/patchinstall.sh
+++ b/src/scripts/patchinstall.sh
@@ -676,7 +676,7 @@ then
     printf  "su_acqproc=yes\n" >> $patch_save_dir/p_uninstall
     echo ""
     echo "Console communication software has been updated."
-    echo "Restart the communication software (su acqproc)"
+    echo "Restart the communication software with acqcomm"
     echo "for the patch to take effect"
     echo ""
 fi

--- a/src/scripts/patchuninstall.sh
+++ b/src/scripts/patchuninstall.sh
@@ -255,7 +255,7 @@ elif [ x$su_acqproc = "xyes" ]
 then 
     echo ""
     echo "Console communication software has been updated."
-    echo "Restart the communication software (su acqproc)"
+    echo "Restart the communication software with acqcomm"
     echo "for the patch to take effect"
     echo ""
 fi

--- a/src/scripts/setacq.sh
+++ b/src/scripts/setacq.sh
@@ -910,7 +910,7 @@ if [[ ${doingMI} -eq 0 ]] ; then
 fi
 
 export vnmrsystem
-${vnmrsystem}/bin/makesuacqproc silent
+#  ${vnmrsystem}/bin/makesuacqproc silent
 
 echo ""
 echo "NMR Console software installation complete"
@@ -925,4 +925,7 @@ then
 else
    ${vnmrsystem}/acqbin/startStopProcs
 fi
+echo ""
+${vnmrsystem}/bin/acqcomm help
+echo ""
 

--- a/src/scripts/sudoins.sh
+++ b/src/scripts/sudoins.sh
@@ -41,7 +41,6 @@ USER HOST = NOPASSWD: \\
    VBIN/jtestuser,\\
    VBIN/vcmdr,\\
    VBIN/vcmdm,\\
-   ABIN/startStopProcs,\\
    /usr/bin/getent,\\
    /usr/bin/passwd,\\
    /usr/sbin/useradd,\\
@@ -62,6 +61,7 @@ USER HOST = NOPASSWD: \\
    SBIN/scanlog
 
 %GROUP HOST = NOPASSWD: \\
+   ABIN/startStopProcs,\\
    VBIN/probe_mount,\\
    VBIN/probe_unmount
 

--- a/src/scripts/vnmrsetup.sh
+++ b/src/scripts/vnmrsetup.sh
@@ -387,7 +387,7 @@ rm -f /etc/profile.d/openwin.csh
 
 form_dest_dir
 #dest_dir="$default_dir/vnmr"
-nmr_user="vnmr1"
+nmr_user=$(logname)
 user_dir="$default_dir"
 nmr_group="nmr"
 
@@ -556,6 +556,7 @@ if [ -e /tmp/.ovj_installed ]; then
                   echo "Configuring $name with the standard configuration (stdConf)"
                   echo "Configuring $name with the standard configuration (stdConf)" >> $insLog
                   sudo -i -u $name /vnmr/bin/Vnmrbg -mback -n1 stdConf >> $insLog 2> /dev/null
+                  echo ""
                else
                   su - $nmr_user -c "/vnmr/bin/create_pgsql_user $name 2>> $insLog"
                   echo "Adding $name to OpenVnmrJ configuration files"
@@ -563,6 +564,7 @@ if [ -e /tmp/.ovj_installed ]; then
                   echo "Configuring $name with the standard configuration (stdConf)"
                   echo "Configuring $name with the standard configuration (stdConf)" >> $insLog
                   su - $name -c "/vnmr/bin/Vnmrbg -mback -n1 stdConf >> $insLog" 2> /dev/null
+                  echo ""
                fi
             fi
          done


### PR DESCRIPTION
The old method was to run "su acqproc". This is replaced with the
acqcomm script. There is also a man page. References to "su acqproc"
have been updated with acqcomm