### PR TITLE
added tools needed to fix Study Queue bug

### DIFF
--- a/src/common/manual/ovjCount
+++ b/src/common/manual/ovjCount
@@ -1,0 +1,17 @@
+*******************************************************************************
+ovjCount:$i - return an incrementing integer to calling macro
+ovjCount(max):$i -return an incrementing integer less than max
+*******************************************************************************
+
+On each call to ovjCount, it returns an integer one greater than the previous
+call. The return values start at 1.
+If an argument is passed, as in ovjCount(10), then the returned integer will be
+less than the passed argument. For ovjCount(10), the returned values will cycle
+from 1 to 9.
+
+This can be used to construct unique file names where the returned value is used
+as a version number.
+
+$rev=''
+ovjCount(10):$rev
+$filename=$filename+$rev

--- a/src/vnmr/builtin.c
+++ b/src/vnmr/builtin.c
@@ -127,6 +127,19 @@ void clearRets(int retc, char *retv[])
         retv[i] = NULL;
 }
 
+int ovjCount(int argc, char *argv[], int retc, char *retv[])
+{
+    static int count = 0;
+    count++;
+    if ( (argc > 1) && (count >= atoi(argv[1])) )
+       count = 1;
+    if (retc)
+       retv[0] = intString( count );
+    else
+       Winfoprintf("ovjCount = %d",count);
+    RETURN;
+}
+
 /*-----------------------------------------------------------------------
 |
 |       beeper

--- a/src/vnmr/table.c
+++ b/src/vnmr/table.c
@@ -355,6 +355,7 @@ extern int writespectrum();
 extern int Off();
 extern int onCancel(int argc, char *argv[], int retc, char *retv[]);
 extern int output_sdf();			/* ImageBrowser */
+extern int ovjCount(int argc, char *argv[], int retc, char *retv[]);
 extern int p11_action();
 extern int p11_switchOpt();
 extern int page();
@@ -935,6 +936,7 @@ static cmd_t vnmr_table[] = {
 	{"off"        , Off,		NO_REEXEC, 0},
 	{"on"         , Off,		NO_REEXEC, 0},
         {"onCancel"   , onCancel,       NO_REEXEC, 0},
+        {"ovjCount"   , ovjCount,       NO_REEXEC, 0},
 	{"p1"         , ernst,		NO_REEXEC, 0},
         {"p11_switchOpt"  , p11_switchOpt, NO_REEXEC, 0},
         {"p11_action" , p11_action,     NO_REEXEC, 0},

--- a/src/vnmrj/src/vnmr/ui/StudyQueue.java
+++ b/src/vnmrj/src/vnmr/ui/StudyQueue.java
@@ -503,6 +503,7 @@ public class StudyQueue implements VObjDef
                 }
                 mgr.newTree(path);
 		// set sqdirs[jviewport]=path
+		path = tok.nextToken().trim();
 		sendSQpath(path);
                 fp.delete();
             }


### PR DESCRIPTION
There is a race between java building the SQ from an study.xml
file and Vnmrbg constructing another study.xml based on a change
from an automation run. This results in a SAX parse error.
Added tools that will be used to fix this long-standing bug. One tool,
ovjCount is documented. The fix is to make a copy of the study.xml
and have java read and delete the copy.