### PR TITLE
Updated installation scripts

### DIFF
--- a/src/scripts/ovjGetpipe.sh
+++ b/src/scripts/ovjGetpipe.sh
@@ -132,19 +132,19 @@ downloadLinux() {
    $OVJ_VECHO "Downloading NMRPipe files to Linux file system"
    if [ "x${OVJ_LOG}" = "x" ] ; then
       $OVJ_VECHO "Downloading file 1 of 7"
-      wget https://www.ibbr.umd.edu/nmrpipe/install.com
+      wget -nv --show-progress https://www.ibbr.umd.edu/nmrpipe/install.com
       $OVJ_VECHO "Downloading file 2 of 7"
-      wget https://www.ibbr.umd.edu/nmrpipe/binval.com
+      wget -nv --show-progress https://www.ibbr.umd.edu/nmrpipe/binval.com
       $OVJ_VECHO "Downloading file 3 of 7"
-      wget https://www.ibbr.umd.edu/nmrpipe/NMRPipeX.tZ
+      wget -nv --show-progress https://www.ibbr.umd.edu/nmrpipe/NMRPipeX.tZ
       $OVJ_VECHO "Downloading file 4 of 7"
-      wget https://www.ibbr.umd.edu/nmrpipe/s.tZ
+      wget -nv --show-progress https://www.ibbr.umd.edu/nmrpipe/s.tZ
       $OVJ_VECHO "Downloading file 5 of 7"
-      wget https://www.ibbr.umd.edu/nmrpipe/dyn.tZ
+      wget -nv --show-progress https://www.ibbr.umd.edu/nmrpipe/dyn.tZ
       $OVJ_VECHO "Downloading file 6 of 7"
-      wget https://spin.niddk.nih.gov/bax/software/talos_nmrPipe.tZ
+      wget -nv --show-progress https://spin.niddk.nih.gov/bax/software/talos_nmrPipe.tZ
       $OVJ_VECHO "Downloading file 7 of 7"
-      wget https://spin.niddk.nih.gov/bax/software/smile/plugin.smile.tZ
+      wget -nv --show-progress https://spin.niddk.nih.gov/bax/software/smile/plugin.smile.tZ
    else
       $OVJ_VECHO "Downloading file 1 of 7"
       echo "Downloading file 1 of 7 (install.com)" >> ${OVJ_LOG}
@@ -265,8 +265,32 @@ if [ ! -d "/vnmr/nmrpipetmp" ]; then
    echo "Rerun as OpenVnmrJ system administrator (vnmr1)."
    return 1
 fi
-date=`date +%Y_%m_%d.%H:%M`
+date=$(date +%Y_%m_%d.%H:%M)
 if [ -d /vnmr/nmrpipe ]; then
+   if [[ "x${OVJ_INSTALL}" = "x" ]] &&
+      [[ -f  /vnmr/nmrpipe/README_NMRPIPE_USERS ]]; then
+      ver=$(grep "NMRPipe Version" /vnmr/nmrpipe/README_NMRPIPE_USERS | xargs)
+      if [[ ! -z $ver ]]; then
+         cd nmrpipe
+         if [ x$(uname -s) = "xDarwin" ]; then
+            curl -O https://www.ibbr.umd.edu/nmrpipe/version.txt
+         elif [ x$(uname -s) = "xLinux" ]; then
+            wget -nv --show-progress https://www.ibbr.umd.edu/nmrpipe/version.txt
+         fi
+         if [[ -f version.txt ]]; then
+             newVer=$(cat version.txt)
+         fi
+         if [[ $ver = $newVer ]]; then
+            echo ""
+            cat version.txt
+            $OVJ_VECHO "NMRPipe is already up-to-date"
+            rm version.txt
+            rmdir /vnmr/nmrpipetmp
+            exit
+         fi
+         cd /vnmr/
+      fi
+   fi
    $OVJ_VECHO "Saving current NMRPipe as NMRPipe_${date}"
    mv nmrpipe nmrpipe_${date}
 fi

--- a/src/scripts/upgrade.nmr.sh
+++ b/src/scripts/upgrade.nmr.sh
@@ -256,6 +256,7 @@ doUpgrade () {
         code/tarfiles/devicetable.tar
         code/tarfiles/pgsql.tar
         code/tarfiles/jre.tar
+        code/tarfiles/fidlib.tar
         code/tarfiles/spinapi.tar
         )
     ignoreFiles="

--- a/src/scripts/vnmrsetup.sh
+++ b/src/scripts/vnmrsetup.sh
@@ -632,29 +632,31 @@ if [ -e /tmp/.ovj_installed ]; then
       echo " "
    fi
 
-   echo " "
-   echo "The VnmrJ 4.2 fidlib can be installed."
-   echo "Depending on network speed, it can take from"
-   echo "5 to 35 minutes."
-   echo "Would you like to install it now? (y/n) "
-   read ans
-   if [ "x$ans" = "xy" -o "x$ans" = "xY" ] ; then
-      echo "Installing VnmrJ fidlib" >> $insLog
-      if [ x$distroType = "xdebian" ]; then
-         sudo -i -u $nmr_user /vnmr/bin/ovjGetFidlib
+   if  [[ ! -d /vnmr/fidlib/Ethylindanone ]]; then
+      echo " "
+      echo "The VnmrJ 4.2 fidlib can be installed."
+      echo "Depending on network speed, it can take from"
+      echo "5 to 35 minutes."
+      echo "Would you like to install it now? (y/n) "
+      read ans
+      if [ "x$ans" = "xy" -o "x$ans" = "xY" ] ; then
+         echo "Installing VnmrJ fidlib" >> $insLog
+         if [ x$distroType = "xdebian" ]; then
+            sudo -i -u $nmr_user /vnmr/bin/ovjGetFidlib
+         else
+            su - $nmr_user -c "/vnmr/bin/ovjGetFidlib"
+         fi
+         echo " "
       else
-         su - $nmr_user -c "/vnmr/bin/ovjGetFidlib"
+         echo "The VnmrJ fidlib may be installed at any time by running"
+         echo "/vnmr/bin/ovjGetFidlib"
       fi
       echo " "
-   else
-      echo "The VnmrJ fidlib may be installed at any time by running"
-      echo "/vnmr/bin/ovjGetFidlib"
+      echo "To see all the fidlib installation options, such as installing"
+      echo "the it without network access, use"
+      echo "/vnmr/bin/ovjGetFidlib -h"
+      echo " "
    fi
-   echo " "
-   echo "To see all the fidlib installation options, such as installing"
-   echo "the it without network access, use"
-   echo "/vnmr/bin/ovjGetFidlib -h"
-   echo " "
 
    echo "Shall this system be configured as a spectrometer."
    if [ -d /vnmr/acq/download ] || [ -d /vnmr/acq/vxBoot ]


### PR DESCRIPTION
Only ask about ovjGetFidlib if fidlib was not available from the
previous /vnmr. upgrade.nmr does not replace fidlib. ovjGetpipe
will check current version before downloading.