### PR TITLE
pulsetool was not handling .DEC shapes correctly

### DIFF
--- a/src/bin/pulsetool_mf.c
+++ b/src/bin/pulsetool_mf.c
@@ -1674,7 +1674,7 @@ XtInputId *id;
 		if (chdir(directory_name) == -1) {
 		    frame_message("Error:  Unable to change directory.", PARAM_DIRECTORY_NAME);
 		}
-		getwd(directory_name);
+                getcwd(directory_name, 256);
 		set_panel_value(PARAM_DIRECTORY_NAME,directory_name);
             }
 	    /****


### PR DESCRIPTION
A .RF shape file has elements, in order, of phase, amplitude, and duration
while the .DEC shape file has elements duration, phase, amplitude. The
DEC amplitude was being mis-interpreted as a duration.
Also fixed a few compiler warnings.