### PR TITLE
Modified popup menu for Annotation select mode

### DIFF
--- a/src/common/templates/vnmrj/interface/MouseMenuFrame.xml
+++ b/src/common/templates/vnmrj/interface/MouseMenuFrame.xml
@@ -37,4 +37,8 @@
                 style="Menu1" seperator="yes"
 		show="aspAnno:$e,$n if($e and $n) then $SHOW=1 else $SHOW=0 endif"
         />
+        <mchoice label = "Exit select mode"
+                vc = "aspSetState(0)"
+                style="Menu1" seperator="yes"
+        />
 </mainmenu>

--- a/src/common/templates/vnmrj/interface/MouseMenuFramePaste.xml
+++ b/src/common/templates/vnmrj/interface/MouseMenuFramePaste.xml
@@ -46,4 +46,8 @@
                 vc = "aspAnno('paste',aspSel[3],aspSel[4])"
                 style="Menu1" seperator="yes"
         />
+        <mchoice label = "Exit select mode"
+                vc = "aspSetState(0)"
+                style="Menu1" seperator="yes"
+        />
 </mainmenu>


### PR DESCRIPTION
A side-effect of PR #564 was that one could not exit the
Asp select mode with a right click. Added an "Exit select mode"
option to the popup menu.