### PR TITLE
Remove confusing error messages when testing for a parfile

### DIFF
--- a/src/vnmr/jexp.c
+++ b/src/vnmr/jexp.c
@@ -3863,7 +3863,7 @@ int exists(int argc, char *argv[], int retc, char *retv[])
          if (is_parfile)
             Winfoprintf("%s is a parameter file",argv[1]);
          else
-            Winfoprintf("%s is not an parameter file",argv[1]);
+            Winfoprintf("%s is not a parameter file",argv[1]);
       }
       else
          retv[0] = realString((double)is_parfile);

--- a/src/vnmr/pvars.c
+++ b/src/vnmr/pvars.c
@@ -2583,7 +2583,7 @@ static int readParsFromDisk(FILE *stream)
 		/*  Read values */
 		for (i=1; i<num+1; i++)
 		{   if (rscanf(stream,buf,1024)<0)
-		    {	Werrprintf("P_ispar: premature EOF\n");
+		    {	// Werrprintf("P_ispar: premature EOF\n");
 			return(0);
 		    }
 		}
@@ -2593,13 +2593,12 @@ static int readParsFromDisk(FILE *stream)
 		TPRINT1(2,"P_ispar: num of enums =%d\n",num);
 		for (i=1; i<num+1; i++)
 		{   if (rscanf(stream,buf,1024)<0)
-		    {	Werrprintf("readNamesFromDisk: premature EOF\n");
+		    {	// Werrprintf("readNamesFromDisk: premature EOF\n");
 			return(0);
 		    }
 		}
 		break;
 	  default:
-		Werrprintf("P_ispar: %s has nonexistent type\n", name);
 		return(0);
 	}
     }


### PR DESCRIPTION
using exists('filename','parfile')