### PR TITLE
Removed debug message about failing to load study

### DIFF
--- a/src/vnmrj/src/vnmr/ui/StudyQueue.java
+++ b/src/vnmrj/src/vnmr/ui/StudyQueue.java
@@ -498,13 +498,13 @@ public class StudyQueue implements VObjDef
                 String path = FileUtil.openPath(fn);
                 if (path == null) {
                     fp.delete();
-                    postError("cannot load study file " + fn);
+                    setDebug("cannot load study file " + fn);
                     return;
                 }
                 mgr.newTree(path);
-		// set sqdirs[jviewport]=path
-		path = tok.nextToken().trim();
-		sendSQpath(path);
+		        // set sqdirs[jviewport]=path
+		        path = tok.nextToken().trim();
+		        sendSQpath(path);
                 fp.delete();
             }
         }


### PR DESCRIPTION
This is only for the new readDelete option. If it fails,
it is because a newer call will be comming. Can still see
the warning if the SQ debug flag is on.