### PR TITLE
Remove jre from release

### DIFF
--- a/src/common/user_templates/.vnmrenv
+++ b/src/common/user_templates/.vnmrenv
@@ -5,12 +5,7 @@ setenv	graphics	sun
 setenv	memsize		64
 umask 22
 
-# deprecated, only used for Sun systems
-# setenv	GNUDIR		$vnmrsystem/gnu
-# setenv	GCC_EXEC_PREFIX	$GNUDIR/lib/gcc-lib/
-# setenv	PATH		$GNUDIR/bin:$JREHOME/bin:"$PATH":$vnmrsystem/bin
-setenv	JREHOME		$vnmrsystem/jre
-setenv	PATH		$JREHOME/bin:"$PATH":$vnmrsystem/bin
+setenv	PATH		"$PATH":$vnmrsystem/bin
 
 setenv TCL_LIBRARY	 $vnmrsystem/tcl/tcllibrary
 setenv TK_LIBRARY	 $vnmrsystem/tcl/tklibrary
@@ -32,8 +27,6 @@ setenv PGPORT 5432
 setenv PGHOST localhost
 
 set path=($vnmrsystem/pgsql/bin $path)
-setenv CLASSPATH $vnmrsystem/jpsg/lib/Jpsg.jar:$vnmrsystem/jpsg/lib:$vnmrsystem/jre
-
 
 setenv BROWSERDIR 	$vnmruser/ib_initdir
 setenv INITDIR 		$vnmruser/aip_initdir
@@ -41,7 +34,7 @@ setenv AIPDIR 		$vnmruser/aip_initdir
 setenv CSIDIR		$vnmruser/csi_initdir
 
 setenv DELEGATE_PATH	$vnmrsystem/user_templates/ImageMagick
-setenv LD_LIBRARY_PATH  $JREHOME/lib:$vnmrsystem/java:$vnmrsystem/lib:$PGLIB
+setenv LD_LIBRARY_PATH  $vnmrsystem/java:$vnmrsystem/lib:$PGLIB
 setenv XFILESEARCHPATH  $home/%T/%N%S:$vnmrsystem/%T/%N%S
 
 # DICOM dcmtk dictionary path

--- a/src/common/user_templates/.vnmrenvbash
+++ b/src/common/user_templates/.vnmrenvbash
@@ -11,13 +11,7 @@ export graphics=sun
 export memsize=64
 # export vnmruser vnmrsystem vnmreditor graphics memsize
 
-# deprecated, only used for Solaris systems.
-# export GNUDIR=$vnmrsystem/gnu
-# export GCC_EXEC_PREFIX=$GNUDIR/lib/gcc-lib/
-# export PATH=$GNUDIR/bin:$JREHOME/bin:$PATH:$vnmrsystem/bin
-export JREHOME=$vnmrsystem/jre
-export PATH=$JREHOME/bin:$PATH:$vnmrsystem/bin
-# export JREHOME GNUDIR GCC_EXEC_PREFIX PATH
+export PATH=$PATH:$vnmrsystem/bin
 
 export TCL_LIBRARY=$vnmrsystem/tcl/tcllibrary
 export TK_LIBRARY=$vnmrsystem/tcl/tklibrary
@@ -41,8 +35,6 @@ export PGHOST=localhost
 # export FASTMAP PGLIB PGDATA PGDATABASE PGPORT PGHOST
 
 export PATH="$vnmrsystem/pgsql/bin:$PATH"
-export CLASSPATH=$vnmrsystem/jpsg/lib/Jpsg.jar:$vnmrsystem/jpsg/lib:$vnmrsystem/jre
-# export path CLASSPATH
 
 export BROWSERDIR=$vnmruser/ib_initdir
 export INITDIR=$vnmruser/aip_initdir
@@ -51,7 +43,7 @@ export CSIDIR=$vnmruser/csi_initdir
 # export BROWSERDIR INITDIR AIPDIR CSIDIR
 
 export DELEGATE_PATH=$vnmrsystem/user_templates/ImageMagick
-export LD_LIBRARY_PATH=$JREHOME/lib:$vnmrsystem/java:$vnmrsystem/lib:$PGLIB
+export LD_LIBRARY_PATH=$vnmrsystem/java:$vnmrsystem/lib:$PGLIB
 export XFILESEARCHPATH=$home/%T/%N%S:$vnmrsystem/%T/%N%S
 # export DELEGATE_PATH LD_LIBRARY_PATH XFILESEARCHPATH
 

--- a/src/common/user_templates/.vnmrenvsh
+++ b/src/common/user_templates/.vnmrenvsh
@@ -13,14 +13,8 @@ graphics=sun
 memsize=64
 export vnmruser vnmrsystem vnmreditor graphics memsize
 
-# deprecated, only used for Solaris systems.
-# GNUDIR=$vnmrsystem/gnu
-# GCC_EXEC_PREFIX=$GNUDIR/lib/gcc-lib/
-# PATH=$GNUDIR/bin:$JREHOME/bin:$PATH:$vnmrsystem/bin
-# export JREHOME GNUDIR GCC_EXEC_PREFIX PATH
-JREHOME=$vnmrsystem/jre
-PATH=$JREHOME/bin:$PATH:$vnmrsystem/bin:$vnmrsystem/pgsql/bin
-export JREHOME GCC_EXEC_PREFIX PATH
+PATH=$PATH:$vnmrsystem/bin:$vnmrsystem/pgsql/bin
+export PATH
 
 TCL_LIBRARY=$vnmrsystem/tcl/tcllibrary
 TK_LIBRARY=$vnmrsystem/tcl/tklibrary
@@ -43,9 +37,6 @@ PGPORT=5432
 PGHOST=localhost
 export FASTMAP PGLIB PGDATA PGDATABASE PGPORT PGHOST
 
-CLASSPATH=$vnmrsystem/jpsg/lib/Jpsg.jar:$vnmrsystem/jpsg/lib:$vnmrsystem/jre
-export CLASSPATH
-
 BROWSERDIR=$vnmruser/ib_initdir
 INITDIR=$vnmruser/aip_initdir
 AIPDIR=$vnmruser/aip_initdir
@@ -53,7 +44,7 @@ CSIDIR=$vnmruser/csi_initdir
 export BROWSERDIR INITDIR AIPDIR CSIDIR
 
 DELEGATE_PATH=$vnmrsystem/user_templates/ImageMagick
-LD_LIBRARY_PATH=$JREHOME/lib:$vnmrsystem/java:$vnmrsystem/lib:$PGLIB
+LD_LIBRARY_PATH=$vnmrsystem/java:$vnmrsystem/lib:$PGLIB
 XFILESEARCHPATH=$home/%T/%N%S:$vnmrsystem/%T/%N%S
 export DELEGATE_PATH LD_LIBRARY_PATH XFILESEARCHPATH
 

--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -50,7 +50,8 @@ turboRepo() {
 name=TurboVNC official RPMs
 baseurl=https://sourceforge.net/projects/turbovnc/files
 gpgcheck=1
-gpgkey=http://pgp.mit.edu/pks/lookup?op=get&search=0x6BBEFA1972FEB9CE
+gpgkey=https://sourceforge.net/projects/turbovnc/files/VGL-GPG-KEY
+       https://sourceforge.net/projects/turbovnc/files/VGL-GPG-KEY-1024
 enabled=1
 exclude=turbovnc-*.*.9[0-9]-*
 EOF
@@ -144,6 +145,8 @@ if [ -d /tmp/ovj_preinstall ]; then
 else
   logfile="/tmp/pkgInstall.log_$postfix"
 fi
+touch $logfile
+chmod 666 $logfile
 
 if [ ! -x /usr/bin/dpkg ]; then
   if [ -f /etc/centos-release ]; then
@@ -371,7 +374,6 @@ if [ ! -x /usr/bin/dpkg ]; then
     PyGreSQL
     sharutils
     a2ps
-    compat-libstdc++-33
     fuseiso
     gconf-editor
   '
@@ -428,7 +430,7 @@ if [ ! -x /usr/bin/dpkg ]; then
 #  Add older motif package
     packageList="openmotif $item68List $commonList $bit32List $pipeList"
   else
-    packageList="$item68List $commonList $pipeList"
+    packageList="$item68List $commonList $pipeList java-1.8.0-openjdk libnsl"
   fi
 
 

--- a/src/scripts/ovjUseRepo.sh
+++ b/src/scripts/ovjUseRepo.sh
@@ -63,7 +63,7 @@ if [ -f /etc/debian_version ]; then
    outfile="/etc/apt/sources.ovj"
    mv $infile $outfile
 #   grep "^deb" $outfile | awk '$2="file:'$repoPath'"' > $infile
-   echo "deb [ allow-insecure=yes ] file:$repoPath /" > $infile
+   echo "deb [ trusted=yes ] file:$repoPath /" > $infile
    apt-get update 2> /dev/null
 else
    rm -f /etc/yum.repos.d/openvnmrj.repo

--- a/src/scripts/ovjddrout.sh
+++ b/src/scripts/ovjddrout.sh
@@ -595,21 +595,21 @@ log_this "PART IV -- INSTALLATION FILES -- $dest_dir"
 # copy some of the installation programs
 #Add jre to DVD
 
-       dir="jre"
-      #log_this "   Tarring jre                     for : "
-       tarring "$dir"
-       cd $OVJ_TOOLS/java
-       tar --exclude=.gitignore -cf $dest_dir_code/$Tarfiles/jre.tar jre
-       # tarIt "--exclude=.gitignore" "$dest_dir_code/$Tarfiles/jre.tar" "jre"
-       cd $dest_dir_code
-       tar xpf $Tarfiles/jre.tar
-       rm -rf jre.linux
-       mv jre jre.linux
-       getSize $dest_dir_code/jre.linux
-       makeTOC jre.tar $Vnmr rht/vnmrs.rht      \
-                             rht/mr400.rht      \
-                             rht/propulse.rht
-       rm $Tarfiles/jre.tar     # exception
+#      dir="jre"
+#     #log_this "   Tarring jre                     for : "
+#      tarring "$dir"
+#      cd $OVJ_TOOLS/java
+#      tar --exclude=.gitignore -cf $dest_dir_code/$Tarfiles/jre.tar jre
+#      # tarIt "--exclude=.gitignore" "$dest_dir_code/$Tarfiles/jre.tar" "jre"
+#      cd $dest_dir_code
+#      tar xpf $Tarfiles/jre.tar
+#      rm -rf jre.linux
+#      mv jre jre.linux
+#      getSize $dest_dir_code/jre.linux
+#      makeTOC jre.tar $Vnmr rht/vnmrs.rht      \
+#                            rht/mr400.rht      \
+#                            rht/propulse.rht
+#      rm $Tarfiles/jre.tar     # exception
 
 #Nirvana CD only
 touch $dest_dir_code/.nv

--- a/src/scripts/ovjmiout.sh
+++ b/src/scripts/ovjmiout.sh
@@ -603,20 +603,20 @@ log_this "PART IV -- INSTALLATION FILES -- $dest_dir"
 # copy some of the installation programs
 #Add jre to DVD
 
-       dir="jre"
-      #log_this "   Tarring jre                     for : "
-       tarring "$dir"
-       cd $OVJ_TOOLS/java
-       tar --exclude=.gitignore -cf $dest_dir_code/$Tarfiles/jre.tar jre
-       # tarIt "--exclude=.gitignore" "$dest_dir_code/$Tarfiles/jre.tar" "jre"
-       cd $dest_dir_code
-       tar xpf $Tarfiles/jre.tar
-       rm -rf jre.linux
-       mv jre jre.linux
-       getSize $dest_dir_code/jre.linux
-       makeTOC jre.tar $Vnmr rht/inova.rht      \
-                             rht/mercplus.rht
-       rm $Tarfiles/jre.tar     # exception
+#      dir="jre"
+#     #log_this "   Tarring jre                     for : "
+#      tarring "$dir"
+#      cd $OVJ_TOOLS/java
+#      tar --exclude=.gitignore -cf $dest_dir_code/$Tarfiles/jre.tar jre
+#      # tarIt "--exclude=.gitignore" "$dest_dir_code/$Tarfiles/jre.tar" "jre"
+#      cd $dest_dir_code
+#      tar xpf $Tarfiles/jre.tar
+#      rm -rf jre.linux
+#      mv jre jre.linux
+#      getSize $dest_dir_code/jre.linux
+#      makeTOC jre.tar $Vnmr rht/inova.rht      \
+#                            rht/mercplus.rht
+#      rm $Tarfiles/jre.tar     # exception
 
 #
 #  VJ cdrom only

--- a/src/scripts/vnmrsetup.sh
+++ b/src/scripts/vnmrsetup.sh
@@ -19,16 +19,11 @@
 #
 # set -x
 
-#This script also responsible for loading JRE enviroment in order to
-#start running LoadNmr
-#
-
 xhost + > /dev/null
 
 set_system_stuff() {
    ostype=$(uname -s)
    os_type="rht"
-   JRE="jre.linux"
    default_dir="/home"
    if [ -f /etc/debian_version ]; then
       distroType="debian"
@@ -382,7 +377,6 @@ then
 fi
 
 host_name=$(uname -n)
-JRE="jre"
 set_system_stuff
 
 #
@@ -405,7 +399,6 @@ user_dir="$default_dir"
 nmr_group="nmr"
 
 adm_base_dir="/var/tmp"
-jre_base_dir=$adm_base_dir
  
 if [ ! -d $adm_base_dir ]
 then
@@ -473,8 +466,6 @@ fi
 
 echo "Starting the OpenVnmrJ installation program..."
 
-jre_base_dir=$src_code_dir
-java_cmd=$jre_base_dir/${JRE}/bin/java
 # Save pipe directory in case we need to copy it
 if [[ -d /vnmr ]] ; then
    oldVnmr=$(readlink /vnmr)
@@ -489,7 +480,7 @@ newgrp=/tmp/newgrp
 rm -f $insLog
 rm -f $newgrp
 
-$java_cmd -classpath $jre_base_dir/${JRE}/lib/rt.jar:$adm_base_dir/VnmrAdmin.jar LoadNmr $base_dir $dest_dir $nmr_user $user_dir $nmr_group $os_type $1
+java -classpath $adm_base_dir/VnmrAdmin.jar LoadNmr $base_dir $dest_dir $nmr_user $user_dir $nmr_group $os_type $1
 if [ $? -ne 0 ]
 then
    rm -f $insLog


### PR DESCRIPTION
With the move to java 8 (see OpenVnmrJ/ovjTools#59 ) the jre is no
longer needed in the dvd image. In fact, it causes problems because
different updates of java 8 require diffentent libraries.