### PR TITLE
dpiv macro aborted

### DIFF
--- a/src/common/maclib/dpiv
+++ b/src/common/maclib/dpiv
@@ -164,19 +164,7 @@ if ($0='dpivn')or($0='pivn') then
   until $ix>$liampsize
   $norm=ins/$norm
 else
-  substr(rev,1):$rev1
-  format($rev1,'lower'):$rev1
-  if $rev1='vnmrj' then
-    $rev=6.1
-  else
-    $rev=0
-    substr(rev,2):$rev
-  endif
-  if $rev<5.3 then	" old integration mode, based on is / ins "
-    $oldint=1
-  else
-    $oldint=0
-  endif
+  $oldint=0
   exists('oldint','parameter'):$e
   exists('oldint','parameter','global'):$eg
   if ($e)or($eg) then
@@ -202,6 +190,7 @@ else
           $norm=$norm+liamp[$ix]
           $ix=$ix+2
         until $ix>$liampsize
+        if ($norm=0) then $norm=1 endif
         $norm=ins/$norm
       endif
     endif

--- a/src/common/maclib/svfj
+++ b/src/common/maclib/svfj
@@ -13,11 +13,6 @@
 
 $version=$0+' version 9.4, 2007-03-15'
 
-$tail='tail'
-exists('/usr/xpg4/bin/tail','file','x'):$e
-if $e then
-  $tail='/usr/xpg4/bin/tail'
-endif
 $isok=0
 $abort=0
 $jdxfid=''
@@ -251,20 +246,13 @@ while $ix<$nlines do
   endif
   $ix=$ix+1
 endwhile
-$token1='' $rev='' $subrev=''
+$rev='' $subrev=''
 if (rev='') then
   lookup('file',systemdir+'/vnmrrev','readline',1):rev
 endif
-substr(rev,1):$token1
-if $token1='VNMRJ' then
-  $sw='VnmrJ'
-  substr(rev,3):$rev
-  substr(rev,5):$subrev
-else
-  $sw='VNMR'
-  substr(rev,2):$rev
-  substr(rev,4):$subrev
-endif
+$sw='OpenVnmrJ'
+substr(rev,3):$rev
+substr(rev,5):$subrev
 length($subrev):$len
 substr($subrev,$len,1):$lch
 if $lch=',' then


### PR DESCRIPTION
It was incorrectly using the rev parameter (as was svfj)
Bug reported in Spinsights