### PR TITLE
OVJ graphics screen would not refresh after being iconified

### DIFF
--- a/src/vnmrj/src/vnmr/ui/VnmrjUI.java
+++ b/src/vnmrj/src/vnmr/ui/VnmrjUI.java
@@ -2195,6 +2195,7 @@ public class VnmrjUI extends AppIF implements VnmrjIF, VnmrKey, DockConstants, V
               break;
           case WindowEvent.WINDOW_DEICONIFIED:
               setFrameListener(false);
+              repaint();
               break;
         }
     }


### PR DESCRIPTION
When switching to a new Linux desktop, when returning to the desktop running OVJ, the graphics is frozen. For example, enter sleep(10) dps into OVJ and then join another desktop. Wait 10 sec. and then retrun to the orginal desktop. OVJ will still be displaying the barber pole activity bar and dps will not be displayed. Required a "repaint()" upon receiving a WINDOW_DEICONIFIED event.