### PR TITLE
Put pre-loading of subfilemenu under user control

### DIFF
--- a/src/vnmrj/src/vnmr/bo/VSubFileMenu.java
+++ b/src/vnmrj/src/vnmr/bo/VSubFileMenu.java
@@ -88,21 +88,23 @@ public class VSubFileMenu extends VSubMenu
                 Messages.writeStackTrace(e);
             }
         }
-/*
-        updateChild = true;
-        int m = getMenuComponentCount();
-        for (int k = 0; k < m; k++) {
-            Component comp = getMenuComponent(k);
-            if (comp instanceof VMenuitemIF) {
-                VMenuitemIF xobj = (VMenuitemIF) comp;
-                xobj.initItem();
-            }
-            else if (comp instanceof ExpListenerIF) {
-                ExpListenerIF obj = (ExpListenerIF) comp;
-                obj.updateValue();
-            }
-        }
- */
+	String att=getAttribute(EXPANDED);
+	if (att != null && att.equals("yes"))
+	{
+           updateChild = true;
+           int m = getMenuComponentCount();
+           for (int k = 0; k < m; k++) {
+               Component comp = getMenuComponent(k);
+               if (comp instanceof VMenuitemIF) {
+                   VMenuitemIF xobj = (VMenuitemIF) comp;
+                   xobj.initItem();
+               }
+               else if (comp instanceof ExpListenerIF) {
+                   ExpListenerIF obj = (ExpListenerIF) comp;
+                   obj.updateValue();
+               }
+           }
+	}
     }
 }
 

--- a/src/vnmrj/src/vnmr/bo/VSubMenu.java
+++ b/src/vnmrj/src/vnmr/bo/VSubMenu.java
@@ -39,6 +39,7 @@ public class VSubMenu extends JMenu
     public String hotkey = null;
     public String iconName = null;
     public String tipStr = null;
+    public String expanded = null;
     public Color  fgColor = Color.black;
     public Color  bgColor, orgBg;
     public Color  inColor = null;
@@ -333,6 +334,8 @@ public class VSubMenu extends JMenu
             return null;
         case TOOLTIP:
             return tipStr;
+        case EXPANDED:
+            return expanded;
          default:
             return null;
         }
@@ -433,6 +436,9 @@ public class VSubMenu extends JMenu
                setToolTipText(Util.getLabel(c));
             else
                setToolTipText(null);
+            break;
+        case EXPANDED:
+            expanded = c;
             break;
         case PANEL_NAME:
             objName = c;


### PR DESCRIPTION
In commit #293, pre-loading of subfilemenus was removed.
This puts it back but under user control. If the attribute
expanded="yes" is present in the subfilemenu, it will be pre-loaded