### PR TITLE
Moved ExpStatus to /vnmr/tmp

### DIFF
--- a/src/expproc/statfuncs.c
+++ b/src/expproc/statfuncs.c
@@ -31,6 +31,7 @@ char *getTimeStr(time_t time, char *timestr,int maxsize);
 char *getTimeDif(time_t time, char *timestr);
 void initConsoleStatus();
 
+#define EXP_STATUS_NAME "/vnmr/acqqueue/ExpStatus"
 
 /*************************************************************
 *  Some programs to work with Time Stamps
@@ -89,11 +90,11 @@ int initExpStatus(int clean)   /* zero out Exp Status */
   {
      struct stat buf;
      /* If the file already exists and is the right size, don't zero it out */
-     if ( ! stat(SHR_EXP_STATUS_PATH, &buf) && (buf.st_size == sizeof(EXP_STATUS_STRUCT)) )
+     if ( ! stat(EXP_STATUS_NAME, &buf) && (buf.st_size == sizeof(EXP_STATUS_STRUCT)) )
         clean = 0;
   }
 
-  ExpStatusObj = shrmCreate(SHR_EXP_STATUS_PATH,SHR_EXP_STATUS_KEY, 
+  ExpStatusObj = shrmCreate(EXP_STATUS_NAME,SHR_EXP_STATUS_KEY, 
 			      sizeof(EXP_STATUS_STRUCT));
   if (ExpStatusObj == NULL)
   {

--- a/src/infoproc/infoqueu.c
+++ b/src/infoproc/infoqueu.c
@@ -27,7 +27,7 @@
 #include "hostAcqStructs.h"
 #include "shrstatinfo.h"
 
-#define EXP_STATUS_NAME "/tmp/ExpStatus"
+#define EXP_STATUS_NAME "/vnmr/acqqueue/ExpStatus"
 
 
 #define TESTINTERVAL 600	/* Test Port every 10 Min */

--- a/src/ncomm/mfileObj.h
+++ b/src/ncomm/mfileObj.h
@@ -27,11 +27,14 @@ typedef unsigned long long int uint64_t;
 
 #define SHR_EXPQ_PATH        "/tmp/ExpQs"
 #define SHR_ACTIVE_EXPQ_PATH "/tmp/ExpActiveQ"
-#define SHR_EXP_STATUS_PATH  "/tmp/ExpStatus"
 #define SHR_SEM_USAGE_PATH   "/tmp/IPC_V_SEM_DBM"
 #define SHR_MSG_Q_DBM_PATH   "/tmp/msgQKeyDbm"
 #define SHR_PROCQ_PATH       "/tmp/ProcQs"
 #define SHR_ACTIVEQ_PATH     "/tmp/ActiveQ"
+/*
+   SHR_EXP_STATUS_PATH was  "/tmp/ExpStatus" moved to /vnmr/acqqueue/ExpStatus
+   permissions on /tmp caused problems
+ */
 
 #define SHR_EXPQ_KEY         ((int) 101)
 #define SHR_ACTIVE_EXPQ_KEY  ((int) 201)


### PR DESCRIPTION
It was in /tmp but on Ubuntu, /tmp has the "sticky bit" set,
which means only the user that created ExpStatus has read access.
Also fixed msgQLib.c, which created shared memory twice, tried
to free non-existant memory, and a couple of other problems.