### PR TITLE
dconi may fail to display data

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,6 +1,8 @@
 OpenVnmrJ Release Notes.
 
 Feb 2020 -
+    exists has new options for the 'file' and 'directory' cases
+       (see manual/exists)
     The global parameters psfont and psfont2 set the font and
        pscharsize sets the font character size used when plotting.
        (see manual/write and manual/setpage)
@@ -67,7 +69,7 @@ Feb 2020 -
     Added 'csv' option to the "find" case of substr (see manual/substr)
     Added new command datafit (see manual/datafit)
     New options for using ranges of traces for maxpeak (see manual/maxpeak)
-    ovjUpdate make a patch to transfer system files to a newly
+    ovjUpdate makes a patch to transfer system files to a newly
       installed OpenVnmrJ (see manual/ovjUpdate)
     Support for CentOS 8.1 and 8.2 as an acquisition system.
     New options for proj (see manual/proj)

--- a/src/vnmrbg/dconi.c
+++ b/src/vnmrbg/dconi.c
@@ -2030,9 +2030,13 @@ int dconi(int argc, char *argv[], int retc, char *retv[])
           strcat(dconi_runstring,"\n");
           if (!d2flag && !axisonly)
             {
-              Wsetgraphicsdisplay(cmd);
-              Werrprintf("no 2D data in data file");
-              ABORT;
+              if (select_init(1,1, 0, 1, 1, 1, 0, 0)) ABORT;
+              if (!d2flag)
+              {
+                 Wsetgraphicsdisplay(cmd);
+                 Werrprintf("no 2D data in data file");
+                 ABORT;
+              }
             }
           if (!d2flag && axisonly)
             setVertAxis();


### PR DESCRIPTION
If 1D in expX and 2D in expY, then jexpX ds jexpY dconi
would give "no 2D data in data file"