### PR TITLE
Updated makefid

### DIFF
--- a/src/common/manual/makefid
+++ b/src/common/manual/makefid
@@ -65,8 +65,7 @@ with a header that does not match the value of dp or np.  Since the
 active value is in the processed tree, you will need to use the setvalue
 command if any changes are needed.
 
-If the target FID is a link to another file, which happens if the data are
-returned to an experiment with the rt command, the links will be removed so
+If the target FID is a link to another file, the links will be removed so
 that the previously linked FID file is not modified.
 
 The remaining three forms of makefid calculate an FID based on the frequency,
@@ -112,10 +111,12 @@ An example file is:
   2500.0 10.0  0.1   0.0
   0.0    20.0  0.1   0.0
 
-The current values of the sw and np parameters are used to determine 
-the dwell time and the number of points to calculate.  The frequencies
-range between -sw/2 and sw/2. A 0.0 frequency will give a peak in the
-middle of the spectrum.
+If an index of 0 is given or if there is no existing FID in the
+experiment, the current values of the sw and np parameters are used
+to determine the dwell time and the number of points to calculate.
+Otherwise, the values of np and sw from the processed tree will be used.
+The frequencies range between -sw/2 and sw/2. A 0.0 frequency will give
+a peak in the middle of the spectrum.
 
 Another form of input to makefid is a text file with five entries.
 These specify the FID index, the frequency, amplitude, decay rate and phase.

--- a/src/vnmr/ddf.c
+++ b/src/vnmr/ddf.c
@@ -742,7 +742,7 @@ int datafit(int argc, char *argv[], int retc, char *retv[])
     {  Werrprintf("%s: first argument must be 'poly0' or 'poly1'",argv[0]);
        ABORT;
     }
-    for (index=0; index<sizeof(col)/sizeof(int); index++)
+    for (index=0; index < (int)(sizeof(col)/sizeof(int)); index++)
        col[index] = index;
     if ( ! strcmp(argv[2],"file") )
     {
@@ -2081,6 +2081,13 @@ int makefid(int argc, char *argv[], int retc, char *retv[])
 
       if (calcFID)
       {
+         double npnts;
+         double swval;
+
+         P_getreal(PROCESSED,"np",&npnts,1);
+         P_setreal(CURRENT,"np",npnts,1);
+         P_getreal(PROCESSED,"sw",&swval,1);
+         P_setreal(CURRENT,"sw",swval,1);
          new_fid_format = cur_fid_format;
       }
       else if (new_fid_format != UNDEFINED)


### PR DESCRIPTION
If the existing FID file header will be used, then the
values of np and sw are taken from the "processed" tree.
Otherwise they come from the "current" tree. Updated
the manual and fixed all compiler warnings.