### PR TITLE
The HOME env was being set to /root in automation

### DIFF
--- a/src/scripts/ovjProcs.sh
+++ b/src/scripts/ovjProcs.sh
@@ -65,8 +65,9 @@ startProcs() {
    LOGNAME=root ;               			\
    NESSIE_CONSOLE=inova;				\
    NIRVANA_CONSOLE=wormhole;				\
+   HOME=$vnmrsystem/bin;                                \
    PATH="$PATH:$vnmrsystem/bin:" ;    			\
-   export TERM TERMCAP LOGNAME TCL_LIBRARY NESSIE_CONSOLE NIRVANA_CONSOLE PATH vnmrsystem; \
+   export TERM TERMCAP LOGNAME TCL_LIBRARY NESSIE_CONSOLE NIRVANA_CONSOLE PATH HOME vnmrsystem; \
    ./Expproc )
 }
 


### PR DESCRIPTION
This is because acqcomm, which uses sudo, sets HOME to the home
directory of the user root (/root) in /etc/passwd. The older "su acqproc"
set HOME to the home directory of the user acqproc (/vnmr/bin) in /etc/passwd.
ovjProcs now overrides the default setting with /vnmr/bin.