### PR TITLE
Operator passwords no longer worked in Java 11

### DIFF
--- a/src/passwd/SConstruct
+++ b/src/passwd/SConstruct
@@ -45,6 +45,10 @@ else:
 print(javaBinPath)
 print(jarBin)
 
+# If java 6 is being used
+if os.path.exists(os.path.join(ovjtools,'java','bin','javaws')):
+   Execute(Copy(os.path.join('src','passwd.java'),'passwd.java6'))
+
 
 # make sure the path(s) exist
 classesPath = os.path.join(cwd, 'classes')

--- a/src/passwd/passwd.java6
+++ b/src/passwd/passwd.java6
@@ -7,10 +7,10 @@
  * For more information, see the LICENSE file.
  */
 
-package vnmr.ui;
 
 import java.io.*;
 import java.util.*;
+import javax.xml.bind.*;
 
 import java.security.*;
 
@@ -23,16 +23,14 @@ import java.security.*;
  *
  */
 
-public class PasswordService
+public class passwd
 {
 
-    private static PasswordService instance;
-
-    private PasswordService()
+    private passwd()
     {
     }
 
-    public synchronized String encrypt(String plaintext) throws UnsupportedEncodingException
+    public String encrypt(String plaintext) throws UnsupportedEncodingException
     {
         MessageDigest md = null;
         try
@@ -53,16 +51,25 @@ public class PasswordService
         }
 
         byte raw[] = md.digest(); //step 4
-        String hash = Base64.getEncoder().encodeToString(raw); //step 5
+        String hash = DatatypeConverter.printBase64Binary(raw); //step 5
         plaintext = "";
         return hash; //step 6
     }
 
-    public static synchronized PasswordService getInstance() //step 1
-    {
-        if(instance == null)
-            return new PasswordService();
-        else
-            return instance;
+    public static void main(String[] args) {
+        String reqpasswd = "";
+        String strNewPasswd = "";
+        if (args.length > 0) {
+            reqpasswd = args[0];
+        }
+        try
+        {
+           strNewPasswd = (new passwd()).encrypt(new String(reqpasswd));
+        }
+        catch (Exception e) {
+            System.out.println("passwd: failed");
+   
+        }
+        System.out.println(strNewPasswd);
     }
 }

--- a/src/passwd/src/passwd.java
+++ b/src/passwd/src/passwd.java
@@ -10,7 +10,6 @@
 
 import java.io.*;
 import java.util.*;
-import javax.xml.bind.*;
 
 import java.security.*;
 
@@ -51,7 +50,7 @@ public class passwd
         }
 
         byte raw[] = md.digest(); //step 4
-        String hash = DatatypeConverter.printBase64Binary(raw); //step 5
+        String hash = Base64.getEncoder().encodeToString(raw); //step 5
         plaintext = "";
         return hash; //step 6
     }

--- a/src/scripts/ovjPasswd.sh
+++ b/src/scripts/ovjPasswd.sh
@@ -16,18 +16,10 @@ then
    vnmrsystem=/vnmr
 fi
 
-modsArg=""
-vers=$(java -fullversion 2>&1 | awk 'BEGIN {FS="\""} {print $2}' | awk 'BEGIN {FS="."} {print $1}')
-if [[ $vers > 8 ]]
-then
-  modsArg="--add-modules java.xml.bind"
-fi
-
-
 if [[ $# -eq 1 ]] ; then
-   ovjPasswd=$(java $modsArg -jar ${vnmrsystem}/java/passwd.jar $1)
+   ovjPasswd=$(java -jar ${vnmrsystem}/java/passwd.jar $1)
 else
-   ovjPasswd=$(java $modsArg -jar ${vnmrsystem}/java/passwd.jar)
+   ovjPasswd=$(java -jar ${vnmrsystem}/java/passwd.jar)
 fi
 
 echo ${ovjPasswd}

--- a/src/vnmrj/PasswordService.java6
+++ b/src/vnmrj/PasswordService.java6
@@ -11,6 +11,7 @@ package vnmr.ui;
 
 import java.io.*;
 import java.util.*;
+import javax.xml.bind.*;
 
 import java.security.*;
 
@@ -53,7 +54,7 @@ public class PasswordService
         }
 
         byte raw[] = md.digest(); //step 4
-        String hash = Base64.getEncoder().encodeToString(raw); //step 5
+        String hash = DatatypeConverter.printBase64Binary(raw); //step 5
         plaintext = "";
         return hash; //step 6
     }

--- a/src/vnmrj/SConstruct
+++ b/src/vnmrj/SConstruct
@@ -45,17 +45,9 @@ print(sys.platform)
 version=20
 
 
-
-#
-# define function to convert SUA paths to Windows
-
-def Sua2WinPath(suaPath):
-   if ( '/dev/fs/' in suaPath ):
-     dLetter = suaPath[8:9]
-     # print(dLetter)
-     return dLetter + ':' + suaPath[9:]
-   else:
-      return suaPath
+# If java 6 is being used
+if os.path.exists(os.path.join(ovjtools,'java','bin','javaws')):
+   Execute(Copy(os.path.join('src','vnmr','ui','PasswordService.java'),'PasswordService.java6'))
 
 
 # target


### PR DESCRIPTION
The javax.xml.bind used to encode the password was removed.
Kept the old versions as vnmrj/PasswordService.java6 and
passwd/passwd.java6 and updated SConstruct files to test if
java 6 is being used to compile since the Base64
replacement does not exist in java 6.