### PR TITLE
MacOS version was getting the wrong envirnmental parameters

### DIFF
--- a/src/macos/VJ.sh
+++ b/src/macos/VJ.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd
+/bin/bash -l -c /vnmr/bin/vnmrj

--- a/src/scripts/ovjmacout.sh
+++ b/src/scripts/ovjmacout.sh
@@ -38,10 +38,11 @@ mkdir "${resdir}"
 
 cd "${gitdir}/src/macos"
 cp -r VnmrJ.app "${packagedir}/$ovjAppName"
-rm -f VJ
-cc -Os $osxflags -arch x86_64 VJ.c -o VJ
+# rm -f VJ
+# cc -Os $osxflags -arch x86_64 VJ.c -o VJ
 mkdir -p "${packagedir}/$ovjAppName/Contents/MacOS"
-cp VJ "${packagedir}/$ovjAppName/Contents/MacOS/."
+cp VJ.sh "${packagedir}/$ovjAppName/Contents/MacOS/VJ"
+chmod 755 "${packagedir}/$ovjAppName/Contents/MacOS/VJ"
 rm -f "${vnmrdir}/bin/convert"
 rm -f "${vnmrdir}/bin/Infostat"
 tar jxf ImageMagick.tar.bz2 -C $vnmrdir


### PR DESCRIPTION
This only happened if it was started from the Dock or Spotlight.
Any local startup resources (.profile) were not being called.
This partially fixes issue #657