### PR TITLE
Converted vnmrauto from a csh to a bash script

### DIFF
--- a/src/scripts/vnmrauto.sh
+++ b/src/scripts/vnmrauto.sh
@@ -1,5 +1,5 @@
-#! /bin/csh
+#!/bin/bash
 # Script used to run background automation. Called from Autoproc.
 
-source $HOME/.vnmrenv
+source $HOME/.vnmrenvsh
 Vnmrbg -mauto -hAutoproc -n1 -i42 -u$vnmruser autoqstart


### PR DESCRIPTION
Removing .vnmrenv to fix the problem with NMRPipe and
IST, issue #657, caused automation to fail since it relied
on .vnmrenv. It now uses .vnmrenvsh