### PR TITLE
wtfile='noCtScaling' will avoid scaling FID by ct

### DIFF
--- a/src/common/manual/df
+++ b/src/common/manual/df
@@ -13,6 +13,9 @@ df<(index)>	-	Display an FID
   rotated (zero order only) by the number of degrees specified by
   the parameter "phfid".  Both left shifting and phasing of the FID
   may be avoided by setting "lsfid" and "phfid" to 'n'.
+  Each FID is scaled by the number of transients (ct) summed during the
+  acquisition of the FID data. By setting the parameter
+  wtfile='noCtScaling' this CT scaling will be turned off.
 
   DF is identical in function to DFID
 

--- a/src/common/manual/ft
+++ b/src/common/manual/ft
@@ -17,6 +17,11 @@ Both commands execute a left-shift, zero-order phase rotation, and
 a frequency shift (first-order phase rotation) according to the
 parameters "lsfid", "phfid", and "lsfrq" respectively, on the time-domain
 data prior to the weighting (if appropriate) and Fourier transformation.
+Each FID is scaled by the number of transients (ct) summed during the
+acquisition of the FID data. This has the effect keeping the amplitude
+of the peaks independent of nt. By setting the parameter
+wtfile='noCtScaling' this CT scaling will be turned off.
+
 All string arguments supplied to these two commands must precede the
 numeric arguments, e.g., ft('nodc','noft',1,10,2).  The type of Fourier
 transformation is determined by the parameter "proc".  Solvent suppression

--- a/src/common/manual/ft1d
+++ b/src/common/manual/ft1d
@@ -14,6 +14,10 @@ dimension, with and without weighting respectively, and matrix trans-
 position.  This allows the display of t1 interferograms with the "dcon"
 and "dconi" commands.  wft2d and ft2d perform the complete 2D Fourier
 transformation, with and without weighting in both dimensions respectively.
+Each FID that is Fourier transformed is first processed as is done by ft
+and wft. That is, it may be left shifted, phase rotated, frequency
+shifted or scaled. See the ft manual page.
+
 For arrayed 2D FID data, a single array element can be transformed using,
 as an example, "ft2d(array element number)".  Complex and Hypercomplex
 interferograms can be constructed explicitly using the following coef-

--- a/src/common/manual/wtfile
+++ b/src/common/manual/wtfile
@@ -29,6 +29,10 @@ filename is the name of the executable weighting function.  The
 executable function has been created by compiling the weighting
 function source code with the UNIX shellscript wtgen.
 
+If wtfile is set to the special keyword wtfile='noCtScaling' then each
+FID is not divided by the number of transients (ct) summed during the
+acquisition of the FID data.
+
 
 Vnmr first checks to see if the file "wtfile" (or "wtfile1") exists
 in $vnmruser/wtlib.  If the file exists in that directory, Vnmr

--- a/src/vnmr/df2d.c
+++ b/src/vnmr/df2d.c
@@ -395,14 +395,16 @@ int getfid(int curfid, float *outp, ftparInfo *ftpar, dfilehead *fidhead, int *l
             inpfloat += ftpar->np0;
             tmp = outp + ftpar->np0 - ftpar->lsfid0;
             npx = ftpar->np0;
-            if ((inblock.head->ctcount > 1) || (inblock.head->scale) )
+            if (( (inblock.head->ctcount > 1) && ftpar->ctScaling) ||
+                  (inblock.head->scale) )
             {
                shift = 1 << abs(inblock.head->scale);
                if (inblock.head->scale < 0)
                   rmult = 1.0/(float)(shift);
                else
                   rmult = (float) shift;
-               rmult /= (float)(inblock.head->ctcount);
+               if (ftpar->ctScaling)
+                  rmult /= (float)(inblock.head->ctcount);
                for (i = 0; i < npx; i++)
                   *(--tmp) = *(--inpfloat) * rmult;
             }
@@ -421,14 +423,16 @@ int getfid(int curfid, float *outp, ftparInfo *ftpar, dfilehead *fidhead, int *l
             inpfloat += ftpar->lsfid0;
             tmp = outp;
             npx = ftpar->np0 - ftpar->lsfid0;
-            if ((inblock.head->ctcount > 1) || (inblock.head->scale) )
+            if (( (inblock.head->ctcount > 1) && ftpar->ctScaling) ||
+                  (inblock.head->scale) )
             {
                shift = 1 << abs(inblock.head->scale);
                if (inblock.head->scale < 0)
                   rmult = 1.0/(float)(shift);
                else
                   rmult = (float) shift;
-               rmult /= (float)(inblock.head->ctcount);
+               if (ftpar->ctScaling)
+                  rmult /= (float)(inblock.head->ctcount);
                for (i = 0; i < npx; i++)
                   *tmp++ = *inpfloat++ * rmult;
             }
@@ -468,7 +472,8 @@ int getfid(int curfid, float *outp, ftparInfo *ftpar, dfilehead *fidhead, int *l
             rmult = 1.0/(float)(shift);
          else
             rmult = (float) shift;
-         rmult /= (float)(inblock.head->ctcount);
+         if (ftpar->ctScaling)
+            rmult /= (float)(inblock.head->ctcount);
          if (inblock.head->status == (S_DATA|S_32|S_COMPLEX))
          {
             cnvrts32(rmult, inp32, outp, ftpar->np0, ftpar->lsfid0);

--- a/src/vnmr/ftinit.c
+++ b/src/vnmr/ftinit.c
@@ -1838,13 +1838,14 @@ static int getFidProcInfo(dfilehead *fidhead, ftparInfo *ftpar)
                {
                   if (fread(&tmp,sizeof(double),1,infile) == 1)
                   {
+                     int ret __attribute__((unused));
                      strcpy(ftpar->ftarg.eccFile,filename);
                      ftpar->ftarg.eccPnts = np0 = (int) tmp;
                      ftpar->ftarg.ecc = (double *) allocateWithId(np0* sizeof(double), "ft2d");
                      ptr = ftpar->ftarg.ecc;
                      for (i=0; i<np0; i++)
                      {
-                         fread(&tmp,sizeof(double),1,infile);
+                         ret = fread(&tmp,sizeof(double),1,infile);
                          *ptr++ = tmp;
                      }
                   }
@@ -2478,6 +2479,19 @@ static int set_offsets(int argus[], ftparInfo *ftpar)
    return(COMPLETE);
 }
 
+void setCtScaling(ftparInfo *ftpar)
+{
+   char         filepath[MAXPATHL];
+/***********************************************
+*   provision for turning of CT scaling of FID *
+***********************************************/
+   ftpar->ctScaling = 1;
+   if (!P_getstring(CURRENT, "wtfile", filepath, 1, MAXPATHL-1))
+   {
+     if ( ! strcmp(filepath,"noCtScaling") )
+        ftpar->ctScaling = 0;
+   }
+}
 
 /*---------------------------------------
 |                                       |
@@ -2607,6 +2621,7 @@ int i_fid(dfilehead *fidhead, ftparInfo *ftpar)
          return(ERROR);
       }
    }
+   setCtScaling(ftpar);
  
    return(COMPLETE);
 }

--- a/src/vnmr/ftpar.h
+++ b/src/vnmr/ftpar.h
@@ -173,6 +173,7 @@ struct _ftparInfo
    int		t1_offset;
    int		t2_offset;
    int		wtflag;
+   int		ctScaling;
    int		zeroflag;
    int		D_cmplx;
    int		D_dimen;

--- a/src/vnmr/wti.c
+++ b/src/vnmr/wti.c
@@ -73,6 +73,7 @@ extern int fnpower(int fni);
 extern int  dim1count();
 extern int setprocstatus(int ft_dimname, int full2d);
 extern int  i_fid(dfilehead *fidhead, ftparInfo *ftpar);
+extern void setCtScaling(ftparInfo *ftpar);
 extern int getfid(int curfid, float *outp, ftparInfo *ftpar, dfilehead *fidhead,
                 int *lastfid);
 extern void ls_ph_fid(char *lsfname, int *lsfval, char *phfname, double *phfval,
@@ -464,6 +465,7 @@ static int wti_showrawfid()
          ftpar.zeroflag = FALSE;
          ftpar.t2dc = FALSE;
          ftpar.dpflag = (fidhead.status & S_32);
+         setCtScaling( &ftpar);
          ddrType = fidhead.status & S_DDR;
          
          if ( getfid(specIndex-1, rawfid, &ftpar, &fidhead, &lastfid) )


### PR DESCRIPTION
Updated relevant manual pages.