### PR TITLE
Added 'nuc' option to substr

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -69,7 +69,7 @@ Feb 2020 -
     setacq could fail on Inova and Mercury systems
     clradd and fiddle were not handling integer data correctly
     graphics screen would not refresh after changing Linux desktops
-    New 'basename' option for substr (see manual/substr)
+    New 'basename' and 'nuc' options for substr (see manual/substr)
     fortran library missing on CentOS 8
     vnmrj adm was not autofilling user name when making a new user
     OpenVnmrJ could fail to start on CentOS 8 due to large PID values.

--- a/src/common/manual/substr
+++ b/src/common/manual/substr
@@ -337,3 +337,21 @@ substr	-	pick a substring or word out of a string
         string n2 = 'a string:_ with funny __ _  characters'
     substr('a string:^ with funny &% # characters','tr','^%&#',''):n2 
         string n2 = 'a string: with funny   characters'
+
+  Case 10. Reformat nucleus name
+    substr('string','nuc'):$newstring
+       where string is an element name. Two schemes are in general use.
+       <element symbol><mass number> and <mass number><element symbol>
+       OpenVnmrJ uses the first scheme. Examples are H1, C13, Cl35, etc.
+       In the second scheme, these would be named 1H, 13C, 35Cl. The 'string'
+       argument can be an element name using either scheme. The 'newstring'
+       return value will be the element name using the OpenVnmrJ scheme.
+       The return value will have the first character capitalized. Any
+       remaining characters in the element name will be in lower case.
+
+    Example
+      substr('Cl35','nuc'):$tn  will set $tn to 'Cl35'
+      substr('33Cl','nuc'):$tn  will set $tn to 'Cl35'
+      substr('CL35','nuc'):$tn  will set $tn to 'Cl35'
+      substr('33CL','nuc'):$tn  will set $tn to 'Cl35'
+       

--- a/src/vnmr/builtin.c
+++ b/src/vnmr/builtin.c
@@ -42,21 +42,17 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <ctype.h>
 #include "pvars.h"
 #include "allocate.h"
 #include "buttons.h"
 #include "tools.h"
 #include "wjunk.h"
 
-#ifdef UNIX
 #include <unistd.h>
 #include <sys/types.h>
 #include <dirent.h>
 #include <sys/stat.h>
-#else 
-#include  stat
-#include  "dirent.h"
-#endif 
 
 #ifdef  DEBUG
 extern int Tflag;
@@ -1137,6 +1133,39 @@ int substr(int argc, char *argv[], int retc, char *retv[])
                retv[0] = newString(  trimmed );
             else
                Winfoprintf("substr tr:  %s",trimmed);
+        }
+        else if (! strcmp(argv[2],"nuc"))
+        {
+            char nuc[STR64];
+            char *ptr;
+            char *ptr2;
+
+            ptr = argv[1];
+            ptr2 = nuc;
+            if ( (argv[1][0] >= '0') && (argv[1][0] <= '9') )
+            {
+               while ((*ptr >= '0') && (*ptr <= '9'))
+                  ptr++;
+               *ptr2++ = toupper( *ptr++ );
+               while (*ptr)
+                  *ptr2++ = tolower( *ptr++ );
+               ptr = argv[1];
+               while ((*ptr >= '0') && (*ptr <= '9'))
+                  *ptr2++ = *ptr++;
+               *ptr2 = '\0';
+            } 
+            else
+            {
+               *ptr2++ = toupper( *ptr++ );
+               while (*ptr)
+                  *ptr2++ = tolower( *ptr++ );
+               *ptr2 = '\0';
+               
+            }
+            if (retc)
+               retv[0] = newString(  nuc );
+            else
+               Winfoprintf("substr nuc:  %s",nuc);
         }
         else
         {   Werrprintf("substr: bad word index!");


### PR DESCRIPTION
It converts nucleus names such as 13C, 35Cl to the
OpenVnmrJ style of C13, Cl35. Updated the man page.