### PR TITLE
rois not displayed when Vnmrbg compiled on CentOS 7

### DIFF
--- a/src/Asp/AspMouse.C
+++ b/src/Asp/AspMouse.C
@@ -823,7 +823,7 @@ void AspMouse::event(int x, int y, int button, int mask, int dummy) {
         case b1+ctrl+drag:
         case b1+shift+drag:
         case b1+ctrl+shift+drag:
-	    if(roi != nullAspRoi) {
+	    if( (state == modifyBand) && (roi != nullAspRoi)) {
 	        if(creating) frame->selectRoiHandle(roi,x,y,!((mask & shift) || (mask & ctrl)));
 	        creating=false;
 		frame->modifyRoi(roi,x,y);
@@ -838,10 +838,15 @@ void AspMouse::event(int x, int y, int button, int mask, int dummy) {
 	    }
             break;
         case b1+up:
-	    if(roi != nullAspRoi && frame->getRoiList()->autoAdjusting) {
+	    if( (state == modifyBand) && roi != nullAspRoi &&
+               frame->getRoiList()->autoAdjusting) {
 	       frame->getRoiList()->autoAdjust(roi);
 	    }
-            if(roi != nullAspRoi) roi->selected=false;
+            if((state == modifyBand) && roi != nullAspRoi)
+            {
+                roi->selected=false;
+		frame->unselectRois();
+            }
             if(anno != NULL) {
 		anno->selected=0;
 		anno->selectedHandle=0;
@@ -856,7 +861,8 @@ void AspMouse::event(int x, int y, int button, int mask, int dummy) {
         case b1+shift+up:
         case b1+ctrl+shift+up:
 	{
-	    if(roi != nullAspRoi && frame->getRoiList()->autoAdjusting) {
+	    if( (state == modifyBand) && roi != nullAspRoi &&
+                 frame->getRoiList()->autoAdjusting) {
 	       frame->getRoiList()->autoAdjust(roi);
 	    }
             if(roi != nullAspRoi) roi->selected=false;

--- a/src/vnmrbg/SConstruct
+++ b/src/vnmrbg/SConstruct
@@ -655,6 +655,11 @@ vnmrBgCppEnv = vnmrBgCEnv.Clone(CC         = 'g++',
 # This will define boost for MacOS and Ubuntu
 if not os.path.exists("/etc/redhat-release"):
     vnmrBgCppEnv.Append(CPPDEFINES = 'boost=std')
+else:
+# This is for CentOS 7
+    if os.path.exists("/usr/bin/systemctl"):
+        vnmrBgCppEnv.Append(CCFLAGS = ' -std=c++11 ')
+        vnmrBgCppEnv.Append(CPPDEFINES = 'boost=std')
 
 if (opensource=="true"):
     if (gplsource=="true"):


### PR DESCRIPTION
The shared_ptr function was broken. CentOS 7 compile now uses
same shared_ptr as MacOS and Ubuntu. If Annos were selected after
rois had been draw, the rois were updated, not the annos. On b1+up,
rois outlines changed to unselected.