### PR TITLE
Fixed seqgen to skip compiler warnings

### DIFF
--- a/src/scripts/seqgen.sh
+++ b/src/scripts/seqgen.sh
@@ -31,18 +31,18 @@ fi
 # (Prevents problems with one user using UNIX command "su"
 # to become some other user)
 
-if [ ! $USER = $LOGNAME ]; then
+if [[ ! -z $LOGNAME ]] && [[ $USER != $LOGNAME ]]; then
    echo "Username: "$USER"  and Logname: "$LOGNAME"  do not agree."
    echo ""
    exit
 fi
 
-if (test x$vnmrsystem = "x")
+if [[ x$vnmrsystem = "x" ]]
 then
    source /vnmr/user_templates/.vnmrenvsh
 fi
 
-if (test ! -f "$vnmrsystem"/lib/libparam.so)
+if [[ ! -f "$vnmrsystem"/lib/libparam.so ]]
 then
    echo " "
    echo " "

--- a/src/scripts/seqgenupdate.sh
+++ b/src/scripts/seqgenupdate.sh
@@ -27,18 +27,18 @@ fi
 # (Prevents problems with one user using UNIX command "su"
 # to become some other user)
 
-if [ ! $USER = $LOGNAME ]; then
+if [[ ! -z $LOGNAME ]] && [[ $USER != $LOGNAME ]]; then
    echo "Username: "$USER"  and Logname: "$LOGNAME"  do not agree."
    echo ""
    exit
 fi
 
-if (test x$vnmrsystem = "x")
+if [[ x$vnmrsystem = "x" ]]
 then
    source /vnmr/user_templates/.vnmrenvsh
 fi
 
-if (test ! -f "$vnmrsystem"/lib/libparam.so)
+if [[ ! -f "$vnmrsystem"/lib/libparam.so ]]
 then
    echo " "
    echo " "

--- a/src/scripts/vnmrseqgen.sh
+++ b/src/scripts/vnmrseqgen.sh
@@ -19,8 +19,6 @@
 #**          although if it is, it is removed, so test or test.c    **
 #**          are both acceptable.                                   **
 #**   Modified:							    **
-#**    10/25/89   Greg B.    Added Code to include the DPS phase of **
-#**			     the pulse sequence compilation.	    **
 #**    01/25/96   Rolf K.    allows compilation of sequences in     **
 #**             $vnmrsystem/psglib; the sequence will be copied     **
 #**		into the local psglib and treated as a local file   **
@@ -38,18 +36,18 @@ echo "Beginning Pulse Sequence Generation Process:"
 # (Prevents problems with one user using UNIX command "su"
 # to become some other user)
 
-if [ ! $USER = $LOGNAME ]; then
+if [[ ! -z $LOGNAME ]] && [[ $USER != $LOGNAME ]]; then
    echo "Username: "$USER"  and Logname: "$LOGNAME"  do not agree."
    echo ""
    exit
 fi
 
-if (test ! -f "$vnmrsystem"/lib/libparam.a)
+if [[ ! -f "$vnmrsystem"/lib/libparam.so ]]
 then
    echo " "
    echo " "
    echo "No PSG library was found in system directory."
-   echo "Specifically, $vnmrsystem/lib/libparam.a does not exist."
+   echo "Specifically, $vnmrsystem/lib/libparam.so does not exist."
    echo "This is an irrecoverable error."
    echo " "
    exit 1
@@ -99,6 +97,16 @@ if [ x$osname="xLinux" ]; then
    if [[ $? -eq 0 ]]
    then
       Wextra=${Wextra}" -Wno-misleading-indentation"
+   fi
+   gcc -Q --help=warning | grep Wstringop-truncation >& /dev/null
+   if [[ $? -eq 0 ]]
+   then
+      Wextra=${Wextra}" -Wno-stringop-truncation"
+   fi
+   gcc -Q --help=warning | grep Wformat-overflow >& /dev/null
+   if [[ $? -eq 0 ]]
+   then
+      Wextra=${Wextra}" -Wno-format-overflow"
    fi
 fi
 

--- a/src/vjqa/vjtest/maclib/testDEA
+++ b/src/vjqa/vjtest/maclib/testDEA
@@ -14,6 +14,8 @@ elseif ($s = '98.05 +/-0.37% (7 of 8 integrals)' ) then
   vvLog('Pass',' with secondary values')
 elseif ($s = '98.04 +/-0.37% (7 of 8 integrals)' ) then
   vvLog('Pass',' with tertiary values')
+elseif ($s = '98.03 +/-0.34% (7 of 8 integrals)' ) then
+  vvLog('Pass',' with quaternary values')
 else
   vvLog('Fail','Dea test: ' + $s)
 endif


### PR DESCRIPTION
These are often interpreted as errors by users.
The OVJ build still has them turned on.