### PR TITLE
seqgen on Ubuntu failed

### DIFF
--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -724,6 +724,8 @@ else
    # these are needed to build
     installList='gdm3
                  gnome-session
+                 gcc-multilib
+                 g++-multilib
                  openjdk-8-jre
                  lib32stdc++-8-dev
                  libc6-dev

--- a/src/scripts/vnmrsetup.sh
+++ b/src/scripts/vnmrsetup.sh
@@ -354,6 +354,12 @@ if [ "x$distroType" = "xrhel" -o "x$distroType" = "xdebian" ]; then
   fi
 fi
 
+if [[ -z $(type -t java) ]] ; then
+   echo "java program not installed"
+   echo "Likely failure with the package installation"
+   echo "Please try again in 5-10 minutes"
+   exit 1
+fi
 # remove reboot flag for SELinux disabling
 rm -f /tmp/reboot
 


### PR DESCRIPTION
missing gcc-multilib and g++-multilib packages were missing
Also, load.nmr gives a nicer message if java failed to install