### PR TITLE
Remove shell commands from panel layouts

### DIFF
--- a/src/common/templates/vnmrj/panelitems/SampleInfo.xml
+++ b/src/common/templates/vnmrj/panelitems/SampleInfo.xml
@@ -160,7 +160,7 @@
     <textmessage loc="120 60" size="240 20"
       style="PlainText"
       vq="sample sdirtmplt adirtmplt samplename"
-      set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as shell('basename '+$as):$s $VALUE='('+$s+')' else $VALUE=sample endif"
+      set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as substr($as,'basename'):$s $VALUE='('+$s+')' else $VALUE=sample endif"
       />
     <entry loc="120 40" size="240 20"
       style="PlainText"

--- a/src/layouts/layout/Startq/Standard.xml
+++ b/src/layouts/layout/Startq/Standard.xml
@@ -538,7 +538,7 @@
         style="PlainText"
         label="(_20080415_01)"
         vq="sample sdirtmplt adirtmplt samplename"
-        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as shell('basename '+$as):$s $VALUE='('+$s+')' else $VALUE=sample endif"
+        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as substr($as,'basename'):$s $VALUE='('+$s+')' else $VALUE=sample endif"
         />
       <label loc="10 65" size="90 20"
         style="Label1"

--- a/src/layouts/layout/Submitq/Standard.xml
+++ b/src/layouts/layout/Submitq/Standard.xml
@@ -326,7 +326,7 @@
         <textmessage loc="20 20" size="190 20"
           style="PlainText"
           vq="globalenter"
-          set="$VALUE='' shell('basename '+globalenter):$VALUE"
+          set="$VALUE='' substr(globalenter,'basename'):$VALUE"
           />
         <label loc="5 0" size="90 20"
           style="Label1"
@@ -348,7 +348,7 @@
           style="PlainText"
           label="auto_20061129_02"
           vq="autodir globalauto"
-          set="$VALUE='' shell('basename '+autodir):$VALUE"
+          set="$VALUE='' substr(autodir,'basename'):$VALUE"
           />
         <label loc="5 0" size="95 20"
           style="Label1"
@@ -485,7 +485,7 @@
         style="PlainText"
         label="(_20080415_01)"
         vq="sample sdirtmplt adirtmplt samplename"
-        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as shell('basename '+$as):$s $VALUE='('+$s+')' else $VALUE=sample endif"
+        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as substr($as,'basename'):$s $VALUE='('+$s+')' else $VALUE=sample endif"
         />
       <label loc="10 65" size="90 20"
         style="Label1"

--- a/src/layouts/layout/Submitq/Standardauto.xml
+++ b/src/layouts/layout/Submitq/Standardauto.xml
@@ -76,7 +76,7 @@
           style="Info"
           label=""
           vq="globalenter"
-          set="$VALUE='' shell('basename '+globalenter):$VALUE"
+          set="$VALUE='' substr(globalenter,'basename'):$VALUE"
           />
         <label loc="5 10" size="90 20"
           style="Label1"
@@ -111,7 +111,7 @@
           style="Info"
           label="auto_20130122_01"
           vq="autodir globalauto"
-          set="$VALUE='' shell('basename '+autodir):$VALUE"
+          set="$VALUE='' substr(autodir,'basename'):$VALUE"
           />
         <label loc="5 10" size="95 20"
           style="Label1"

--- a/src/layouts/layout/Submitq/Standardcluster.xml
+++ b/src/layouts/layout/Submitq/Standardcluster.xml
@@ -116,7 +116,7 @@
       <textmessage loc="100 25" size="260 20"
         style="PlainText"
         vq="sample sdirtmplt adirtmplt samplename"
-        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as shell('basename '+$as):$s $VALUE='('+$s+')' else $VALUE=sample endif"
+        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as substr($as,'basename'):$s $VALUE='('+$s+')' else $VALUE=sample endif"
         />
       <label loc="5 95" size="100 20"
         style="Label1"

--- a/src/layouts/layout/default/standard2.xml
+++ b/src/layouts/layout/default/standard2.xml
@@ -197,7 +197,7 @@
         style="Info"
         label="(data)"
         vq="sample sdirtmplt adirtmplt samplename"
-        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as shell('basename '+$as):$s $VALUE='('+$s+')' else $VALUE=sample endif"
+        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as substr($as,'basename'):$s $VALUE='('+$s+')' else $VALUE=sample endif"
         />
       <label loc="10 25" size="90 20"
         style="Label1"
@@ -234,7 +234,7 @@
           style="Info"
           label="auto_20100408_01"
           vq="autodir globalauto"
-          set="$VALUE='' shell('basename '+autodir):$VALUE"
+          set="$VALUE='' substr(autodir,'basename'):$VALUE"
           />
         <label loc="5 0" size="95 20"
           style="Label1"
@@ -254,7 +254,7 @@
         <textmessage loc="20 20" size="195 20"
           style="Info"
           vq="globalenter"
-          set="$VALUE='' shell('basename '+globalenter):$VALUE"
+          set="$VALUE='' substr(globalenter,'basename'):$VALUE"
           />
         <label loc="5 0" size="90 20"
           style="Label1"

--- a/src/layouts/layout/s2pul/standard2.xml
+++ b/src/layouts/layout/s2pul/standard2.xml
@@ -123,7 +123,7 @@
         style="Info"
         label="(_20071013_01)"
         vq="sample sdirtmplt adirtmplt samplename"
-        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as shell('basename '+$as):$s $VALUE='('+$s+')' else $VALUE=sample endif"
+        set="if (sample='') then $as='' $s='' Svfname(adirtmplt+'/'+sdirtmplt,''):$as substr($as,'basename'):$s $VALUE='('+$s+')' else $VALUE=sample endif"
         />
       <label loc="10 25" size="90 20"
         style="Label1"
@@ -280,7 +280,7 @@
         <textmessage loc="20 20" size="190 20"
           style="Info"
           vq="globalenter"
-          set="$VALUE='' shell('basename '+globalenter):$VALUE"
+          set="$VALUE='' substr(globalenter,'basename'):$VALUE"
           />
         <label loc="5 0" size="90 20"
           style="Label1"
@@ -301,7 +301,7 @@
           style="Info"
           label="auto_20061129_02"
           vq="autodir globalauto"
-          set="$VALUE='' shell('basename '+autodir):$VALUE"
+          set="$VALUE='' substr(autodir,'basename'):$VALUE"
           />
         <label loc="5 0" size="95 20"
           style="Label1"


### PR DESCRIPTION
Replaced shell('basename '+filename) with substr(filename,'basename')