### PR TITLE
Removed annoying warning message from getparam

### DIFF
--- a/src/common/maclib/getparam
+++ b/src/common/maclib/getparam
@@ -9,6 +9,14 @@ if ($# < 1) then
      return
 endif
 
+if system<>'spectrometer' then
+    if ($#<3 and probe='') then 
+	return 
+    else
+	if $3='' then return endif
+    endif
+endif
+
 if ($# < 2) then $2=tn endif
 $param=$2+$1
 $ret='' $num=0 $e=0


### PR DESCRIPTION
On datastation, removed "Probe parameter not set, please set with addprobe"