### PR TITLE
vnmrj.jar was creating local $e in current tree

### DIFF
--- a/src/vnmrj/src/vnmr/ui/VToolPanel.java
+++ b/src/vnmrj/src/vnmr/ui/VToolPanel.java
@@ -823,7 +823,7 @@ public class VToolPanel extends PushpinPanel implements ExpListenerIF, PropertyC
 
         if (bCreateExpParam) {
             bCreateExpParam = false;
-            s = "exists('"+expParamName+"','parameter','global'):$e if($e=0) then create('"+expParamName+"','string','global') endif\n";
+            s = "create('"+expParamName+"','string','global','')\n";
             Util.sendToVnmr(s);
         }
 

--- a/src/vnmrj/src/vnmr/util/ContextMenu.java
+++ b/src/vnmrj/src/vnmr/util/ContextMenu.java
@@ -67,7 +67,7 @@ public class ContextMenu  {
         // Create the contextmenuarg as a global parameter if it does not
         // already exist.  It has to be global in case the menu cmd using
         // it is being run in a different viewport.
-        Util.sendToVnmr("exists('contextmenuarg','parameter','global'):$e if($e=0) then create('contextmenuarg','string','global') endif");
+        Util.sendToVnmr("create('contextmenuarg','string','global','')");
 
         // Put the arg in vnmr variables contextmenuarg
         Util.sendToVnmr("contextmenuarg=" + arg );

--- a/src/vnmrj/src/vnmr/util/DisplayOptions.java
+++ b/src/vnmrj/src/vnmr/util/DisplayOptions.java
@@ -1056,7 +1056,7 @@ public class DisplayOptions extends ModelessDialog
     	return laf;
     }
     public static void setLAFParam(){
-        String str = "exists('LAF','parameter','global'):$e if $e<0.5 then create('LAF','string','global') endif LAF='"+LAF+"'";
+        String str = "create('LAF','string','global','') LAF='"+LAF+"'";
         //String str = "LAF='"+LAF+"'";
         DisplayOptions d=Util.getDisplayOptions();
         setDebug("setLAF:"+str);


### PR DESCRIPTION
If vnmrj.jar sends a local $e in a sendToVnmrJ message,
it remains in the current tree. This can cause problems
for other macros that may use $e.