### PR TITLE
add procdim to appendlist only when it changes

### DIFF
--- a/src/procproc/procproc.c
+++ b/src/procproc/procproc.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <string.h>
 #include <sys/param.h>
 #include <sys/types.h>
@@ -132,6 +133,10 @@ int main(int argc, char *argv[])
   sigaddset( &blockmask, SIGUSR2 );
  
    DebugLevel = 0;
+   if ( ! access("/vnmr/acqbin/Proclog",F_OK) )
+   {
+      DebugLevel = 1;
+   }
 
    umask(000); /* clear file creation mode mask,so that open has control */
 
@@ -207,7 +212,7 @@ void processMsge(void *notin)
 	   /* if we got a message then go ahead and parse it */
 	   if (rtn > 0)
 	   {
-	      DPRINT2(1,"received %d bytes, MsgInbuf len %d bytes\n",rtn,strlen(MsgInbuf));
+	      DPRINT2(1,"received %d bytes, MsgInbuf len %zd bytes\n",rtn,strlen(MsgInbuf));
 	      parser(MsgInbuf);
 	      MsgInbuf[0] = '\0';
 	   }


### PR DESCRIPTION
every time ft is called, procdim was being added to the
list of parameters that changed, causing java to update
items that depend on it. This caused quite a bit of overhead
during mtune, which calls ft every BS. Now it is appended
only if it changes.
Added Proclog to turn on debugging for Procproc
Some compiler warning cleanup