### PR TITLE
On MacOS, tests for read-only root partition failed

### DIFF
--- a/src/macos/ovjFixMac.sh
+++ b/src/macos/ovjFixMac.sh
@@ -23,9 +23,10 @@ if [[ $ostype != "Darwin" ]]; then
    exit 1
 fi
 
-osver=$(sw_vers -productVersion | tr "." " " | awk '{print $2}')
+osVer=$(sw_vers -productVersion | tr "." " " | awk '{print $1}')
+osSubVer=$(sw_vers -productVersion | tr "." " " | awk '{print $2}')
 
-if [[ $osver -lt 15 ]]; then
+if ! [[ $osVer -gt 10 ]] && ! [[ $osSubVer -ge 15 ]]; then
    echo "$0: only required for MacOS Catalina (10.15) systems or newer"
    exit 1
 fi

--- a/src/macos/postinstall
+++ b/src/macos/postinstall
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 dir="/Applications/OpenVnmrJ_2.1.app/Contents/Resources/OpenVnmrJ"
-osver=$(sw_vers -productVersion | tr "." " " | awk '{print $2}')
-if [[ $osver -lt 15 ]]; then
+osVer=$(sw_vers -productVersion | tr "." " " | awk '{print $1}')
+osSubVer=$(sw_vers -productVersion | tr "." " " | awk '{print $2}')
+
+if ! [[ $osVer -gt 10 ]] && ! [[ $osSubVer -ge 15 ]]; then
    rm -rf /vnmr
    ln -s $dir /vnmr
 else


### PR DESCRIPTION
This is due to a change in the Apple naming convention
for their OS. The read-only partition started with
Catalina (10.15.1). The next release, Big Sur, is 16.0.1
and not 10.16.1  This fixes issue #509