### PR TITLE
Some java programs were not running on MacOS version

### DIFF
--- a/src/scripts/doAcct.sh
+++ b/src/scripts/doAcct.sh
@@ -80,13 +80,19 @@ then
    usage
 fi
 
+javabin="$vnmrsystem/jre/bin/java"
+if [ ! -f $javabin ]
+then
+   javabin="java"
+fi
+
 if [[ ${doCut} -eq 1 ]] ;
 then
-   $vnmrsystem/jre/bin/java -jar $vnmrsystem/java/account.jar -saveDir "${saveDir}" -cut
-   $vnmrsystem/jre/bin/java -jar $vnmrsystem/java/account.jar -saveDir "${saveDir}" \
+   $javabin -jar $vnmrsystem/java/account.jar -saveDir "${saveDir}" -cut
+   $javabin -jar $vnmrsystem/java/account.jar -saveDir "${saveDir}" \
             -in "${saveDir}"/acctLog.xml -summary -summaryCsv -acctCsv
 else
-   $vnmrsystem/jre/bin/java -jar $vnmrsystem/java/account.jar -saveDir "${saveDir}" \
+   $javabin -jar $vnmrsystem/java/account.jar -saveDir "${saveDir}" \
             -startDate "${startDate}" -endDate "${endDate}" -summary -summaryCsv -acctCsv
 fi
 

--- a/src/scripts/simplemovie.sh
+++ b/src/scripts/simplemovie.sh
@@ -11,15 +11,9 @@
 # 
 #
 
-ostype=`uname -s`
-
 if [ x$vnmrsystem = "x" ]
 then
-   if [ x$ostype = "xInterix" ]; then
-      . /vnmr/user_templates/.vnmrenvbash
-   else
-      source /vnmr/user_templates/.vnmrenvsh
-   fi
+   source /vnmr/user_templates/.vnmrenvsh
 fi
 
 if [ x$VGLRUN = "x" ]
@@ -30,20 +24,14 @@ else
 fi
 
 javabin="$vnmrsystem/jre/bin/java"
+if [ ! -f $javabin ]
+then
+   javabin="java"
+fi
 
 jclasspath=$vnmrsystem/java/simplemovie.jar
 
-if [ x$ostype = "xInterix" ]
-then
-   jclasspath=`/bin/unixpath2win "$jclasspath"`
-   javabin="/vnmr/jre/bin/java.exe"
-   $vjshell "$javabin"  \
-       -classpath $jclasspath \
-       -Djava.library.path="C:/SFU/vnmr/lib" \
-       SimpleMovie $* &
-else
-  $vjshell "$javabin"  \
+$vjshell "$javabin"  \
        -classpath $jclasspath \
        SimpleMovie $* &
-fi
 

--- a/src/scripts/vnmr_iplot.sh
+++ b/src/scripts/vnmr_iplot.sh
@@ -1,5 +1,4 @@
-#! /bin/sh
-: '@(#)vnmr_iplot.sh 22.1 03/24/08 1991-2006 '
+#! /bin/bash
 # 
 #
 # Copyright (C) 2015  University of Oregon
@@ -21,14 +20,9 @@ then
    exit 1
 fi
 
-#if (test x$vnmrsystem = "x")
 if [ x$vnmrsystem = "x" ]
 then
-   if [ x$ostype = "xInterix" ]; then
-      . /vnmr/user_templates/.vnmrenvbash
-   else
-      source /vnmr/user_templates/.vnmrenvsh
-   fi
+   source /vnmr/user_templates/.vnmrenvsh
 fi
 
 vjclasspath=$vnmrsystem/java/vnmrj.jar
@@ -43,37 +37,17 @@ fi
 
 iplotData=$1
 itype="exp"
-ostype=`uname -s`
 sysdir=$vnmrsystem
 userdir=$vnmruser
 shtoolcmd="/bin/sh"
 shtooloption="-c"
 javabin="$vnmrsystem/jre/bin/java"
-
-if [ x$ostype = "xInterix" ]
+if [ ! -f $javabin ]
 then
-   vjclasspath=`/bin/unixpath2win "$vjclasspath"`
-   sysdir=`/bin/unixpath2win "$sysdir"`
-   userdir=`/bin/unixpath2win "$userdir"`
-   shtoolcmd="$SFUDIR\common\ksh.bat"
-   shtooloption="-lc"
-   javabin="/vnmr/jre/bin/java.exe"
+   javabin="java"
 fi
 
-
-if [ x$ostype = "xInterix" ]
-then
-     $vjshell "$javabin"  \
-       -classpath $vjclasspath \
-       -Dsysdir=$sysdir -Duserdir=$userdir \
-       -Duser=$USER -Dpersona=$itype \
-       -Dsfudirwindows="$SFUDIR" -Dsfudirinterix="$SFUDIR_INTERIX" \
-       -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption" \
-       -DiplotDatafile=$iplotData \
-       -Djava.library.path="C:/SFU/vnmr/lib" \
-       vnmr.ui.VnmrPlot 
-else
-     $vjshell $vnmrsystem/jre/bin/java \
+$vjshell $javabin \
         -classpath $vjclasspath \
         -Dsysdir=$sysdir -Duserdir=$userdir \
         -Duser=$USER -Dpersona=$itype \
@@ -82,5 +56,4 @@ else
         -DiplotDatafile=$iplotData \
         -Djava.library.path="/vnmr/lib" \
         vnmr.ui.VnmrPlot &
-fi
 

--- a/src/scripts/vnmr_jplot.sh
+++ b/src/scripts/vnmr_jplot.sh
@@ -1,4 +1,4 @@
-: '@(#)vnmr_jplot.sh 22.1 03/24/08 1991-1994 '
+#! /bin/bash
 # 
 #
 # Copyright (C) 2015  University of Oregon
@@ -9,6 +9,11 @@
 # For more information, see the LICENSE file.
 # 
 #
-: /bin/sh
 
-"$vnmrsystem"/jre/bin/java  -Dsysdir="$vnmrsystem" -Duserdir="$vnmruser" -Duser=$USER -cp "$vnmrsystem"/java/jplot.jar PlotConfig $* &
+javabin="$vnmrsystem/jre/bin/java"
+if [ ! -f $javabin ]
+then
+   javabin="java"
+fi
+
+"$javabin" -Dsysdir="$vnmrsystem" -Duserdir="$vnmruser" -Duser=$USER -cp "$vnmrsystem"/java/jplot.jar PlotConfig $* &

--- a/src/scripts/xmlToCsv.sh
+++ b/src/scripts/xmlToCsv.sh
@@ -1,4 +1,4 @@
-#!/bin/csh
+#!/bin/bash
 # 
 #
 # Copyright (C) 2015  University of Oregon
@@ -44,12 +44,14 @@
 #   -type login -paramlist type start end operator owner
 #   -startdate "Jan 01 2014" -enddate "Feb 1 2014"
 
-set shtoolcmd="/bin/sh"
-set shtooloption="-c"
-set javacmd="$vnmrsystem/jre/bin/java"
-set vjclasspath="$vnmrsystem/java/vnmrj.jar"
+shtoolcmd="/bin/bash"
+shtooloption="-c"
+javabin="$vnmrsystem/jre/bin/java"
+if [ ! -f $javabin ]
+then
+   javabin="java"
+fi
 
-$javacmd -mx600m -classpath $vjclasspath  -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption"  vnmr.ui.XmlToCsvUtil $argv:q
+vjclasspath="$vnmrsystem/java/vnmrj.jar"
 
-# Note: the "$argv:q" causes args with spaces (like dates) to be passed as intact
-# arguments provided they are surrounded by double quotes.
+$javabin -mx600m -classpath $vjclasspath  -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption"  vnmr.ui.XmlToCsvUtil "$@"

--- a/src/vnmrj/macos/ExpPanel.java
+++ b/src/vnmrj/macos/ExpPanel.java
@@ -3383,6 +3383,9 @@ public class ExpPanel extends JPanel
 			args += " -Duserdir=\""+UtilB.unixPathToWindows(userDir)+"\"";
 			args += " -Duser=" + user;
 			String java = FileUtil.SYS_VNMR+"/jre/bin/java";
+                        UNFile file = new UNFile(java);
+                        if ( ! file.exists() )
+				java = "java";
 			String jplot = UtilB.unixPathToWindows(sysDir+ "/java/jplot.jar PlotConfig");
 			if (UtilB.iswindows())
 				java += ".exe";
@@ -5768,8 +5771,12 @@ public class ExpPanel extends JPanel
 
         if (!Util.iswindows())
         {
-            String[] cmd2 = {WGlobal.SHTOOLCMD, WGlobal.SHTOOLOPTION, FileUtil.SYS_VNMR + 
-                                "/jre/bin/java -Duser.dir=" + strUserdir +  " -jar " + strPath};
+	    String java = FileUtil.SYS_VNMR+"/jre/bin/java";
+            UNFile file = new UNFile(java);
+            if ( ! file.exists() )
+	        java = "java";
+            String[] cmd2 = {WGlobal.SHTOOLCMD, WGlobal.SHTOOLOPTION,
+                              java + " -Duser.dir=" + strUserdir +  " -jar " + strPath};
             WUtil.runScriptInThread(cmd2);
         }
         else

--- a/src/vnmrj/src/vnmr/ui/ExpPanel.java
+++ b/src/vnmrj/src/vnmr/ui/ExpPanel.java
@@ -3456,6 +3456,9 @@ public class ExpPanel extends JPanel
 			args += " -Duserdir=\""+UtilB.unixPathToWindows(userDir)+"\"";
 			args += " -Duser=" + user;
 			String java = FileUtil.SYS_VNMR+"/jre/bin/java";
+                        UNFile file = new UNFile(java);
+                        if ( ! file.exists() )
+				java = "java";
 			String jplot = UtilB.unixPathToWindows(sysDir+ "/java/jplot.jar PlotConfig");
 			if (UtilB.iswindows())
 				java += ".exe";
@@ -5841,8 +5844,12 @@ public class ExpPanel extends JPanel
 
         if (!Util.iswindows())
         {
-            String[] cmd2 = {WGlobal.SHTOOLCMD, WGlobal.SHTOOLOPTION, FileUtil.SYS_VNMR + 
-                                "/jre/bin/java -Duser.dir=" + strUserdir +  " -jar " + strPath};
+	    String java = FileUtil.SYS_VNMR+"/jre/bin/java";
+            UNFile file = new UNFile(java);
+            if ( ! file.exists() )
+	        java = "java";
+            String[] cmd2 = {WGlobal.SHTOOLCMD, WGlobal.SHTOOLOPTION,
+                              java + " -Duser.dir=" + strUserdir +  " -jar " + strPath};
             WUtil.runScriptInThread(cmd2);
         }
         else


### PR DESCRIPTION
The jmol, jchempaint, and jdesign were not running on MacOS
because they were called with an absolute path to
/vnmr/jre/bin/java, which does not exist in the MacOS version.
Bug reported in Spinsights.