### PR TITLE
rt, rtp, rtv, and fread use same search

### DIFF
--- a/src/common/manual/fread
+++ b/src/common/manual/fread
@@ -15,10 +15,11 @@ fread	- 	read in variables from a file and load them in a tree
 
   If the file exists and it is not a directory, parameters will be read from
   it. If the file exists and it is a directory, parameters will be read from
-  a procpar from within that directory. If the file does not exist, first a
-  ".fid/procpar" will be appended to the file name. If it exists, it will
-  be used. Otherwise, a ".par/procpar" will be appended and if that exists,
-  it will be used.
+  a procpar from within that directory. If the file does not exist, the following
+  will be appended to the file name. The first one that is found will be used.
+  The names appended, in order, are: ".REC/acqfil/procpar", ".rec/acqfil/procpar",
+  ".vfs/procpar", ".fid/procpar", and finally ".par/procpar". Note that this
+  is the same search order used by rt, rtp, and rtv.
 
   A "reset" option causes the variable tree to first be cleared before
   the new variable file is read. Without this option, variables read from

--- a/src/common/manual/rt
+++ b/src/common/manual/rt
@@ -5,21 +5,49 @@ rtp<(filename)> -  Retrieve Parameters
 rtv(filename,paramname,....):val - Retrieve individual parameter(s)
 ******************************************************************************
   
-  "rt" retrieves all fid's stored in the file "filename.fid" into the
-  current experiment. If "filename.fid" does not exist, and "filename.par" does,
-  it retrieves the parameters only from "filename.par". If the argument 'nolog'
-  is specified the log-file will not be retrieved.
-  "rtp" does retrieve parameters from "filename.par", if this file exists. If
-  not, and if "filename.fid" exists, it retrieves the parameters only from 
-  "filename.fid".
+  "rt" retrieves a fid and paramters into the current experiment. If no fid
+  exists in the filename directory, then only parameters are retrieved.
+  "rtp" retrieves parameters into the current experiment.
+  "rtv" retrieves one or more parameters into the current experiment
+  or into local macro parameters..
+
+  The filename argument specifies where the data will be obtained from.
+  For "rt", the filename is expected to be a directory with a fid and
+  procpar file in it. In only a procpar exists, then only parameters
+  will be retrieved.
+  For "rtp", the filename is expected to be a directory with a procpar
+  file in it.
+  For "rtv", the filename can be a directory with a procpar file in it
+  or it can be a full name of a parameter file.
+
+  For "rt", if the filename does exist and if "fid" exists in that directory,
+  it will be used along with the procpar. If "fid" does not exist, only
+  the "procpar" will be retrieved.
+  For "rt", if the filename does not exist,the following will be appended to
+  the file name. The first "fid" file that is found will be used.  The names
+  appended, in order, are: ".REC/acqfil/fid", ".rec/acqfil/fid",
+  ".vfs/acqfil/fid", and finally ".fid/fid". If no "fid" file is found but there
+  exists filename with ".par/procpar" appended to it, only parameters will be
+  retrieved.
+
+  For "rtp", if the filename does not exist,the following will be appended to
+  the file name. The first "procpar" file that is found will be used.  The names
+  appended, in order, are: ".REC/acqfil/procpar", ".rec/acqfil/procpar",
+  ".vfs/procpar", ".fid/procpar" and finally ".par/procpar".
+
+  For "rtv", if the file exists and it is not a directory, parameters will be
+  read from it. If the file exists and it is a directory, parameters will be
+  read from a procpar from within that directory. If the file does not exist,
+  the following will be appended to the file name. The first one that is found
+  will be used. The names appended, in order, are: ".REC/acqfil/procpar",
+  ".rec/acqfil/procpar", ".vfs/procpar", ".fid/procpar", and finally ".par/procpar".
+  Note that this is the same search order used by fread.
+
+  If the argument 'nolog' is specified the log-file will not be retrieved.
 
   "rtv" retrieves one or several parameters from a parameter file. The file
   may have been made with "svf" or "svp" or "sd" commands, or it may be
-  from another experiment. For rtv, if the supplied filename is a directory,
-  (with or without the .fid or .par extension), then the
-  parameters will be retrieved from the procpar file in that directory.
-  If the filename does not correspond to a directory but rather is a 
-  Vnmr parameter file, that file will be used.  If rtv is used without
+  from another experiment. If rtv is used without
   returning values to the macro by appending a colon and macro variables,
   then the parameters will be copied into the experiments "current" tree.
   If the parameter does not already exist in the current tree, it will be

--- a/src/vnmr/builtin1.c
+++ b/src/vnmr/builtin1.c
@@ -1062,13 +1062,43 @@ int f_read(int argc, char *argv[], int retc, char *retv[])
        // see if .fid or .par directories exist
        else
        {
-          strcat(path,".fid");
+          strcat(path,".REC");
           if ( ! access(path, R_OK))
           {
-             strcat(path,"/procpar");
+             strcat(path,"/acqfil/procpar");
              stream = fopen(path,"r");
           }
-          else
+          if ( stream == NULL )
+          {
+             strcpy(path,argv[1]);
+             strcat(path,".rec");
+             if ( ! access(path, R_OK))
+             {
+                strcat(path,"/acqfil/procpar");
+                stream = fopen(path,"r");
+             }
+          }
+          if ( stream == NULL )
+          {
+             strcpy(path,argv[1]);
+             strcat(path,".vfs");
+             if ( ! access(path, R_OK))
+             {
+                strcat(path,"/procpar");
+                stream = fopen(path,"r");
+             }
+          }
+          if ( stream == NULL )
+          {
+             strcpy(path,argv[1]);
+             strcat(path,".fid");
+             if ( ! access(path, R_OK))
+             {
+                strcat(path,"/procpar");
+                stream = fopen(path,"r");
+             }
+          }
+          if ( stream == NULL )
           {
              strcpy(path,argv[1]);
              strcat(path,".par");

--- a/src/vnmr/files.c
+++ b/src/vnmr/files.c
@@ -115,6 +115,29 @@ int isRec(char *s)
 }
 
 /*----------------------------------------------------------------------
+|   isVfs  
+|
+|   This routine determines if the directory is a vfs diredtory.
+|   It returns 1 if it is, a 0 if it is not.  
++-----------------------------------------------------------------------*/
+int isVfs(char *s)
+{
+	char *ptr;
+
+/*   directory path has the form  /abc/xxx.vfs   */
+
+	if (!(ptr = strrchr(s,'.'))) {		/* find last dot in last field */  
+		return 0;
+	}
+	if (strncmp(".vfs",ptr,4) == 0  && strlen(ptr) == 4) {
+		return 1;
+	}
+	else {
+		return 0;
+	}
+}
+
+/*----------------------------------------------------------------------
 |   isFid  
 |
 |   This routine determines if the directory is a fid diredtory.


### PR DESCRIPTION
If the "filename" does not exist, then .REC, .rec, .vfs, .fid
and .par directories are searched. Man pages have been updated.