### PR TITLE
Optimize lock tpwr choise missing

### DIFF
--- a/src/layouts/layout/calibrate/QuickN15AT.xml
+++ b/src/layouts/layout/calibrate/QuickN15AT.xml
@@ -32,6 +32,15 @@
       rows="1"
       columns="1"
       >
+      <check loc="195 125" size="150 20"
+        style="Label1"
+        label="Optimize lock tpwr"
+        vq="LKtpwr caliblist"
+        vc="LKtpwr=0"
+        vc2="$tpwr=0 getparam('tpwr','lk'):$tpwr LKtpwr=$tpwr"
+        set="if (LKtpwr=0) then $VALUE=1 else $VALUE=0 endif"
+        show="xmhaha_calib('','lkGmap'):$v $ENABLE=$v*2-1"
+        />
       <check loc="10 145" size="210 20"
         style="Label1"
         label="Optimize low-order XY shims"


### PR DESCRIPTION
from 15N autocalibration. It is present for the
"Lock Gmap/Z0" and "H1/C13/Gradient Lock Gmap/Z0"
autocalibrations. Fix from Bert.