### PR TITLE
macro updates from Krish

### DIFF
--- a/src/common/maclib/CPwtmenu
+++ b/src/common/maclib/CPwtmenu
@@ -6,7 +6,7 @@
 " CPwtmenu(dimension,'readfile',file) "
 " CPwtmenu(dimension,'read'<,directory>) "
 " CPwtmenu(dimension,'copy',fromdim)"
-"       arg1 is typically 'acq' or 'f1' or 'f2' or 'f3' "
+"       arg1 is typically 'acq' or 'f1' or 'f2' "
 "	arg3 for set option can be 'none' - "
 "		- turns off all window functions"
 "	default arg3 for save/read option is curexp or autodir"
@@ -19,25 +19,30 @@ $ret=''
 $arg1=$1
 $arg2=$2
 
-  getdim:$dim
-  if ($dim=2) and ($arg1='f2') then
-	$arg1='acq'
-  endif
-  if ($dim=3) and ($arg1='f3') then
-	$arg1='acq'
-  endif
+//  getdim:$dim
+// arg1 is interpreted as is.  There is no instance
+//   where f2 or f3 is used.  
+//   The f2 can be used even for 2D with ni2 incrementation
+
+//  if ($dim=2) and ($arg1='f2') then
+//	$arg1='acq'
+//  endif
+//  if ($dim=3) and ($arg1='f3') then
+//	$arg1='acq'
+//  endif
   if ($arg1<>'acq') and ($arg1<>'f1') and ($arg1<>'f2') then
 	write('error','Argument %s not supported',$arg1)
 	return($ret)
   endif
   if $arg2='copy' then
     $arg3=$3
-    if ($dim=2) and ($arg3='f2') then
-	$arg3='acq'
-    endif
-    if ($dim=3) and ($arg3='f3') then
-	$arg3='acq'
-    endif
+// arg3 is interpreted as is.
+//    if ($dim=2) and ($arg3='f2') then
+//	$arg3='acq'
+//    endif
+//    if ($dim=3) and ($arg3='f3') then
+//	$arg3='acq'
+//    endif
     if ($arg3<>'acq') and ($arg3<>'f1') and ($arg3<>'f3') then
         write('error','Argument %s not supported',$arg3)
         return($ret)
@@ -144,7 +149,7 @@ ELSEIF ($arg2 = 'read') or ($arg2='readfile') THEN
     else
 	$parfile=$3
     endif
-  shell('touch '+$parfile):$dum
+  touch($parfile):$dum
   fread($parfile)
 	"Now update panel pages"
   string2array($pars):$pars
@@ -175,17 +180,17 @@ ELSEIF ($arg2 = 'purge') THEN
         else $3=curexp endif
   endif
   $parfile=$3+'/windowpars_'+$arg1
-  shell('rm -f '+$parfile):$dum
+  delete($parfile,''):$dum
 
 ELSEIF ($arg2 = 'copy') THEN
 
     $arg3=$3
-    if ($dim=2) and ($arg3='f2') then
-        $arg3='acq'
-    endif
-    if ($dim=3) and ($arg3='f3') then
-        $arg3='acq'
-    endif
+//    if ($dim=2) and ($arg3='f2') then
+//        $arg3='acq'
+//    endif
+//    if ($dim=3) and ($arg3='f3') then
+//        $arg3='acq'
+//    endif
     if ($arg3<>'acq') and ($arg3<>'f1') and ($arg3<>'f3') then
         write('error','Argument %s not supported',$arg3)
         return

--- a/src/common/maclib/NUSprocIST
+++ b/src/common/maclib/NUSprocIST
@@ -155,7 +155,8 @@ $option=''
 if $mode='quiet' then $progress='-noprogress' else $progress='' endif
 $iconic='-iconic'
 bgmode_is:$bg
-if $bg then $progress='-noprogress' $iconic='' endif
+if $bg then $progress='-noprogress' endif
+if $progress='-noprogress' then $iconic='' endif
 
 // Check if this is an ni2 2D plane
 if ( ($ni<2 ) and ($ni2>1) )   then 
@@ -198,7 +199,7 @@ if ($nDIM < 3) then
 
        // data is in experiment - all processing done in curexp/pipe directory:
         
-	$pipe_cmd=' xterm '+$iconic+' -geom 30x20 -bg dodgerblue3 -fg white -cr white   -T NMRPipe -e " '\
+	$pipe_cmd=' xterm '+$iconic+' -geom 60x20+200+200 -bg Gray82 -fg Navy -fa Monospace -fs 9 -T NMRPipe -e " '\
                   + $prg +' vj2pipe.com    -nograph  -clean -cd '+curexp+ ' -vjfid ' + curexp+  '/acqfil/fid '\
 		  + ' '+$f1negate+' '+$f1window+' '+$f2window+' -istTMult '+pipeistTMult+' -istCMult '+pipeistCMult\
 		  + ' -istIter '+pipeistIter+' -istMaxRes '+pipeistMaxRes\
@@ -219,14 +220,33 @@ if ($nDIM < 3) then
 	setvalue('procdim',2,'processed')
 	nm2d
 	dconi
+		// adjust proccmd to reflect processing by ist
+	if ni>1 then
+	    write('line3','%s(\'ni\')',$0):$proccmd
+	else
+	    write('line3','%s(\'ni2\')',$0):$proccmd
+	endif
+	setvalue('proccmd',$proccmd)
+	setvalue('proccmd',$proccmd,'processed')
 
+	create('procplane','string','current',''):$cdum
+	create('procplane','string','processed',''):$cdum
+	setgroup('procplane','processing')
+	setgroup('procplane','processing','processed')
+	if ni>1 then 
+	    setvalue('procplane','ni')
+	    setvalue('procplane','ni','processed')
+	else
+            setvalue('procplane','ni2')
+            setvalue('procplane','ni2','processed')
+	endif
 // record some key values in the pipe directory
 // This helps to decide (by other macros) if reprocessing is required
 // For now record fn,fn1,fn2 and file parameters
 	if $f1window<>'' then
 	    create('pipeF1window','string','current',$2):$dum
 	endif
-	writeparam(curexp+'/pipe/PipePar','fn fn1 pipeF1window fn2 file pipeGLB pipeELB','current')
+	writeparam(curexp+'/pipe/PipePar','fn fn1 pipeF1window fn2 file pipeGLB pipeELB proccmd procplane','current')
 	if $f1window<>'' then
 	    destroy('pipeF1window'):$dum
 	endif

--- a/src/common/maclib/cft2da
+++ b/src/common/maclib/cft2da
@@ -43,12 +43,11 @@ if $1<>curexp and $1<>'' then
     endif
 endif
 
-//if $fex and $1<>curexp then
-//    exists('craft_extend_F1np','parameter'):$fex
-//endif
 if $fex then
     exists('readheader','command'):$fex
 endif
+
+if ni>1 then $ftarg='ni' else $ftarg='ni2' endif
 
 if $fex then
     readheader($fidf1):$f1np,$f2np
@@ -74,59 +73,62 @@ if $fex then
 	    copy($imgf1,curexp+'/fidf1i'):$dum
 	endif
     endif
-    $origni=ni 
+    $origni={$ftarg}
     readheader(curexp+'/acqfil/fid'):$np,$origdim
-//getvalue('arraydim','processed'):$origdim
     $mult=$origdim/$origni
-//    fn1=$f1np
-//    trace='f1'
     if $imgf1<>'' then
 	pmode='full'
     else
         pmode='partial'
     endif
     if $1<>curexp then
-        setLP1(0)
+	if $ftarg='ni' then setLP1(0) else setLP2(0) endif
     endif
     $nus=0
     is_NUS2d:$nus
     if $nus then
-	$ni=ni
-	$psize=size('phase')
+	$ni={$ftarg}
+	if $ftarg='ni' then 
+	    $psize=size('phase')
+	else
+	    $psize=size('phase2')
+	endif
 	$mult=$psize
-	ni=$origdim/$psize
-	setvalue('ni',ni,'processed')
+	{$ftarg}=$origdim/$psize
+	setvalue($ftarg,{$ftarg},'processed')
 	setvalue('arraydim',$origdim)
 	setvalue('arraydim',$origdim,'processed')
-	wft1da
-	ni=$ni
-	setvalue('ni',ni,'processed')
+	wft1da($ftarg)
+	{$ftarg}=$ni
+        setvalue($ftarg,{$ftarg},'processed')
 	setvalue('arraydim',$origdim,'processed')
 	setvalue('arraydim',$origdim,'processed')
     else
-    	wft1da
+    	wft1da($ftarg)
     endif
-    if fn1<$f1np then
-	downsizefid(fn1,curexp+'/fidf1r')
+    if $ftarg='ni' then $fn1=fn1 else $fn1=fn2 endif
+
+    if $fn1<$f1np then
+	downsizefid($fn1,curexp+'/fidf1r')
 	if $imgf1<>'' then
-	    downsizefid(fn1,curexp+'/fidf1i')
+	    downsizefid($fn1,curexp+'/fidf1i')
 	endif
-    elseif fn1>$f1np then
-	zerofillfid(fn1,curexp+'/fidf1r')
+    elseif $fn1>$f1np then
+	zerofillfid($fn1,curexp+'/fidf1r')
 	if $imgf1<>'' then
-	    zerofillfid(fn1,curexp+'/fidf1i')
+	    zerofillfid($fn1,curexp+'/fidf1i')
 	endif
     endif
     readf1
-    ni=$f1np/2
-    setvalue('ni',ni,'processed')
-    setvalue('arraydim',ni*$mult)
-    setvalue('arraydim',ni*$mult,'processed')
+    {$ftarg}=$f1np/2
+    setvalue($ftarg,{$ftarg},'processed')
+    setvalue('arraydim',{$ftarg}*$mult)
+    setvalue('arraydim',{$ftarg}*$mult,'processed')
     if $0='cft1da' then return endif
     lp1=0 rp1=0
-    wft2da
-    ni=$origni
-    setvalue('ni',ni,'processed')
+    wft2da($ftarg)
+    {$ftarg}=$origni
+    setvalue($ftarg,{$ftarg},'processed')
     setvalue('arraydim',$origdim)
     setvalue('arraydim',$origdim,'processed')
     if $1<>curexp then
@@ -136,6 +138,6 @@ if $fex then
 	endif
     endif
 else
-    wft2da
+    wft2da($ftarg)
 endif
 

--- a/src/common/maclib/colorMap
+++ b/src/common/maclib/colorMap
@@ -6,7 +6,7 @@
 // the color id as well as the color string.
 
 $colors='spectrum','threshold','parameter','integral','cursor'
-$colors=$colors,'black','red','yellow','green','cyan','blue','magenta','white','gray'
+$colors=$colors,'black','red','yellow','green','cyan','blue','magenta','white','orange','pink','gray'
 $colors=$colors,'spectrum2','spectrum3','spectrum4','spectrum5'
 $colors=$colors,'spectrum6','spectrum7','spectrum8','spectrum9'
 $colors=$colors,'expSpec','dsSpec','craftSpec','residSpec'
@@ -14,7 +14,7 @@ $colors=$colors,'sumSpec','modelSpec','refSpec','notUsed','roli'
 $colors=$colors,'craftRois','alignRois','align2Rois','align3Rois','segRois'
 
 $ID='11','15','13','12','18'
-$ID=$ID,'0','1','2','3','4','5','6','7','64'
+$ID=$ID,'0','1','2','3','4','5','6','7','56','63','64'
 $ID=$ID,'16','17','257','258'
 $ID=$ID,'259','260','261','262'
 

--- a/src/common/maclib/digfilt
+++ b/src/common/maclib/digfilt
@@ -1,7 +1,5 @@
-"macro digfilt"
-
-"Interface to postprocessing digital filtering and downsampling with"
-"  copying FID to another experiment to allow saving of the filtered FID."
+// Chempacker macro
+// Derivative of /vnmr/maclib/digfilt, but all wft calls are replaced with ft
 
 if ($# < 1) then
   write('error','Error - must specify destination experiment number')
@@ -46,23 +44,17 @@ while ($i < $numargs) do
 endwhile
 
 if ($numargs = 0) then
-  wft('downsamp',$expno)
-endif
-if ($numargs = 1) then
-  wft('downsamp',$expno,$args[1])
-endif
-if ($numargs = 2) then
-  wft('downsamp',$expno,$args[1],$args[2])
-endif
-if ($numargs = 3) then
-  wft('downsamp',$expno,$args[1],$args[2],$args[3])
-endif
-if ($numargs = 4) then
-  wft('downsamp',$expno,$args[1],$args[2],$args[3],$args[4])
-endif
-if ($numargs = 5) then
-  wft('downsamp',$expno,$args[1],$args[2],$args[3],$args[4],$args[5])
-endif
-if ($numargs > 5) then
+  ft('downsamp',$expno)
+elseif ($numargs = 1) then
+  ft('downsamp',$expno,$args[1])
+elseif ($numargs = 2) then
+  ft('downsamp',$expno,$args[1],$args[2])
+elseif ($numargs = 3) then
+  ft('downsamp',$expno,$args[1],$args[2],$args[3])
+elseif ($numargs = 4) then
+  ft('downsamp',$expno,$args[1],$args[2],$args[3],$args[4])
+elseif ($numargs = 5) then
+  ft('downsamp',$expno,$args[1],$args[2],$args[3],$args[4],$args[5])
+elseif ($numargs > 5) then
   write('error','more than 10 args not supported by macro "digfilt"')
 endif

--- a/src/common/maclib/dndvfs
+++ b/src/common/maclib/dndvfs
@@ -1,7 +1,12 @@
 "macro dndvfs"
 
     $data=$1
+    if $#<2 then $2='' endif
+    if $2='nofixpar' then
+	rtvfs($data,$2)
+    else
             rtvfs($data)
+    endif
 	    wexp=''
             on('execprocess'):$e
             if ($e > 0.5) then

--- a/src/common/maclib/dssi
+++ b/src/common/maclib/dssi
@@ -24,6 +24,16 @@
 
 // The real and string arguments are mutually exclusive
 
+//*** another special case (2021-04-27)
+   // one or two arguments
+   // one string and one non-array'ed real
+   // The string cannot be one of the specials, above
+   // some examples below:
+   //  dssi(1,'red') will display trace 1 in red
+   //  dssi(4) will display trace 4 in dssicolors[4] OR in spectrum color
+   //  dssi('red') will display trace 1 red
+//*** end of special case
+
 // Use of dssi with a return value is a special case
     if($##>0) then
 	dss:$dim
@@ -31,6 +41,60 @@
 	else return(arraydim) endif
     endif
 
+// if the number of arguments is =1 or 2, check for a special case
+    $special=0
+    if $#>0 then
+	if typeof('$1') then
+	    if $1='voup' or
+           	$1='vodown' or 
+           	$1='vo0' or 
+           	$1='select' or 
+           	$1='unselect' or 
+           	$1='all' then 
+                    $special=1 
+	    endif
+	else
+	    if $1=0 then $special=1 endif
+	endif
+    endif
+
+    if ($# > 0 and $# < 3) and not $special then
+	$color='' $inx=0
+	if typeof('$1') then
+	    $color=$1
+	    if $#>1 then
+		if not typeof('$2') then
+		    $inx=$2
+		    if not $inx then $inx=1 endif
+		endif
+	    else
+		$inx=1
+	    endif
+	else
+	    $inx=$1
+	    if $#>1 then
+		$color=$2 
+	    endif
+	endif
+ 		// Exclude an array of $inx
+	$size=size('$inx')
+	    if $color='' then
+	        exists('dssicolors','parameter'):$pex
+    		if $pex then $size=size('dssicolors') else $size=0 endif
+    		if $size>=$inx then
+    		    $color=dssicolors[$inx]
+    		endif
+	    endif
+	    if $color='' then $color='spectrum' endif
+	    mspec('clear')
+	    write('line3',`mspec(%d,'%s')`,$inx,$color):$cmd
+	    exec($cmd)
+	    intmod='off' ds
+	    return
+    endif
+
+// end of special case
+	      
 // If argument is supplied, interpret it, set appropriate
 //   parameter and call dssi again
     if ($# > 0) then
@@ -38,7 +102,20 @@
 	    $vo=vo*0.1
 	    if $vo<0.2 then $vo=0.2 endif
 	    if ($1='voup') then
-	    	vo=vo+$vo
+		if vo=0 then
+			// This is a special case, reset vo to a nominal value
+			// based on the number of trace
+		    exists('dssitrace','parameter'):$pex
+		    if $pex=1 then if dssitrace=0 then $pex=0 endif endif
+		    if not $pex then
+			readheader(curexp+'/acqfil/fid'):$np,$tdim
+		    else
+			$tdim=size('dssitrace')
+		    endif
+		    vo=0.7*wc2max/$tdim
+		else
+	    	    vo=vo+$vo
+		endif
 	    	dssi
 	    elseif ($1='vodown') then
 	        $vo=vo-$vo
@@ -49,11 +126,14 @@
 		vo=0
 		dssi
 	    elseif ($1='all') then
-		dssi(1)
+		dssi(0)
 	    elseif ($1='select') then
-		if $# < 2 then dssi(1)
+		if $# < 2 then dssi(0)
 		else
-		    create('dssitrace','real','current',0):$dum
+		    exists('dssitrace','parameter'):$pex
+		    if not $pex then
+		    	create('dssitrace','real','current',0):$dum
+		    endif
 		    setgroup('dssitrace','display')
 		    dssitrace=0
 		    $i=2 $j=1
@@ -66,9 +146,12 @@
 		    dssi
 		endif
 	    elseif ($1='unselect') then
-		if $# < 2 then dssi(1)
+		if $# < 2 then dssi(0)
 		else
-                    create('dssitrace','real','current',0):$dum
+                    exists('dssitrace','parameter'):$pex
+                    if not $pex then
+                        create('dssitrace','real','current',0):$dum
+		    endif
                     setgroup('dssitrace','display')
 		    getvalue('arraydim','processed'):$dim
 		    $i=1 $trace=0
@@ -101,7 +184,10 @@
 	    $start=$1 $end=$dim $step=1
 	    if ($# > 1) then $end=$2 endif
 	    if ($# > 2) then $step=$3 endif
-	    create('dssitrace','integer','current',0):$dum
+            exists('dssitrace','parameter'):$pex
+            if not $pex then
+                create('dssitrace','real','current',0):$dum
+            endif
 	    setgroup('dssitrace','display')
 	    dssitrace=0
 	    $x=$start $j=1
@@ -148,10 +234,10 @@
     if ($trace[1]=0) then $tracedim=0 endif
 
 // evaluate the total number of real traces and
-//  if it exceeds 128, mspec will panic.  
-//  if it exceeds 128, call dssn instead for each
+//  if it exceeds 512, mspec will abort.  
+//  if it exceeds 512, call dssn instead for each
 //  trace
-    if $tracedim>128 then
+    if $tracedim>512 then
 	$i=1 $realdim=0
 	repeat
 	    if ($trace[$i]>0.5) then
@@ -159,7 +245,7 @@
 	    endif
 	    $i=$i+1
 	until $i > $tracedim
-	if $realdim > 128 then
+	if $realdim > 512 then
 // Dont bother with color here
 	    $i=1 $first=1 $vp=vp
 	    repeat

--- a/src/common/maclib/dssiselect
+++ b/src/common/maclib/dssiselect
@@ -13,24 +13,33 @@
 //  	- string (example 'N thru M' - N, M and all indices in between will be included)
 
 
-readheader(curexp+'/datdir/data'):$np,$datdim
-if $# < 2 then
-    write('line3','1 thru %d',$datdim):$2
-endif
-if $# < 1 then $1='' endif
-
 if $# < 3 then
     exists('craft_dssiselect','maclib'):$macex
-	// branch off to craft_dssiselect
-	//  it serves both craft results and non-craft results
-	// but, if the number of argument is greater than 2
-	//   then there is no difference betwen this macro
-	//   and the craft_dssiselect macro
+        // branch off to craft_dssiselect
+        //  it serves both craft results and non-craft results
+        // but, if the number of argument is greater than 2
+        //   then there is no difference betwen this macro
+        //   and the craft_dssiselect macro
     if $macex then
-	craft_dssiselect($1,$2)
-	return
+	if $#<1 then craft_dssiselect
+	elseif $# < 2 then craft_dssiselect($1)
+	else craft_dssiselect($1,$2) 
+	endif
+   	return
     endif
 endif
+
+readheader(curexp+'/datdir/data'):$np,$datdim
+if $# < 2 then
+    exists('dssitrace','parameter'):$pex
+    if $pex then if dssitrace=0 then $pex=0 endif endif
+    if $pex then
+        $2=dssitrace
+    else
+        write('line3','1 thru %d',$datdim):$2
+    endif
+endif
+if $# < 1 then $1='' endif
 
 if $1<>'' and $1<>'add' and $1<>'remove' and $1<>'stack' then
     write('error','invalid first argument for %s',$0)
@@ -42,7 +51,9 @@ endif
     while $i<=$# do
 	write('line3','$%d',$i):$arg
 	if not typeof($arg) then
-	    $j=$j+1 $trace[$j]={$arg}
+                // this can be an array of reals
+            $j=$j+1 $trace[$j]={$arg}
+            $j=size('$trace')
 	else
 	    $ok=0
 	    //  Must have 3 words
@@ -135,8 +146,10 @@ endif
 	endif
       endif
     endif
-
-    create('dssitrace','real','current',0)
+    exists('dssitrace','parameter'):$pex
+    if not $pex then
+    	create('dssitrace','real','current',0)
+    endif
     setgroup('dssitrace','display')
     setprotect('dssitrace','on',256,'current')
     dssitrace=$newtrace

--- a/src/common/maclib/getversion
+++ b/src/common/maclib/getversion
@@ -1,9 +1,9 @@
 // Chempacker macro
 
 $t='/vnmr/tmp/version'
-shell('rm -f '+$t):$e
+rm('-f',$t):$dum
 cp('/vnmr/vnmrrev',$t)
-shell('chmod 666 ' +$t):$e
+chmod('a+w',$t)
 
 $logfile='/vnmr/adm/log/options'
 exists($logfile,'file'):$e
@@ -59,14 +59,27 @@ exists('CP_Version','CP_Readme'):$e,$path
 if ($e) then
   write('file',$t,'')
   write('file',$t,'CHEMPACK:')
-  shell('(cat '+$path+' | grep \'^Chempack\' | grep -w Patch | head -n 1 >> '+$t+')'):$e
-  shell('(cat '+$path+' | grep \'Installed on\' >> '+$t+')'):$e
+  append($path,'grep','^Chempack','grep -w','Patch','head',1,$t)
+  append($path,'grep','Installed on',$t)
 endif
 getbinpath('Craft'):$ce,$cv
 if $ce then
      write('file',$t,'')
+    $crev='' exists('craftrev',''):$ex,$crev
+    if $ex then
+	append($crev,'grep','^craftbox',$t)
+    endif
+    $cbacct=''
+    exists(systemdir+'/craft/cbInfo','file'):$cbex
+    if $cbex then
+        lookup('mfile',systemdir+'/craft/cbInfo','seekcs','cbAcct','readline',1):$cbacct
+        substr($cbacct,1):$cbacct
+    endif
+    if $cbacct='' then $cbacct='Guest' endif
+    write('file',$t,'CraftID \t%s',$cbacct)
+
      shell('('+$cv+' -CraftRev | grep -v CraftID >> '+$t+')'):$devnull
-     shell('('+$cv+' -listModules | awk \'{print "  "$0}\' >> '+$t+')'):$devnull
+     shell('('+$cv+' -listModules | awk \'{print "  "$0}\' | sed \'s|MISTQ|MISTiQ|g\' >> '+$t+')'):$devnull
 endif
 dousermacro($0,$t)
-shell('chmod 666 ' +$t):$e
+chmod('a+w',$t)

--- a/src/common/maclib/projboth
+++ b/src/common/maclib/projboth
@@ -4,6 +4,12 @@
 newexp('quiet'):$nexp1
 newexp('quiet'):$nexp2
 $proj=$1
+exists('procplane','parameter'):$parex
+if $parex then
+    if procplane='ni2' then $isni2=1 else $isni2=0 endif
+else
+    substr(proccmd,'find','ni2','delimiter','\',('):$isni2
+endif
 
 dconi 
 if $#>3 then
@@ -15,7 +21,12 @@ elseif $#>1 then
 else
     proj($nexp1)
 endif
-rp1=rp1+180 dconi 
+if $isni2 then
+    rp2=rp2+180
+else
+    rp1=rp1+180 
+endif
+dconi 
 if $#>3 then
     proj($nexp2,$2,$3,$4)
 elseif $#>2 then
@@ -25,7 +36,12 @@ elseif $#>1 then
 else
     proj($nexp2)
 endif
-rp1=rp1-180 dconi
+if $isni2 then
+    rp2=rp2-180
+else
+    rp1=rp1-180
+endif
+dconi
 
 $addsub=addsubexp
 addsubexp=$proj clradd:$dum

--- a/src/common/maclib/rt
+++ b/src/common/maclib/rt
@@ -1,6 +1,8 @@
 "macro rt"
 " rt - retrieve data set"
 
+if axis='SS' then aspAnno('clear') axis='p' endif
+
 if ($# > 0.5) then
   length($1):$len
   if $len>220 then
@@ -35,9 +37,9 @@ strstr(file,'.','last'):$e,$name,$ext
 $lcdata=$name+'.fid/lcdata'
 exists($lcdata,'file'):$e
 if $e then
-  shell('chmod u+w '+curexp+'/lcdata'):$dum
+  chmod('u+w',curexp+'/lcdata'):$dum
   copy($lcdata,curexp+'/lcdata')
-  shell('chmod u+w '+curexp+'/lcdata'):$dum
+  chmod('u+w',curexp+'/lcdata'):$dum
 else
   exists(curexp+'/lcdata','file'):$e
   if $e then rm(curexp+'/lcdata') endif

--- a/src/common/maclib/rtp
+++ b/src/common/maclib/rtp
@@ -1,6 +1,8 @@
 "macro rtp"
 " rtp - retrieve parameter set"
 
+if axis='SS' then aspAnno('clear') axis='p' endif
+
 if ($# > 0.5) then
   length($1):$len
   if $len>220 then

--- a/src/common/maclib/rtpipe
+++ b/src/common/maclib/rtpipe
@@ -22,6 +22,8 @@ writeparam(curexp+'/pipe/PipePar','file','current','add')
     	pread(curexp+'/pipe/spec_ist.ft2')
     	setvalue('procdim',2)
     	setvalue('procdim',2,'processed')
+	readparam(curexp+'/pipe/PipePar','proccmd procplane','current')
+	readparam(curexp+'/pipe/pipePar','proccmd procplane','processed')
     	nm2d
     	dconi
 //    endif

--- a/src/common/maclib/rtvfs
+++ b/src/common/maclib/rtvfs
@@ -1,5 +1,9 @@
 "macro rtvfs"
 
+if axis='SS' then aspAnno('clear') axis='p' endif
+
+if $# < 2 then $2='' endif
+
 $d='' $b='' $e=''
 substr($1,'dirname'):$d,$b,$e
 $1=$d+'/'+$b+'.vfs'
@@ -32,7 +36,10 @@ endif
     endif
     fread(curexp+'/curpar','current','reset')
     fread(curexp+'/procpar','processed','reset')
-    fixpar
+    if $2<>'nofixpar' then
+    	fixpar
+    endif
     file=$d+'/'+$b
     setvalue('file',file,'processed')
     if $oldseq<>seqfil then dg newdg endif
+    return(1)

--- a/src/common/maclib/svvfs
+++ b/src/common/maclib/svvfs
@@ -30,7 +30,8 @@ endif
 
     // Use svf/svp to make sure the procpar 
     // is based on appropriate acquisition/processing/display groups
-if ($3='fid') then
+exists(curexp+'/acqfil/fid','file'):$fidex
+if ($3='fid') and $fidex then
     Svfname($d+'/'+$b+'_%R2%','.fid','.fid, .par'):$tmpfid
     svf($tmpfid,'nodb')
 else

--- a/src/common/maclib/xmhaha
+++ b/src/common/maclib/xmhaha
@@ -424,8 +424,8 @@ ELSEIF ($1='unknown') or ($1='file') THEN
 	return(1)
    endif
    $e=''
-   substr($2,'basename'):$b,$e
-   if $e='txt' or $e='csv' then
+   exists($2,'ascii'):$isascii
+   if $isascii then
 	shell('vnmr_open '+$2+'&'):$devnull
 	return(1)
    endif


### PR DESCRIPTION
cft2da		- deals with crafted data in ni or ni2 dimensions
colorMap	- includes 2 or 3 more colors
CPwtmenu	- bug (not reported) fix
digfilt		- should not do wft, weighting is not part of digfilt
dndvfs		- supports nofixpar option
dssi		- voup option when vo=0 zooms the traces to half the display
			a few other small improvements. up to 512 traces handled
dssiselect	- minor adjustment.
getversion	- improved to handle current craft modules
NUSprocIST	- saves procplane, proccmd in the pipe directory
projboth	- works with 2D in ni and ni2 dimensions
rt		- clears axis='SS'
rtp		- clears axis='SS'
rtpipe		- supports proccmd and procplane
rtvfs		- clears axis='SS' and supports nofixpar option
svvfs		- minor bug fix
xmhaha		- opens any ascii file with vnmr_open (not just csv and txt extensions)