### PR TITLE
fid_display macro will fail if fidscanmode parameter does not exist

### DIFF
--- a/src/common/maclib/fid_display
+++ b/src/common/maclib/fid_display
@@ -3,6 +3,8 @@
 mousebuttons:$b
 if (not $b) then
     graphis:$gr
+    exists('fidscanmode','parameter'):$e
+    if (not $e) then return endif
     strstr(fidscanmode, 's'):$spec
     if ($spec) then
         if ($gr <> 'ds') then


### PR DESCRIPTION
This can happen if a pulse sequence is named fid.c