### PR TITLE
touch was not updating time-stamp of the files.

### DIFF
--- a/src/vnmr/shellcmds.c
+++ b/src/vnmr/shellcmds.c
@@ -390,6 +390,7 @@ int Touch(int argc, char *argv[], int retc, char *retv[]) {
    }
    else
    {
+      futimens(res,NULL);
       close(res);
       res = 1;
    }


### PR DESCRIPTION
The system call futimens does not work on CentOS 6.