### PR TITLE
csh should be link to tcsh

### DIFF
--- a/src/scripts/chksystempkgs.sh
+++ b/src/scripts/chksystempkgs.sh
@@ -56,7 +56,7 @@ else
    echo "Checking for Ubuntu / Debian packages required by OpenVnmrJ"
    distrover=$(lsb_release -rs)
    distmajor=${distrover:0:2}
-   packagecommonlist='csh make gcc gfortran expect openssh-server mutt sharutils sendmail-cf gnome-power-manager kdiff3 ghostscript imagemagick xterm'
+   packagecommonlist='tcsh make gcc gfortran expect openssh-server mutt sharutils sendmail-cf gnome-power-manager kdiff3 ghostscript imagemagick xterm'
    if [ $distmajor -ge 16 ] ; then
      packageXlist='openjdk-8-jre bc libmotif-dev'
    elif [ $distmajor -ge 14 ] ; then

--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -657,7 +657,7 @@ else
 # apt-get -qq -y dist-upgrade
 # Prevent packages from presenting an interactive popup
   export DEBIAN_FRONTEND=noninteractive
-  apt-get install -y csh make expect bc git scons g++ gfortran \
+  apt-get install -y tcsh make expect bc git scons g++ gfortran \
       openssh-server mutt sharutils sendmail-cf gnome-power-manager \
       kdiff3 libcanberra-gtk-module ghostscript imagemagick vim xterm \
       gedit dos2unix zip cups gnuplot gnome-terminal enscript rpcbind &>> $logfile

--- a/src/scripts/vnmrpipe.sh
+++ b/src/scripts/vnmrpipe.sh
@@ -29,7 +29,7 @@ if (!($?NMRBASE)) then
    source /vnmr/nmrpipe/dynamo/com/dynInit.com
 endif
 
-if ($# == 1) then
+if ($#argv == 1) then
    $1
 else
    $1 $argv[2-]


### PR DESCRIPTION
On Ubuntu, csh was link to bsd-csh, which caused NMRPipe
and vnmrpipe to fail. Now tcsh is installed.