### PR TITLE
Updated bootp.service for RHEL 8 systems

### DIFF
--- a/src/scripts/bootpd.service.sh
+++ b/src/scripts/bootpd.service.sh
@@ -2,6 +2,8 @@
 Description=Bootp Daemon
 ConditionPathExists=/usr/sbin/bootpd
 Before=vnmr.service
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
As in PR#589 , bootp also needs the network to be ready.
Added After and Wants for network-online.target