### PR TITLE
ddf can now return data values to macro

### DIFF
--- a/src/common/manual/averag
+++ b/src/common/manual/averag
@@ -25,6 +25,13 @@ ddf,ddff,ddfp:
       For FID's, the maximum value in the block is scaled by the values of
       of scale and ctcount in the block header. A second return argument will
       to be to this scaled value.
+      If the keyword 'max' is not used but the third argument is given, then
+      by appending return values, the data points can be returned to the
+      calling macro. For example,
+         ddff(1,1,1):$re,$im
+      will return the first two data points in the FID file.
+         ddfp(1,1,64):$n1,$n2,$n3,$n4
+      will return four data points, starting with point number 64.
       
 
 noise:

--- a/src/stat/statdispfuncs.c
+++ b/src/stat/statdispfuncs.c
@@ -667,7 +667,7 @@ int updatestatscrn(AcqStatBlock *statblock)
     int i;
     struct tm *tmtime;
     char  *chrptr;
-    char  datetim[27];
+    char  datetim[30];
     /*struct timeval clock;
     struct timezone tzone;
      */

--- a/src/vnmr/init_display.c
+++ b/src/vnmr/init_display.c
@@ -1079,7 +1079,7 @@ void
 DispField2(int pos, int color, double val, int dez)
 {
    double tmp;
-   char  ln[12],format[8];
+   char  ln[16],format[8];
 
    if(P_getreal(GLOBAL, "mfShowFields", &tmp, 1)) tmp = 1.0; 
 #ifdef VNMRJ


### PR DESCRIPTION
This is now documented. Fixed some core dumps (Vnmrbg and Infostat)
caused by sprintf overrunning buffers. Fixed makefid to use standard
block header if index 0 is used.