### PR TITLE
Newer linkers have different rules for rpath

### DIFF
--- a/src/psg/SConstruct
+++ b/src/psg/SConstruct
@@ -257,7 +257,7 @@ psgLibList = psgList + cndPsgList
 s2pulList  = psgSeqFileList
 
 # library lists
-libLists = ['acqcomm', 'm']
+libLists = ['m']
 
 # actual builds
 paramStatic = env.StaticLibrary(target  = paramStaticTarget,


### PR DESCRIPTION
shared libraries linked from other shared libraries
do not use rpath. This is the case for Ubuntu 20.
Inova's libpsglib.so and libparam.so were linking libacqcomm.so,
which was not found.