### PR TITLE
reconcileQ failed with EXPLIST and LONGLIST errors

### DIFF
--- a/src/common/maclib/cpautoQ
+++ b/src/common/maclib/cpautoQ
@@ -93,6 +93,8 @@ endif
   endif
 
   $maclibdir=archivedir+'/'+sample+'/dirinfo/macdir'
+  pwd:$curdir
+  cd($maclibdir):$str
 
   touch($maclibdir+'/EXPLIST'):$dum
   touch($maclibdir+'/LONGLIST'):$dum
@@ -104,6 +106,7 @@ endif
   else
 	append($lngfile,'awk','$1 $3',$maclibdir+'/EXPalias')
   endif
+  cd($curdir):$str
 
     rename($expfile,$md+'/EXPLIST'):$dum
     rename($lngfile,$md+'/LONGLIST'):$dum


### PR DESCRIPTION
reconcileQ expects to be in the correct directory.
In PR #620, the section of cpautoQ that put it in the
correct directory for reconcileQ was removed. It is
now replaced.