### PR TITLE
first argument to fread can be a directory

### DIFF
--- a/src/common/manual/fread
+++ b/src/common/manual/fread
@@ -13,6 +13,13 @@ fread	- 	read in variables from a file and load them in a tree
   auto, operator, vnmraddr, and acqaddr.  If a tree is provided, it must
   be the second argument.
 
+  If the file exists and it is not a directory, parameters will be read from
+  it. If the file exists and it is a directory, parameters will be read from
+  a procpar from within that directory. If the file does not exist, first a
+  ".fid/procpar" will be appended to the file name. If it exists, it will
+  be used. Otherwise, a ".par/procpar" will be appended and if that exists,
+  it will be used.
+
   A "reset" option causes the variable tree to first be cleared before
   the new variable file is read. Without this option, variables read from
   a file are added to the existing preloaded variables.  In order to


### PR DESCRIPTION
it will read a procpar in the directory. If the directory does not
exist, it will try appending .fid/procpar and .par/procpar.
This is analogous to the rtv behavior.