### PR TITLE
Bug fix: full failed if called from background

### DIFF
--- a/src/common/manual/center
+++ b/src/common/manual/center
@@ -3,10 +3,14 @@
 center	-	Set Display Limits for Center of Screen
 left	-	Set Display Limits for Left Half of Screen
 right	-	Set Display Limits for Right Half of Screen
-full	-	Set Display Limits for Full Screen
+full<('1d'|'2d')> -	Set Display Limits for Full Screen
 fullt	-	Set Display Limits for Full Screen with room for traces (dconi)
 *******************************************************************************
 
   All these commands set the horizontal control parameters "sc" and "wc"
   accordingly. "full", "fullt" and "center" also set the vertical control
   parameters "sc2" and "wc2". For 2D data, space is left for the scales.
+  Whether a dataset is 1D or 2D is determined by the 'procdim' parameter
+  or the 'nD' or 'ni' parameters. The automatic determination of whether
+  a dataset is 1D or 2D can be overridden by using full('1d'), which forces
+  1D behavior, or full('2d'), which forces 2D behavior.

--- a/src/vnmr/full.c
+++ b/src/vnmr/full.c
@@ -161,8 +161,17 @@ int setFullChart(int d2flag) {
     { P_err(r,"current ","wc2:"); return 1; }
 
       if ( d2flag ) { 
-  	  double xband = 9*xcharpixels/((double)(mnumxpnts-right_edge) / wcmax);
-	  double yband = 3*ycharpixels/((double)(mnumypnts-ymin) / wc2max); 
+  	  double xband;
+	  double yband; 
+          if ( ((mnumxpnts-right_edge) < 5) || ((mnumypnts-ymin) < 5) )
+          {
+             yband = xband = wcmax / 10.0;
+          }
+          else
+          {
+  	     xband = 9*xcharpixels/((double)(mnumxpnts-right_edge) / wcmax);
+	     yband = 3*ycharpixels/((double)(mnumypnts-ymin) / wc2max); 
+          }
 	  wc  = wcmax - xband;
 	  sc  = 0;
           wc2 = wc2max - yband;
@@ -269,6 +278,13 @@ int full(int argc, char *argv[], int retc, char *retv[])
 
   if (strcmp(argv[0],"full")==0) 
     {
+        if (argc > 1)
+        {
+           if ( !strcasecmp(argv[1],"1d") )
+              d2flag = 0;
+           else if ( !strcasecmp(argv[1],"2d") )
+              d2flag = 1;
+        }
 	setFullChart(d2flag && (!dsflag));
   	appendvarlist("sc,wc,sc2,wc2");
 	RETURN;


### PR DESCRIPTION
wc and wc2 were set to -inf due to division by 0.
Also added '1d' and '2d' options for full to force '1d' or
'2d' chart determination behavior.