### PR TITLE
getparam could fail

### DIFF
--- a/src/common/maclib/getparam
+++ b/src/common/maclib/getparam
@@ -11,9 +11,9 @@ endif
 
 if system<>'spectrometer' then
     if ($#<3 and probe='') then 
-	return 
-    else
-	if $3='' then return endif
+	  return 
+    elseif ($#>=3) then 
+	  if $3='' then return endif
     endif
 endif
 


### PR DESCRIPTION
If called with system='datastation' and not called with three
arguments, it would abort. Bug reported in SpinSights