### PR TITLE
fortran library missing on CentOS 8

### DIFF
--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -183,7 +183,7 @@ if [ ! -x /usr/bin/dpkg ]; then
   if [ $version -lt 8 ]; then
     commonList="$commonList rsh rsh-server"
   else
-    commonList="$commonList csh libnsl compat-openssl10"
+    commonList="$commonList csh libnsl compat-openssl10 compat-libgfortran-48"
   fi
 
 # Must list 32-bit packages, since these are no longer


### PR DESCRIPTION
DOSY programs require this. Added compat-libgfortran-48