### PR TITLE
Set the icon for a running OpenVnmrJ

### DIFF
--- a/src/common/user_templates/vnmrj.desktop
+++ b/src/common/user_templates/vnmrj.desktop
@@ -11,3 +11,4 @@ Categories=GNOME;Application;
 StartupNotify=true
 X-Desktop-File-Install-Version=0.4
 OnlyShowIn=GNOME;
+StartupWMClass=vnmr-ui-VNMRFrame

--- a/src/common/user_templates/vnmrjadmin.desktop
+++ b/src/common/user_templates/vnmrjadmin.desktop
@@ -11,3 +11,4 @@ Categories=GNOME;Application;
 StartupNotify=true
 X-Desktop-File-Install-Version=0.4
 OnlyShowIn=GNOME;
+StartupWMClass=vnmr-ui-VNMRFrame

--- a/src/common/user_templates/vnmrjja.desktop
+++ b/src/common/user_templates/vnmrjja.desktop
@@ -13,3 +13,4 @@ StartupNotify=true
 X-Desktop-File-Install-Version=0.4
 OnlyShowIn=GNOME;
 Name[en_US]=OpenVnmrJ 日本語 
+StartupWMClass=vnmr-ui-VNMRFrame

--- a/src/common/user_templates/vnmrjzh.desktop
+++ b/src/common/user_templates/vnmrjzh.desktop
@@ -13,3 +13,4 @@ StartupNotify=true
 X-Desktop-File-Install-Version=0.4
 OnlyShowIn=GNOME;
 Name[en_US]=OpenVnmrJ 中文 
+StartupWMClass=vnmr-ui-VNMRFrame


### PR DESCRIPTION
It was showing up as the generic Java icon in the task bar on Ubuntu.