### PR TITLE
setacq could fail on Inova and Mercury systems

### DIFF
--- a/src/scripts/setacq.sh
+++ b/src/scripts/setacq.sh
@@ -923,6 +923,11 @@ then
    echo "You must reboot Linux for these changes to take effect"
    echo "As root type 'reboot' to reboot Linux"
 else
+   if [[ ${doingMI} -eq 1 ]] ; then
+      if [[ -x /usr/sbin/bootpd ]] ; then
+         (/usr/sbin/bootpd -s > /dev/console &)
+      fi
+   fi
    ${vnmrsystem}/acqbin/startStopProcs
 fi
 echo ""


### PR DESCRIPTION
If no re-boot was required, setacq would not start
the bootpd process for Inova and Mercury systems.
Re-booting the PC would work. This closes issue #419