### PR TITLE
trtune may show tuning dips in the wrong place

### DIFF
--- a/src/common/maclib/trtune
+++ b/src/common/maclib/trtune
@@ -159,7 +159,7 @@ if $action = 'start' then
   wbs='trtune(`process`)'
   wexp='trtune(`reset`)'
   au('silent','tune','bsclear')
-  clear(2)
+  clear(2) f full
 endif
 
 if $action = 'tunesw' then


### PR DESCRIPTION
fixed by calling f full. Bug reported in Spinsights