### PR TITLE
Auto Plot Preview caused OVJ crash

### DIFF
--- a/src/common/maclib/pageview
+++ b/src/common/maclib/pageview
@@ -189,7 +189,7 @@ if ($1='review') then
 
   delete($tmpplot,''):$dum
   delete($tmpplot+'.pdf',''):$dum
-  page($tmpplot):$dum
+  plotpage($tmpplot):$dum
  
   copyf($tmpplot,'sed g','Plotname: --Not assigned--','',$tmpplot+'2'):$dum
  


### PR DESCRIPTION
Bug reported in SpinSights. Button calls pageview('auto')
which calls docpplot which does a macrold of page with the line
pageview. docpplot than calls plot which eventually calls page.
This calls the cached page which calls pageview. At line 192, pageview
called page, which called pageview, which at line 192 called page,
which called pageview, etc, etc.