### PR TITLE
tune macros check to see if they should call su

### DIFF
--- a/src/common/maclib/mtune_ddr
+++ b/src/common/maclib/mtune_ddr
@@ -403,6 +403,10 @@ elseif ($action = 'quit') then
   acqmode=''
   tmpreturn('tutmp')
   cp(curexp+'/tmptext',curexp+'/text')
-  newdg dg su
+  newdg dg
+  exists(seqfil,'psglib'):$e
+  if ($e) then
+    su
+  endif
   return
 endif

--- a/src/common/maclib/trtune
+++ b/src/common/maclib/trtune
@@ -347,7 +347,11 @@ if ($action = 'quit') then
   acqmode=''
   tmpreturn('tutmp')
   cp(curexp+'/tmptext',curexp+'/text')
-  newdg dg su
+  newdg dg
+  exists(seqfil,'psglib'):$e
+  if ($e) then
+    su
+  endif
   $e_remotely=0 exists('nettune_requests','parameter','global'):$e_remotely
   //if $e_remotely then // let nmrwebd know tuning is done
   //  write('net',instrument,'5555','bye '+username+'.vnmrj.trtune '+$port)


### PR DESCRIPTION
In some cases, seqfil may not exist as in the case of
seqfil='submitQ'