### PR TITLE
spaces now allowed in file names

### DIFF
--- a/src/vnmr/shellcmds.c
+++ b/src/vnmr/shellcmds.c
@@ -886,9 +886,10 @@ int Cp(int argc, char *argv[], int retc, char *retv[])
     strcpy(cmdstr,"/bin/cp ");
     for (i=1; i<argc; i++)
     {
-	strncat(cmdstr," ",MAXSHSTRING - strlen(cmdstr) -1);
+	strncat(cmdstr," '",MAXSHSTRING - strlen(cmdstr) -1);
 	len = MAXSHSTRING - strlen(cmdstr) -1;
 	strncat(cmdstr,argv[i],len);
+	strncat(cmdstr,"'",len);
     }
     
     TPRINT1("cp: command string \"%s\"\n",cmdstr);

--- a/src/vnmr/tools.c
+++ b/src/vnmr/tools.c
@@ -523,7 +523,7 @@ char *check_spaces(char *inptr, char *outptr, int maxlen )
 /************************************************************************/
 /*  The routine "verify_fname" was written to help fix a problem
     where the 'svf' command would create file names with obscure
-    characters, such as ' ', causing problems with UNIX.
+    characters
 
     If the argument contains a character listed in the table or
     is a control character (ADE < 32), the routine returns -1;
@@ -531,7 +531,6 @@ char *check_spaces(char *inptr, char *outptr, int maxlen )
 
     Each character in the table below is disallowed for one of
     the following reasons:
-	It leads to inconvenient file names, e. g. ' '
 	The shell uses the character for its own reasons, e. g. '<', '|'
 	The character is a quotation character - ', ", `
 	The file-name interpreter uses the character, e. g. '*', '?', '~'
@@ -539,25 +538,9 @@ char *check_spaces(char *inptr, char *outptr, int maxlen )
     The NUL character serves to terminate this table.			*/
 /************************************************************************/
 
-#if defined(__INTERIX) || defined(MACOS)
-/*  Space character allowed for Interix or MACOS */
 static char illegal_fchars[] = {
 	     '!', '"', '$', '&', '\'', '(', ')', '*', ';', '<', '>', '?',
 	'\\', '[', ']', '^', '`', '{', '}', '|', ',', '\0' };
-#else
-static char illegal_fchars[] = {
-	' ', '!', '"', '$', '&', '\'', '(', ')', '*', ';', '<', '>', '?',
-	'\\', '[', ']', '^', '`', '{', '}', '|', ',', '\0' };
-#endif 
-
-/*  Separate version required for VMS.  Remove '[', ']'; add '%'.  */
-
-#ifdef VMS
-static char illegal_fchars[] = {
-	' ', '!', '"', '$', '&', '\'', '(', ')', '*', '<', '>', '?',
-	'\\', '^', '`', '{', '}', '|', '%', '\0'
-};
-#endif 
 
 /*  Returns 0 is supplied character is valid for a file name
  *  returns -1 if supplied character is not valid for a file name


### PR DESCRIPTION
This has been the case for the MacOS version for several years.
cp('-r',file1,file2) would fail if file1 had spaces in its name.
The partially fix issue #657