### PR TITLE
Fixed use of substr

### DIFF
--- a/src/common/maclib/plotside
+++ b/src/common/maclib/plotside
@@ -52,7 +52,7 @@ else
     if ($1 <> 'proj') then jexp:$curexp endif
     if ($1 <> 'proj' and $sub1d <> 'exp') then
         $ext=''
-	substr($1,'basename'):$fidname,$ext
+        substr($1,'basename','.fid .rec .REC'):$fidname,$ext
 	if ($ext<>'') then
 	    exists($1,'directory'):$fidex
 	else

--- a/src/common/maclib/plottop
+++ b/src/common/maclib/plottop
@@ -51,7 +51,7 @@ else
     if ($1 <> 'proj') then jexp:$curexp endif
     if ($1 <> 'proj' and $sub1d <> 'exp') then
         $ext=''
-        substr($1,'basename'):$fidname,$ext
+        substr($1,'basename','.fid .rec .REC'):$fidname,$ext
         if ($ext<>'') then
             exists($1,'directory'):$fidex
         else

--- a/src/common/maclib/xmhaha_select
+++ b/src/common/maclib/xmhaha_select
@@ -48,8 +48,8 @@ if ($status='Completed') then
    $fc='' substr($data,1,1):$fc
    if ($fc<>'/') then $data=userdir+'/data/'+$data endif
 
-   $e=''
-   substr($data,'dirname'):$d,$b,$e
+   $d='' $b='' $e=''
+   substr($data,'dirname','.fid .REC .rec .vfs'):$d,$b,$e
    $data=$d+'/'+$b
    if $e='' then
 	$e='fid'


### PR DESCRIPTION
File names like 1.restOfName were failing with 'dirname' and 'basename'
because the characters after the dot were being treated like the
extension rather than the file name. The dirname was being returned
as a real because the returned value was not initialized as a string.