### PR TITLE
Start of OpenVnmrJ 3.1 beta test

### DIFF
--- a/src/scripts/create_pgsql_user.sh
+++ b/src/scripts/create_pgsql_user.sh
@@ -22,18 +22,7 @@ if [ x$vnmrsystem = "x" ]
 then
    vnmrsystem="/vnmr"
 fi
-# Are we using the newer postgres or the old version distributed with vnmrj?
-# If createuser exists in $vnmrsystem/pgsql/bin/, use it, 
-# else use system version.
-file="$vnmrsystem/pgsql/bin/createuser"
-if [ -f "$file" ]
-then
-    # Old one, use appropriate path and args
-    $vnmrsystem/pgsql/bin/createuser -a -q -d -h /tmp $1
-else
-    # New one, use no path and appropriate args
-    createuser -d -h /tmp -S -R $1 2> /dev/null
-fi
+createuser -d -h /tmp -S -R $1 2> /dev/null
 
 echo "DONE"
 

--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -558,7 +558,7 @@ if [ ! -x /usr/bin/dpkg ]; then
   if [ $perlHomeInstalled -eq 0 ]
   then
     echo "Removing perl-home rpm" &>> $logfile
-    yum -y erase perl-homedir &>> $logfile
+    yum -y erase perl-homedir > /dev/null 2>&1
   fi
 
  # No need to add repos if OVJ repo is being used

--- a/src/scripts/vnmrsetup.sh
+++ b/src/scripts/vnmrsetup.sh
@@ -469,6 +469,10 @@ echo "Starting the OpenVnmrJ installation program..."
 # Save pipe directory in case we need to copy it
 if [[ -d /vnmr ]] ; then
    oldVnmr=$(readlink /vnmr)
+   oldJava=$(echo $PATH | grep jre)
+   if [[ ! -z $oldJava ]]; then
+      export PATH=$(echo $PATH | sed 's|/vnmr/jre/bin:||')
+   fi
 else
    oldVnmr=""
 fi


### PR DESCRIPTION
Three problems were quickly found. If previous OVJ2 was installed,
the java 1.6 based /vnmr/jre caused problems. Solution is to remove
it from PATH. The wrong call to createuser was being made for Postgres 9.
A nuisance message during package installation about perl-homedir was removed.