### PR TITLE
Added option to substr basename

### DIFF
--- a/src/common/manual/substr
+++ b/src/common/manual/substr
@@ -139,9 +139,15 @@ substr	-	pick a substring or word out of a string
        The 'basename' of the special cases of '/', '.', and '..' return
        '/', '.', and '..' respectively.
     substr('string','basename'<,'suffixes'>):$base<,$ext>
-       An optional third argument is a list of suffixes. If the basename
-       has a dot (.) in it, the extension will only be removed if it matches
-       one on the supplied suffixes.
+       The behavior depends on whether a second return argument ($ext) is
+       requested.  If there is no second return argument, the third optional
+       argument is a single suffix. It will be removed from the basename if it
+       is present. This is consistent with the behavior of the Linux basename
+       command.
+       If there is a second return argument, the optional third argument is
+       a list of one or more suffixes.  If the basename has a dot (.) in it,
+       the extension will only be removed if it matches one on the supplied
+       suffixes.
        The examples will illustrate the behavior.
   Examples
     substr('/home/vnmr1','basename'):$base          $base='vnmr1'
@@ -149,6 +155,7 @@ substr	-	pick a substring or word out of a string
     substr('s2pul','basename'):$base                $base='s2pul'
     substr('s2pul','basename'):$base,$ext           $base='s2pul' $ext=''
     substr('s2pul.c','basename'):$base              $base='s2pul.c'
+    substr('s2pul.c','basename','.c'):$base         $base='s2pul'
     substr('s2pul.c','basename'):$base,$ext         $base='s2pul' $ext='c'
     substr('s2pul.','basename'):$base               $base='s2pul.'
     substr('s2pul.','basename'):$base,$ext          $base='s2pul.' $ext=''

--- a/src/vnmr/builtin.c
+++ b/src/vnmr/builtin.c
@@ -696,6 +696,15 @@ int substr(int argc, char *argv[], int retc, char *retv[])
            {
              if (retc == 1)
              {
+                if (argc > 3)
+                {
+                   char *ptr;
+                   if ( ( (ptr = strstr(tmp,argv[3])) != NULL ) &&
+                        ( strlen(ptr) == strlen(argv[3]) ) )
+                   {                
+                      *ptr = '\0';
+                   }
+                }
                 retv[0] = newString(tmp);
              }
              else if ( (strcmp(tmp,"..") == 0) || (strcmp(tmp,".") == 0) )
@@ -1700,7 +1709,7 @@ int groupcopy(int argc, char *argv[], int retc, char *retv[])
                 {   if ( 0 <= ( group = goodGroup(argv[3])))
                     {
 #ifdef VNMRJ
-			char to_tree[MAXPATH];
+			char to_tree[MAXPATH+8];
 
 			strncpy(to_tree,argv[2],MAXPATH);
 			vnmr_tolower(to_tree);
@@ -2422,7 +2431,7 @@ int unlinkFilesWithSuffix( char *dirpath, char *suffix )
  
    if ( (dirp = opendir(dirpath)) )
    {
-      char newname[MAXPATH];
+      char newname[MAXPATH*2];
       int len;
 
       for (dp = readdir(dirp); dp != NULL; dp = readdir(dirp))


### PR DESCRIPTION
Suppling a suffix with one return argument is now consistent
with the Linux basename command. The suffix is removed from
the basename. With two return arguments, the behavior has
not changed.