### PR TITLE
update to fiddle

### DIFF
--- a/src/common/manual/fiddle
+++ b/src/common/manual/fiddle
@@ -48,6 +48,11 @@ will result in an increase in the amplitude of both signal and noise.  To
 save the corrected data it is necessary to use the option 'writefid' when 
 doing the reference deconvolution, e.g. fiddle('writefid','correctedfid') 
 will store the file 'correctedfid.fid' in the current working directory.
+The 'writescaledfid' option is like 'writefid' except takes an additional
+argument, which will be the maximum value of the FID that is written.
+The call might be something like
+  ddff(1,1,'max'):$e,$scl
+  fiddle('writescaledfid','correctedfid',$scl)
 
 The options 'writecf','<filename>' and 'readcf','<filename>' will write and 
 read the correction function respectively.  Thus performing reference
@@ -161,6 +166,9 @@ The options available are as follows:
                 writefid        write out corrected fid to '<filename>'; if
                                 '<filename>' does not begin with / it is assumed
                                 to be in the current working directory
+                writescaledfid  write out scaled corrected fid to '<filename>';
+                                if '<filename>' does not begin with / it is
+                                assumed to be in the current working directory
 
 
 


### PR DESCRIPTION
When writing the corrected FID, it is written as floating point
numbers rather than integers. Added a new 'writescaledfid' keyword
which is like 'writefid' except it allows one to supply a scaling
factor for the FID.