### PR TITLE
Vnmrbg build failed on MacOS

### DIFF
--- a/src/vnmr/shellcmds.c
+++ b/src/vnmr/shellcmds.c
@@ -390,7 +390,11 @@ int Touch(int argc, char *argv[], int retc, char *retv[]) {
    }
    else
    {
+#ifdef MACOS
+      futimes(res,NULL);
+#else
       futimens(res,NULL);
+#endif
       close(res);
       res = 1;
    }


### PR DESCRIPTION
The futimens() function call used by _Touch does not
exists in older versions of MacOS. It is called futimes()