### PR TITLE
Improved interactive creation of box and oval annotations

### DIFF
--- a/src/Asp/AspAnno.C
+++ b/src/Asp/AspAnno.C
@@ -394,6 +394,30 @@ int AspAnno::selectLabel(int x, int y) {
    return selected;
 }
 
+void AspAnno::check(spAspCell_t cell) {
+   if(npts<1) return;
+   double tmp;
+   if (sCoord[1].x > sCoord[0].x )
+   {
+      tmp = sCoord[0].x;
+      sCoord[0].x = sCoord[1].x;
+      sCoord[1].x = tmp;
+      tmp = pCoord[0].x;
+      pCoord[0].x = pCoord[1].x;
+      pCoord[1].x = tmp;
+   }
+   if (sCoord[1].y < sCoord[0].y )
+   {
+      tmp = sCoord[0].y;
+      sCoord[0].y = sCoord[1].y;
+      sCoord[1].y = tmp;
+      tmp = pCoord[0].y;
+      pCoord[0].y = pCoord[1].y;
+      pCoord[1].y = tmp;
+   }
+
+}
+
 void AspAnno::modify(spAspCell_t cell, int x, int y, int prevX, int prevY) {
 
    if(npts<1) return;

--- a/src/Asp/AspAnno.h
+++ b/src/Asp/AspAnno.h
@@ -103,6 +103,7 @@ public:
 
     virtual string toString();
 
+    virtual void check(spAspCell_t cell);
     virtual void modify(spAspCell_t cell, int x, int y, int prevX, int prevY);
     virtual void modifyTR(spAspCell_t cell, int x, int y, int prevX, int prevY, bool trCase=false);
     virtual void display(spAspCell_t cell, spAspDataInfo_t dataInfo);

--- a/src/Asp/AspBox.C
+++ b/src/Asp/AspBox.C
@@ -48,9 +48,19 @@ void AspBox::display(spAspCell_t cell, spAspDataInfo_t dataInfo) {
    roiX=roiY=roiW=roiH=0;
    if(disFlag & ANN_SHOW_ROI) {
      roiX=(int)pCoord[0].x;
-     roiY=(int)pCoord[0].y;
      roiW=(int)pCoord[1].x-roiX;
+     if (roiW < 0)
+     {
+       roiX=(int)pCoord[1].x;
+       roiW=(int)pCoord[0].x-roiX;
+     }
+     roiY=(int)pCoord[0].y;
      roiH=(int)pCoord[1].y-roiY;
+     if (roiH < 0)
+     {
+       roiY=(int)pCoord[1].y;
+       roiH=(int)pCoord[0].y-roiY;
+     }
      if(created_type == ANNO_OVAL)
 	draw_oval(roiX,roiY,roiX+roiW,roiY+roiH,0,roiColor,fillRoi);
      else if(roundBox)

--- a/src/Asp/AspDisAnno.C
+++ b/src/Asp/AspDisAnno.C
@@ -614,6 +614,18 @@ void AspDisAnno::modifyAnno(spAspFrame_t frame, AspAnno *anno, int x, int y,
    frame->displayTop();
 }
 
+void AspDisAnno::checkAnno(spAspFrame_t frame, AspAnno *anno, int x, int y)
+{
+   if(anno == NULL) return;
+   if(frame == nullAspFrame) return;
+   spAspCell_t cell =  frame->selectCell(x,y);
+
+   if(cell == nullAspCell) return;
+
+   anno->check(cell); 
+   frame->displayTop();
+}
+
 void AspDisAnno::deleteAnno(spAspFrame_t frame, AspAnno *anno) {
    AspAnnoList *annoList = frame->getAnnoList();
    if(annoList == NULL) return;

--- a/src/Asp/AspDisAnno.h
+++ b/src/Asp/AspDisAnno.h
@@ -27,6 +27,7 @@ public:
 
     static AspAnno *createAnno(spAspFrame_t frame, int x, int y, AnnoType_t type,
                                bool trCase=false);
+    static void checkAnno(spAspFrame_t frame, AspAnno *anno, int x, int y);
     static void modifyAnno(spAspFrame_t frame, AspAnno *anno, int x, int y, int prevX, int prevY,
                            bool trCase = false);
     static void addPoint(spAspFrame_t frame, AspAnno *anno, int x, int y, bool insert=false);

--- a/src/Asp/AspMouse.C
+++ b/src/Asp/AspMouse.C
@@ -848,6 +848,12 @@ void AspMouse::event(int x, int y, int button, int mask, int dummy) {
 		frame->unselectRois();
             }
             if(anno != NULL) {
+                if ((state == modifyBox) ||
+                     (state == modifyOval) )
+                {
+		   AspDisAnno::checkAnno(frame, anno, x, y);
+                }
+         
 		anno->selected=0;
 		anno->selectedHandle=0;
            	sprintf(cmd,"aspCmd('annoModified',%d,%d,%d)\n",anno->index,x,y);


### PR DESCRIPTION
One can now create them by dragging the mouse left or right
and up or down. It used to only work for dragging right and down.