### PR TITLE
paramcopy uses return argument to avoid aborting.

### DIFF
--- a/src/common/manual/paramcopy
+++ b/src/common/manual/paramcopy
@@ -7,7 +7,9 @@ paramcopy	-   copy a variable to another variable
    The variables can be in the same or different trees.
    Default trees are current. If the parameter that is being copied to already
    exists, it will be deleted first. This command copies the parameter value
-   all of its attributes.
+   all of its attributes. If the fromVar does not exist, the paramcopy command
+   will abort unless a return value is given. In this case, the return
+   value will be set to 1 for success and 0 for failure.
 
    Usage -- paramcopy(fromVar, toVar, fromTree, toTree)
             trees can be  current,global,processed,usertree

--- a/src/vnmr/builtin.c
+++ b/src/vnmr/builtin.c
@@ -1842,6 +1842,11 @@ int paramcopy(int argc, char *argv[], int retc, char *retv[])
       }
       if (P_copyvar(fromTree,toTree,argv[1],argv[2]) < 0)
       {
+         if (retc)
+         {
+            retv[0] = intString(0);
+            RETURN;
+         }
          Werrprintf("paramcopy: parameter \"%s\" does not exist", argv[1]);
          ABORT;
       }
@@ -1850,6 +1855,8 @@ int paramcopy(int argc, char *argv[], int retc, char *retv[])
    {   Werrprintf("Usage -- paramcopy(fromVar,toVar<,fromTree<,toTree>>)");
        ABORT;
    }
+   if (retc)
+      retv[0] = intString(1);
    RETURN;
 }
 


### PR DESCRIPTION
It will be set to 1 for success and 0 for failure