### PR TITLE
Fixed problems with interactive baseline correction

### DIFF
--- a/src/Asp/AspFrame.C
+++ b/src/Asp/AspFrame.C
@@ -27,6 +27,7 @@ int P_read(int, char*);
 void set_top_frame_on_top(int onTop);
 int currentindex();
 int getAxisOnly();
+int do_mkdir(const char *dir, int psub, mode_t mode);
 }
 
 spAspFrame_t nullAspFrame = spAspFrame_t(NULL);
@@ -531,6 +532,7 @@ void AspFrame::showRois(bool b) {
     displayTop();
 }
 
+#ifdef TEST
 void AspFrame::registerAspDisplayListener(DFUNC_t func) 
 {
     AspDisplayListenerList::iterator begin = displayListenerList.begin();
@@ -547,6 +549,7 @@ void AspFrame::unregisterAspDisplayListener(DFUNC_t func)
         displayListenerList.remove(func);
     }
 }
+#endif
 
 void AspFrame::callAspDisplayListeners() 
 {
@@ -732,9 +735,11 @@ int AspFrame::saveSession(char *path, bool full) {
       // make sure dir exists
       struct stat dstat;
       if (stat(dir.c_str(), &dstat) != 0) {
-         char str[MAXSTR2];
-         (void)sprintf(str, "mkdir -p %s \n", dir.c_str());
-         (void)system(str);
+         if (do_mkdir(dir.c_str(), 1, 0777))
+         {
+	        Winfoprintf("Failed to make directory %s.",dir.c_str());
+	        return 0;
+         }
       }
 
    } else if(fstat.st_mode & S_IFDIR) { // is a directory

--- a/src/Asp/AspFrame.h
+++ b/src/Asp/AspFrame.h
@@ -85,8 +85,10 @@ public:
     spAspTrace_t getDefaultTrace();
     int getCursorMode();
 
+#ifdef TEST
     void registerAspDisplayListener(DFUNC_t func);
     void unregisterAspDisplayListener(DFUNC_t func);
+#endif
     void callAspDisplayListeners();
 
     void updateDataMap();

--- a/src/aip/aipGframe.C
+++ b/src/aip/aipGframe.C
@@ -877,13 +877,12 @@ void Gframe::drawFrameLabel() {
     int ascent;
     int descent;
     int cwd;
-    int cht;
 
     if (transparency_level > 80)
        return;
     // Get width and height of a character (cwd, cht)
     GraphicsWin::getTextExtents("0", 14, &ascent, &descent, &cwd);
-    cht = ascent + descent;
+    // cht = ascent + descent;
     int numLeft = maxX();
     int nMax = DataManager::get()->getNumberOfImages();
     int n;
@@ -1152,7 +1151,7 @@ void Gframe::draw() {
 }
 
 bool Gframe::updateScaleFactors() {
-    int i, j, k;
+    int i, j;
 
     ViewInfoList::iterator pView = viewList->begin();
     if (pView == viewList->end()) {
@@ -1644,7 +1643,6 @@ void Gframe::quickZoom(int x, int y, double factor) {
     // convert data center to magnet frame for aipZoomBind to use
     // do this before setZoom because it will change pixToMagnet.
     double mx,my,mz;
-    double px,py,pz;
     view->pixToMagnet((double)x,(double)y,0.0,mx,my,mz);
         
     setZoom(xdata, ydata, newPixPerCm);
@@ -1843,7 +1841,7 @@ void Gframe::setPan(int x, int y, bool moving) {
     // convert data center to magnet frame for aipZoomBind to use
     // do this before setZoom bacause it will change dataToPix and piToMagnet.
     double mx,my,mz;
-    double px,py,pz;
+    double px,py;
     view->dataToPix(dataCenterX, dataCenterY,px,py);
     view->pixToMagnet(px,py,0.0,mx,my,mz);
 
@@ -1927,7 +1925,7 @@ void Gframe::segmentSelectedRois(bool minFlag, double minData, bool maxFlag,
             //check Roi size. return if bigger than data size.
             spCoordVector_t dat = r->getpntData();
             int rsize;
-            for (int i=0; i<dat->coords.size(); i++) {
+            for (int i=0; i<(int) dat->coords.size(); i++) {
                 rsize = (int)(dat->coords[i].x*dat->coords[i].y);
                 if (rsize > size)
                     return;
@@ -2422,7 +2420,7 @@ string Gframe::getViewName(int ind) {
    return string(str);
 }
 
-void Gframe::setColormap(char *name) {
+void Gframe::setColormap(const char *name) {
    spViewInfo_t view = getViewByIndex(layerID);
    if(view == nullView) return;
 
@@ -2458,7 +2456,7 @@ void Gframe::removeOverlayImg() {
 }
 
 // path can be the key
-void Gframe::loadOverlayImg(char *path, char *cmapName, int colormapId) {
+void Gframe::loadOverlayImg(const char *path, const char *cmapName, int colormapId) {
    string key = string(path);
    if(strstr(path, " ") == NULL) { 
      key += " 0";
@@ -2491,14 +2489,14 @@ void Gframe::loadOverlayImg(char *path, char *cmapName, int colormapId) {
    grabMouse();  // to update graphics toolbar
 }
 
-void Gframe::loadOverlayImg(char *path, char *cmapName) {
+void Gframe::loadOverlayImg(const char *path, const char *cmapName) {
    loadOverlayImg(path, cmapName, 0);
 }
 
 // fill layer list
 void Gframe::sendImageInfo() {
 
-    set_aip_image_info(0,0,0,0,"",0); // always clear current info display
+    set_aip_image_info(0,0,0,0,(char *)"",0); // always clear current info display
 
     if(!viewList->empty()) {
 
@@ -2588,7 +2586,7 @@ void Gframe::setPositionInfo(int x, int y) {
         i++;
         name = di->getShortName();
         int p = name.find_last_of(" ");
-        if(p != string::npos) {
+        if(p != (int) string::npos) {
            name=name.substr(p);
         }
         sprintf(info,"%s %d %d %.0f", name.c_str(),dx,dy,mag);

--- a/src/aip/aipGframe.h
+++ b/src/aip/aipGframe.h
@@ -152,11 +152,11 @@ public:
     bool hasSpec();
     void resetSpecFrame();
     void zoomSpecFrame(int x,int y,double factor);
-    void setColormap(char *name);
+    void setColormap(const char *name);
     void setTransparency(int value);
     void removeOverlayImg();
-    void loadOverlayImg(char *path, char *cmapName);
-    void loadOverlayImg(char *path, char *cmapName, int colormapId);
+    void loadOverlayImg(const char *path, const char *cmapName);
+    void loadOverlayImg(const char *path, const char *cmapName, int colormapId);
     void selectViewLayer(int imgId, int order, int mapId);
     bool parallelPlane(spViewInfo_t view, spViewInfo_t baseView);
     bool coPlane(spViewInfo_t view, spViewInfo_t baseView);

--- a/src/aip/aipGframeManager.C
+++ b/src/aip/aipGframeManager.C
@@ -48,6 +48,7 @@ bool GframeManager::overlaid = false;
 //spGframe_t    GframeManager::blownUpFrame; // Initialized by toggleFullScreen
 
 
+#ifdef TEST
 /***********  TEST  **************/
 extern bool memTest();
 bool memTest() {
@@ -65,6 +66,7 @@ bool memTest() {
     return rtn;
 }
 /***********  END TEST  **************/
+#endif
 
 /* PRIVATE CONSTRUCTOR */
 GframeManager::GframeManager() {
@@ -2289,7 +2291,7 @@ int GframeManager::getFrameToStart(int x, int y) {
 // delete existing colormaps in given directory
 void GframeManager::deleteCmaps(char *path) {
    char *ptr;
-   char file[MAXSTR];
+   char file[MAXSTR+16];
    struct dirent **namelist;
    struct stat fstat;
 

--- a/src/aip/aipVnmrFuncs.h
+++ b/src/aip/aipVnmrFuncs.h
@@ -71,7 +71,7 @@ extern "C" {
     int P_setprot(int tree, const char *name, int value);
     int P_setactive(int tree, const char *name, int activeFlag);
     int P_getactive(int tree, const char *name);
-    void clearVar(char *name);
+    void clearVar(const char *name);
     char *realString(double x);
     char *newString(const char *str);
     int getWin_draw();

--- a/src/aip/sharedPtr.h
+++ b/src/aip/sharedPtr.h
@@ -6,13 +6,22 @@
  *
  * For more information, see the LICENSE file.
  */
+
+#ifndef SHAREDPTR_H
+#define SHAREDPTR_H
+
+#ifdef boost
+
+#include <memory>
+
+#else
+
 /*-*- Mode: C++ -*-*/
 /*
  * This file abstracted from the Boost smart_ptr.hpp header file
  * described in the comments below.
  * --Chris Price 9 May 2001
  */
-
 /*
  * BEWARE! passing a shared pointer as an argument to fprintf(), or the like.
  *     This results in the ref count getting bumped up and never decremented.
@@ -67,8 +76,6 @@
 //  27 Apr 99  leak when new throws fixes (Dave Abrahams)
 //  21 Oct 98  initial Version (Greg Colvin/Beman Dawes)
 
-#ifndef SHAREDPTR_H
-#define SHAREDPTR_H
 
 #include <stdio.h>  // for stsderr definition  11/04/09  GMB
 
@@ -366,4 +373,5 @@ template<typename T>
 
 #endif  // ifndef BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION
 
+#endif  // boost
 #endif  // SHAREDPTR_H

--- a/src/common/maclib/bcpopup
+++ b/src/common/maclib/bcpopup
@@ -32,7 +32,11 @@ if($#=1) then
     endif
     if(bcmode[1]=0) then aspRegion('CWT')
     else aspRegion(bcmode[5]) endif
-    vnmrjcmd('popup','mode:modeless','file:BCdialog.xml','rebuild:yes','close:aspRegion(`clear`)','title:Baseline Correction')
+    vnmrjcmd('popup','mode:modeless','file:BCdialog.xml','rebuild:yes','close:bcpopup(`close`)','title:Baseline Correction')
+    return 
+  elseif($1='close') then 
+    aspRegion('clear')
+    aspSetState(0)
     return 
   endif
 endif

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -426,7 +426,7 @@ int lpreset;
 CP make_cp(CP cp)
 {
    FILE *fp;
-   char shapepath[MAXSTR];
+   char shapepath[MAXSTR*3];
    extern char userdir[];
    int nmin = cp.n90;
    int ntick,nrpuls,naccumpuls,chnl;
@@ -1197,7 +1197,7 @@ MPSEQ MPchopper(MPSEQ seq)
 {
    FILE *fp;
    extern char userdir[];
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[MAXSTR*3],str[MAXSTR];
    int npuls, iph, ntick,nrpuls,naccumpuls;
    int i = 0;
    double phase = 0.0;
@@ -1704,7 +1704,7 @@ SHAPE make_shape(SHAPE s)
 {
    FILE *fp;
    extern char userdir[];
-   char shapepath[MAXSTR],str[MAXSTR];
+   char shapepath[MAXSTR*3],str[MAXSTR];
    int ntick,nrpuls,naccumpuls;
    double t,ph,dph,phShapeCurrent,phShapeLast,aLast,aCurrent,phase,gate;
    STATE state;

--- a/src/vnmr/ft.c
+++ b/src/vnmr/ft.c
@@ -110,6 +110,7 @@ extern void currentDate(char* cstr, int len );
 extern void rotate_fid(float *fidptr, double ph0, double ph1, int np, int datatype);
 extern void driftcorrect_fid(float *outp, int np, int lsfid, int datamult);
 extern int saveProcpar(char *path);
+extern int aspFrame(char *keyword, int frameID, int x, int y, int w, int h);
 
 
 typedef struct wtparams wtPar;
@@ -2729,6 +2730,8 @@ int ft(int argc, char *argv[], int retc, char *retv[])
      }
   }
 
+  if (!Bnmr)
+     aspFrame("clear",0,0,0,0,0); // clear asp display
   if (!Bnmr && do_ds)
   {
      releasevarlist();

--- a/src/vnmr/iplan.h
+++ b/src/vnmr/iplan.h
@@ -444,7 +444,7 @@ void getStack(iplan_stack* stack, int planType);
 int calcBoxIntersection(iplan_view *view, float3 *box, float2 *points);
 planParams *getCurrPlanParams(int planType);
 
-extern void  clearVar(char *name);
+extern void  clearVar(const char *name);
 extern int appdirFind(const char *filename, const char *lib, char *fullpath, const char *suffix,
                int perm);
 

--- a/src/vnmr/pvars.c
+++ b/src/vnmr/pvars.c
@@ -556,7 +556,7 @@ static int compareVar(char *n, varInfo *v, symbol **root)
 |	This function clears all the values of a parameter without deleting it.
 |
 +-----------------------------------------------------------------------------*/
-void clearVar(char *name)
+void clearVar(const char *name)
 {
     varInfo *vinfo;
 

--- a/src/vnmr/shellcmds.c
+++ b/src/vnmr/shellcmds.c
@@ -1115,7 +1115,7 @@ static int mk_dir_args(mode_t *mode, int *psub, int *ict, int argc, char *argv[]
   RETURN;
 }
 
-int do_mkdir(char *dir, int psub, mode_t mode)
+int do_mkdir(const char *dir, int psub, mode_t mode)
 {
    int	ival=0;
    if (psub == 1)

--- a/src/vnmrbg/SConstruct
+++ b/src/vnmrbg/SConstruct
@@ -663,6 +663,12 @@ else:
                                CCFLAG = '',
                                CPPDEFINES = ['LINUX', 'VNMRJ'])
 
+if (platform=="darwin"):
+    vnmrBgCppEnv.Append(CPPDEFINES = 'boost=std')
+
+if os.path.exists("/etc/lsb-release"):
+    vnmrBgCppEnv.Append(CPPDEFINES = 'boost=std')
+
 if (opensource=="true"):
     if (gplsource=="true"):
         vnmrBgCppEnv.Append(CPPDEFINES = 'VNMR_GPL')


### PR DESCRIPTION
fn=4k wft and then interactive BC with bcpopup('init')
followed by fn=64k wft bcpopup('init')  would core dump
Vnmrbg. ft now calls aspFrame("clear",...)
With Ubuntu and MacOS compiles, could not modify or delete the BC points.
This was because the boost::shared_ptr was causing problems.
When replaced with std::shared_ptr, both Ubuntu and MacOS work.
Removed some aip and Asp functions that were causing problems
with std::shared_ptr.
Fixed the bcpopup macro to exit the asp Select mode when the
close button is hit.
Fixed some compiler warnings