### PR TITLE
fixed doAcct script

### DIFF
--- a/src/scripts/doAcct.sh
+++ b/src/scripts/doAcct.sh
@@ -51,7 +51,7 @@ then
    sMon=12
    sYear=$((eYear-1))
 else
-   sMon=$((eMon-1))
+   sMon=$((10#$eMon-1))
    sYear=$eYear
 fi
 doCut=0


### PR DESCRIPTION
Was treating the month as an octal number while doing the subtraction
to get the start date.