### PR TITLE
lsb-release does not always exist

### DIFF
--- a/src/scripts/chksystempkgs.sh
+++ b/src/scripts/chksystempkgs.sh
@@ -32,7 +32,7 @@ if [ ! -x /usr/bin/dpkg ]; then
    if [[ $version -eq 7 ]] || [[ $version -eq 8 ]]
    then
 #     for RHEL 7.X must list 32-bit packages, since these are no longer installed with the 64-bit versions
-      package71list='libgfortran motif'
+      package71list='libgfortran motif java-1.8.0-openjdk'
       package32Bitlist='rsh libstdc++.i686 libstdc++-devel.i686 glibc.i686 glibc-devel.i686 mesa-libGL-devel mesa-libGL mesa-libGLU'
       package32Bitlist='rsh libstdc++.i686 libstdc++-devel.i686 glibc.i686 glibc-devel.i686'
       packagelist="$packagecommonlist $package71list $package32Bitlist"
@@ -54,8 +54,8 @@ if [ ! -x /usr/bin/dpkg ]; then
 
 else
    echo "Checking for Ubuntu / Debian packages required by OpenVnmrJ"
-   distrover=$(lsb_release -rs)
-   distmajor=${distrover:0:2}
+   . /etc/lsb-release
+   distmajor=${DISTRIB_RELEASE:0:2}
    packagecommonlist='tcsh make gcc gfortran expect openssh-server mutt sharutils sendmail-cf gnome-power-manager kdiff3 ghostscript imagemagick xterm'
    if [ $distmajor -ge 16 ] ; then
      packageXlist='openjdk-8-jre bc libmotif-dev'
@@ -68,7 +68,6 @@ else
    fi
    packagelist="$packagecommonlist $packageXlist";
 fi
-#       libidn is contained within the ia32-libs
 
 if [ ! -x /usr/bin/dpkg ]; then
    for xpack in $packagelist

--- a/src/scripts/dtsharcntrl.sh
+++ b/src/scripts/dtsharcntrl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # 
 #
 # Copyright (C) 2015  University of Oregon
@@ -23,22 +23,10 @@
 # set -x
 
 #
-# For Ubuntu use the system provided Vino interface, rather than the X11 Server for VNC
 #
-distro=`lsb_release -is`    # RedHatEnterpriseClient or Ubuntu
-if [ x$distro = "xUbuntu" ]; then
-   echo "On Ubuntu, Use System->Preferences->Remote Desktop, to enable desktop sharing"
+if [ -f /etc/debian_version ]; then
+   echo "On Ubuntu, use Settings->Sharing to enable desktop sharing"
    exit 1
-fi
-
-#
-# For RHEL 6.X  use the system provided Vino interface, rather than the X11 Server for VNC
-#
-if [ "$(echo $distro  | grep -i 'RedHat' > /dev/null;echo $?)" == "0" ]; then
-   if [ "$(lsb_release -rs | grep 6 > /dev/null;echo $?)" == "0" ]; then
-      echo "On RHEL 6.X, Use System->Preferences->Remote Desktop, to enable desktop sharing"
-      exit 1
-   fi
 fi
 
 #

--- a/src/scripts/htmltopdf.sh
+++ b/src/scripts/htmltopdf.sh
@@ -1,6 +1,4 @@
-#! /bin/sh
-#  '@(#)htmltopdf.sh  1991-2014 '
-# 
+#! /bin/bash
 #
 # Copyright (C) 2015  University of Oregon
 # 
@@ -12,18 +10,4 @@
 #
 #-----------------------------------------------
 
-if [  -r /etc/SuSE-release ]
-then
-   distrover=5.0
-elif [  -r /etc/debian_version ]
-then
-   distrover=`lsb_release -rs` # 8.04, 9.04, etc.
-else
-   distrover=`cat /etc/redhat-release | sed -r 's/[^0-9]+//' | sed -r 's/[^0-9.]+$//'`    # yield 5.1, 5.3 , 6.1, etc..
-fi
-if [[ $distrover < 6.0 ]];
-then
-  wkhtmltopdf --page-size Letter $1 $2
-else
-  wkhtmltopdf --no-footer-line --footer-font-size 8 --footer-right "[page]/[topage]" --page-size Letter $1 $2
-fi
+wkhtmltopdf --no-footer-line --footer-font-size 8 --footer-right "[page]/[topage]" --page-size Letter $1 $2

--- a/src/scripts/ins_vnmr2.sh
+++ b/src/scripts/ins_vnmr2.sh
@@ -432,9 +432,8 @@ case x$os_version in
             lflvr="suse"
         elif [  -r /etc/debian_version ]
         then
-            distro=$(lsb_release -is)    # Ubuntu
-            distrover=$(lsb_release -rs) # 8.04, 9.04, etc.
-            distmajor=$(echo $distrover | cut -f1 -d.)
+            . /etc/lsb-release
+            distmajor=${DISTRIB_RELEASE:0:2}
             lflvr="debian"
                  # Ubuntu has awk
                  NAWK="awk"
@@ -959,34 +958,6 @@ echo "ALL REQUESTED SOFTWARE EXTRACTED"
 #fix some things, depending on what system we are
 if [ x$did_vnmr = "xy" ]
 then
-
-   #Check if jre exists and is newer than 1.1.6, if not, load it
-
-   if [ -x /usr/bin/jre ]
-   then
-      version=$(/usr/bin/jre -version 2>&1 | grep Version)
-      minor=$(echo $version | awk 'BEGIN { FS = "." } { print $2 }')
-      sub=$(echo $version | awk 'BEGIN { FS = "." } { print $3 }')
-      if [ x$minor = "x" ]
-      then
-         minor=1
-         sub=3
-      fi 
-      if [ $minor -lt 2 ]
-      then 
-         if [ $sub -lt 6 ]
-         then
-            load=1
-         else
-            load=0
-         fi
-      else
-         load=0
-      fi
-   else
-      version=""
-      load=1
-   fi
 
    load_type=${cons_type}.opt
 
@@ -1865,8 +1836,6 @@ home yes no '${nmr_home}'/$accname' > "$dest_dir"/adm/users/userDefaults.bak
          fi 
 
          # for RHEL 6.1 
-         # if [ "$(lsb_release -rs  | grep '6' > /dev/null;echo $?)" == "0" ]; then   # appears some version of RHEL 5.X don't have lsb_release
-         # if [ "$(echo $distrover  | grep '6' > /dev/null;echo $?)" == "0" ]; then
          if [ $distmajor -ge 6 ]
          then
             # shareutils package nolonger resides on the RHEL 6.X Installation DVD


### PR DESCRIPTION
Ubuntu 20 does not have it installed by default.
Replaced with "sourcing" the /etc/lsb_release file.