### PR TITLE
trtune was not updating display correctly

### DIFF
--- a/src/vnmr/ft.c
+++ b/src/vnmr/ft.c
@@ -2730,10 +2730,9 @@ int ft(int argc, char *argv[], int retc, char *retv[])
      }
   }
 
-  if (!Bnmr)
-     aspFrame("clear",0,0,0,0,0); // clear asp display
   if (!Bnmr && do_ds)
   {
+     aspFrame("clear",0,0,0,0,0); // clear asp display
      releasevarlist();
      appendvarlist("cr");
      Wsetgraphicsdisplay("ds");		/* activate the ds program */


### PR DESCRIPTION
This was traced to a change in PR #467 where bcpopup('init')
was core dumping. ft was clearing the graphics screen. Now it
only clears the screen if the 'nods' argument is not given.