### PR TITLE
On bootup on RHEL 8 systems, the procs were not starting correctly

### DIFF
--- a/src/scripts/vnmr.service.sh
+++ b/src/scripts/vnmr.service.sh
@@ -1,6 +1,8 @@
 [Unit]
 Description=Acquisition Communication Daemon
 ConditionPathExists=/vnmr/acqbin/acqpresent
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
The systemd was starting them before the network was ready.
Solution is the add After and Wants for network-online.target