### PR TITLE
Deleting annotations caused core dump

### DIFF
--- a/src/Asp/AspAnnoList.C
+++ b/src/Asp/AspAnnoList.C
@@ -89,6 +89,7 @@ void AspAnnoList::deleteAnno() {
    for (itr = annoMap->begin(); itr != annoMap->end(); ++itr) {
         if(itr->second->selected != 0) {
 	  annoMap->erase(itr->first);
+	  break;
 	}
    }
    int inx=0;


### PR DESCRIPTION
This only appears to be a problem when compiling
with newer gcc compilers