### PR TITLE
Remote status unit does not work with python3

### DIFF
--- a/src/scripts/rsu_bt_setup.sh
+++ b/src/scripts/rsu_bt_setup.sh
@@ -5,6 +5,17 @@
 #-----------------------------------------------------------------
 # make sure no VnmrJ is running
 #
+
+#if python does not exist, exit
+if [[ -z $(type -t python) ]]; then
+   exit 0
+fi
+
+#if /vnmr/web does not exist, exit
+if [[ ! -d /vnmr/web ]]; then
+   exit 0
+fi
+
 findacqproc="ps -e  | grep Vnmr | awk '{ printf(\"%d \",\$1) }'"
 npids=`eval $findacqproc`
 if (test x"$npids" != "x" )

--- a/src/scripts/upgrade.nmr.sh
+++ b/src/scripts/upgrade.nmr.sh
@@ -256,6 +256,7 @@ doUpgrade () {
         code/tarfiles/devicetable.tar
         code/tarfiles/pgsql.tar
         code/tarfiles/jre.tar
+        code/tarfiles/fidlib.tar
         code/tarfiles/spinapi.tar
         )
     ignoreFiles="
@@ -470,8 +471,16 @@ if [[ $(stat -c %a "$vnmrsystem"/bin/execkillacqproc) -eq 500 ]]; then
     doAcq=1
 fi
 
+noWeb=0
+if [[ ! -d /vnmr/web ]]; then
+   noWeb=1
+fi
+
 doUpgrade
 
+if [[ $noWeb -eq 1  ]]; then
+    rm -rf $vnmrsystem/web
+fi
 if [[ $doAcq -eq 0 ]]; then
     if [[ -f $upgrade_save_dir/bin/sudoins ]]; then
         doAcq=1

--- a/src/scripts/vnmrsetup.sh
+++ b/src/scripts/vnmrsetup.sh
@@ -515,7 +515,7 @@ if [ -e /tmp/vskippkgchk ]; then
    rm -f /tmp/vskippkgchk
 fi
 
-if ! hash python 2> /dev/null; then
+if [[ -z $(type -t python) ]]; then
    if [ -d /vnmr/web ]; then
       mv /vnmr/web /vnmr/web_off
    fi
@@ -632,29 +632,31 @@ if [ -e /tmp/.ovj_installed ]; then
       echo " "
    fi
 
-   echo " "
-   echo "The VnmrJ 4.2 fidlib can be installed."
-   echo "Depending on network speed, it can take from"
-   echo "5 to 35 minutes."
-   echo "Would you like to install it now? (y/n) "
-   read ans
-   if [ "x$ans" = "xy" -o "x$ans" = "xY" ] ; then
-      echo "Installing VnmrJ fidlib" >> $insLog
-      if [ x$distroType = "xdebian" ]; then
-         sudo -i -u $nmr_user /vnmr/bin/ovjGetFidlib
+   if  [[ ! -d /vnmr/fidlib/Ethylindanone ]]; then
+      echo " "
+      echo "The VnmrJ 4.2 fidlib can be installed."
+      echo "Depending on network speed, it can take from"
+      echo "5 to 35 minutes."
+      echo "Would you like to install it now? (y/n) "
+      read ans
+      if [ "x$ans" = "xy" -o "x$ans" = "xY" ] ; then
+         echo "Installing VnmrJ fidlib" >> $insLog
+         if [ x$distroType = "xdebian" ]; then
+            sudo -i -u $nmr_user /vnmr/bin/ovjGetFidlib
+         else
+            su - $nmr_user -c "/vnmr/bin/ovjGetFidlib"
+         fi
+         echo " "
       else
-         su - $nmr_user -c "/vnmr/bin/ovjGetFidlib"
+         echo "The VnmrJ fidlib may be installed at any time by running"
+         echo "/vnmr/bin/ovjGetFidlib"
       fi
       echo " "
-   else
-      echo "The VnmrJ fidlib may be installed at any time by running"
-      echo "/vnmr/bin/ovjGetFidlib"
+      echo "To see all the fidlib installation options, such as installing"
+      echo "the it without network access, use"
+      echo "/vnmr/bin/ovjGetFidlib -h"
+      echo " "
    fi
-   echo " "
-   echo "To see all the fidlib installation options, such as installing"
-   echo "the it without network access, use"
-   echo "/vnmr/bin/ovjGetFidlib -h"
-   echo " "
 
    echo "Shall this system be configured as a spectrometer."
    if [ -d /vnmr/acq/download ] || [ -d /vnmr/acq/vxBoot ]


### PR DESCRIPTION
Fixed rsu_bt_setup to check for python(2) and /vnmr/web
upgrade.nmr will not add /vnmr/web if it is not already present