### PR TITLE
loginpassword and loginpaswordcheck failed to run if called directly.

### DIFF
--- a/src/scripts/loginpassword.sh
+++ b/src/scripts/loginpassword.sh
@@ -1,4 +1,4 @@
-#: '@(#)loginpassword.sh 22.1 03/24/08 1999-2002 '
+#! /usr/bin/expect -f
 # 
 #
 # Copyright (C) 2015  University of Oregon
@@ -9,9 +9,6 @@
 # For more information, see the LICENSE file.
 # 
 #
-
-#!/bin/sh
-# \
 
 # wrapper to make passwd(1) be non-interactive
 # username is passed as 1st arg, passwd as 2nd

--- a/src/scripts/loginpasswordcheck.sh
+++ b/src/scripts/loginpasswordcheck.sh
@@ -1,4 +1,4 @@
-#: '@(#)loginpasswordcheck.sh 22.1 03/24/08 1999-2002 '
+#! /usr/bin/expect -f
 # 
 #
 # Copyright (C) 2015  University of Oregon
@@ -9,7 +9,6 @@
 # For more information, see the LICENSE file.
 # 
 #
-#! /bin/sh -f
 
 # Checks unix password by doing su username password
 


### PR DESCRIPTION
This was identified in Issue #588 and the solution posted there
was implemented.