### PR TITLE
OVJ was not working if java newer than 1.8

### DIFF
--- a/src/bin/header_change.c
+++ b/src/bin/header_change.c
@@ -49,11 +49,15 @@ struct {
 
 // From data.h
 
+#define S_VAR           0x0     /* 1 = Varian data               */ 
 #define S_QONE          0x800   /* 1 = Q-One data               */ 
 #define S_MAKEFID       0x1000  /* 1 = data from makefid        */
 #define S_JEOL          0x2000  /* 1 = JEOL data                */ 
 #define S_BRU           0x4000  /* 1 = Bruker data              */ 
+#define S_MAG           0x1800  /* 1 = Magritek data              */ 
 #define P_VENDOR_ID     0x7800  /* preserves vendor ID status   */
+#define S_COMPLEX       0x10    /* 0 = real         1 = complex    */
+#define VERSION 1
 
 /*** PROGRAM BEGIN *************************************/
 int main(int argc, char *argv[])
@@ -123,16 +127,29 @@ int main(int argc, char *argv[])
       if ( versID)
       {
          short vers_id;
+         short status;
          vers_id = ntohs(datafilehead.vers_id);
+         status = ntohs(datafilehead.status);
+         if ( ! (status & S_COMPLEX) )
+         {
+            status  &= ~(0x40);
+            status |= S_COMPLEX;
+            datafilehead.status = htons(status);
+         }
          vers_id &= ~P_VENDOR_ID;
+         if (argv[3][0] == 'V')
+            vers_id |= S_VAR;
          if (argv[3][0] == 'B')
             vers_id |= S_BRU;
          if (argv[3][0] == 'J')
             vers_id |= S_JEOL;
          if (argv[3][0] == 'Q')
             vers_id |= S_QONE;
-         if (strstr(argv[3],"M") != NULL)
+         if (argv[3][0] == 'C')
             vers_id |= S_MAKEFID;
+         if (argv[3][0] == 'M')
+            vers_id |= S_MAG;
+         vers_id |= VERSION;
         
          datafilehead.vers_id = htons(vers_id);
          rewind(in_file);  

--- a/src/scripts/vnmrj.sh
+++ b/src/scripts/vnmrj.sh
@@ -173,7 +173,7 @@ then
 fi
 modsArg=""
 vers=$($javabin -fullversion 2>&1 | awk 'BEGIN {FS="\""} {print $2}' | awk 'BEGIN {FS="."} {print $1}')
-if [[ $vers > 8 ]]
+if [[ $vers -gt 8 ]]
 then
   modsArg="--add-modules ALL-SYSTEM"
 fi

--- a/src/vnmrj/SConstruct
+++ b/src/vnmrj/SConstruct
@@ -123,18 +123,18 @@ if (platform.startswith('linux')):
 elif (platform=="darwin"):
    javaBinDir = os.path.join('/', 'usr', 'bin')
    jarBin = os.path.join(javaBinDir, 'jar')
-   Execute('rm -rf ' + os.path.join('src','vnmr','lc'))
-   Execute('rm -f ' + os.path.join('src','vnmr','util','CorbaClient.java'))
-   Execute('rm -f ' + os.path.join('src','vnmr','bo','VMsStatusButton.java'))
-   Execute('rm -f ' + os.path.join('src','vnmr','bo','VStatusButton.java'))
-   Execute('rm -f ' + os.path.join('src','vnmr','templates','LayoutBuilder.java'))
-   Execute('rm -f ' + os.path.join('src','vnmr','ui','ExpPanel.java'))
-   Execute(Copy(os.path.join('src','vnmr','bo','VStatusButton.java'),
-                os.path.join('macos','VStatusButton.java')))
-   Execute(Copy(os.path.join('src','vnmr','templates','LayoutBuilder.java'),
-                os.path.join('macos','LayoutBuilder.java')))
-   Execute(Copy(os.path.join('src','vnmr','ui','ExpPanel.java'),
-                os.path.join('macos','ExpPanel.java')))
+#  Execute('rm -rf ' + os.path.join('src','vnmr','lc'))
+#  Execute('rm -f ' + os.path.join('src','vnmr','util','CorbaClient.java'))
+#  Execute('rm -f ' + os.path.join('src','vnmr','bo','VMsStatusButton.java'))
+#  Execute('rm -f ' + os.path.join('src','vnmr','bo','VStatusButton.java'))
+#  Execute('rm -f ' + os.path.join('src','vnmr','templates','LayoutBuilder.java'))
+#  Execute('rm -f ' + os.path.join('src','vnmr','ui','ExpPanel.java'))
+#  Execute(Copy(os.path.join('src','vnmr','bo','VStatusButton.java'),
+#               os.path.join('macos','VStatusButton.java')))
+#  Execute(Copy(os.path.join('src','vnmr','templates','LayoutBuilder.java'),
+#               os.path.join('macos','LayoutBuilder.java')))
+#  Execute(Copy(os.path.join('src','vnmr','ui','ExpPanel.java'),
+#               os.path.join('macos','ExpPanel.java')))
 else: 
    print("Unknown Platform: ", platform)
    sys.exit()
@@ -191,11 +191,16 @@ if (platform!="darwin"):
                              'CLASSPATH' : classesPath,
                              'PATH' : javaBinDir + ':' + os.environ['PATH']})
 elif (platform=="darwin"):
+   if not "JAVA_HOME" in os.environ:
+      os.environ['JAVA_HOME'] = os.popen('/usr/libexec/java_home -v 1.8').read()
+
    vjmolEnv  = Environment(ENV = {'CLASSPATH' : os.path.join(cwd, 'jmol.jar'),
+                                  'JAVA_HOME' : os.environ['JAVA_HOME'],
                                   'PATH' : javaBinDir + ':' + os.environ['PATH']})
 
    # define build environment
    jEnv = Environment(ENV = {'CLASSPATH' : classesPath,
+                             'JAVA_HOME' : os.environ['JAVA_HOME'],
                              'PATH' : javaBinDir + ':' + os.environ['PATH']})
 
 

--- a/src/vnmrj/src/vnmr/templates/LayoutBuilder.java
+++ b/src/vnmrj/src/vnmr/templates/LayoutBuilder.java
@@ -527,11 +527,15 @@ public class LayoutBuilder extends PanelTemplate implements VObjDef, Types
         addVObject("selmenu",       vnmr.bo.VSelMenu.class);
         addVObject("selfilemenu",   vnmr.bo.VSelFileMenu.class);
         addVObject("plot",          vnmr.bo.VPlot.class);
-        addVObject("lcplot",        vnmr.lc.VLcPlot.class);
-        addVObject("msplot",        vnmr.lc.VMsPlot.class);
-        addVObject("pdaplot",       vnmr.lc.VPdaPlot.class);
-        addVObject("pdaimage",      vnmr.lc.VPdaImage.class);
-        addVObject("lcTableItem",   vnmr.lc.VLcTableItem.class);
+        // CORBA has been remove after java 1.8
+        if ( System.getProperty("java.version").startsWith("1.") )
+        {
+           addVObject("lcplot",        vnmr.lc.VLcPlot.class);
+           addVObject("msplot",        vnmr.lc.VMsPlot.class);
+           addVObject("pdaplot",       vnmr.lc.VPdaPlot.class);
+           addVObject("pdaimage",      vnmr.lc.VPdaImage.class);
+           addVObject("lcTableItem",   vnmr.lc.VLcTableItem.class);
+        }
         addVObject("undobutton",    vnmr.bo.VUndoButton.class);
         addVObject("redobutton",    vnmr.bo.VRedoButton.class);
         addVObject("rfmonbutton",   vnmr.bo.VRFMonButton.class);


### PR DESCRIPTION
The CORBA modules have been removed from java 9 and newer.
The LC-NMR parts of OVJ requires them. Now do a run-time
test of the java version and only load the CORBA stuff
if java is 1.8 or older. Also fixed a typo in vnmrj script.
This fix also works on MacOS.