### PR TITLE
Some macros used 'file' option of exists incorrectly

### DIFF
--- a/src/common/maclib/ProtocolManager
+++ b/src/common/maclib/ProtocolManager
@@ -814,7 +814,7 @@ ELSEIF ($1 ='GetAllList') THEN
     $gstr='name','label','tab','menu1','menu2'
     $fex=0
     $file=userdir+'/templates/vnmrj/interface/ExperimentSelector_'+owner+'.xml'
-    exists($file,'file'):$fex,$file
+    exists($file,'file'):$fex
     if ($fex) then
         $key=$file
         $done=0

--- a/src/common/maclib/parammodule
+++ b/src/common/maclib/parammodule
@@ -669,15 +669,15 @@ endif
             $retpath = autodir
          else $retpath = curexp endif
          $retpath = $retpath + '/' + $modulename
-         exists($retpath,'file'):$ex,$retpath  
+         exists($retpath,'file'):$ex
       elseif ($3 = 'study') then
          if (sample <> '') then 
             $retpath = archivedir+'/'+sample+'/dirinfo/'+ $modulename
-            exists($retpath,'file'):$ex,$retpath 
+            exists($retpath,'file'):$ex
          endif
       elseif ($3 = 'file') then 
          $retpath = $2
-         exists($retpath,'file'):$ex,$retpath
+         exists($retpath,'file'):$ex
          substr($retpath,'dirname'):$basename,$modulename
       else
          return(-2,'','','')          

--- a/src/common/maclib/probeidez
+++ b/src/common/maclib/probeidez
@@ -461,7 +461,7 @@ elseif ($1='recall') then
         $fistchar='' substr(probeidfile[$i],1,1):$firstchar
         if $firstchar='/' then
           $e=0 $probe=':none:' $path=''
-          exists(probeidfile[$i],'file'):$e,$path
+          exists(probeidfile[$i],'file'):$e
           if $e then
             strstr(probeidfile[$i],'/','last'):$e,$path,$probe
             probeidattr[2]=$probe

--- a/src/common/maclib/sqLog
+++ b/src/common/maclib/sqLog
@@ -5,7 +5,8 @@ rights($0):$e
 if ($e) then
   exists($0,'templates/vnmrj/loginfo'):$e,$path
 else
-  exists(vnmrsystem+'/templates/vnmrj/loginfo/'+$0,'file'):$e,$path
+  $path=vnmrsystem+'/templates/vnmrj/loginfo/'+$0
+  exists($path,'file'):$e
 endif
 if (not $e) then return('') endif
 


### PR DESCRIPTION
Some macros assumed a second return from exists with the file
option returned the path. It did not. With PR #469 , the second
return value indictated whether file was a soft link, etc.
This broke the macros that assumed the second value was a path.