### PR TITLE
xml files could leave $variables in current tree

### DIFF
--- a/src/vnmrbg/smagic.c
+++ b/src/vnmrbg/smagic.c
@@ -3404,6 +3404,27 @@ static void jShowExpression(int exnum, char *express, char *format )
 	jExpressUse = 0;
 }
 
+/* execute command jFunc 104
+ * this is to avoid creating $variables in the current tree.
+ */
+static void jExecCmd(char *incmd )
+{
+   char cmd[ 8*MAXPATH ];
+   strcpy(cmd,incmd);
+   if ( cmd[strlen(cmd)] != '\n')
+      strcat(cmd,"\n");
+   if (strstr(cmd,"$"))
+   {
+      pushTree();
+      execString( cmd );
+      popTree();
+   }
+   else
+   {
+      execString( cmd );
+   }
+}
+
 /* execute expression ($VALUE = ...) or any command */
 static void jExecExpression(char *key, char *exnum, char *express, char *format )
 {
@@ -3892,6 +3913,7 @@ int isimagebrowser(int argc, char *argv[], int retc, char *retv[])
 #define CMDLINEOK  101
 #define RETEVAL  102
 #define FVERTICAL 103
+#define JEXECCMD 104
 
 #define JGRAPH 	1
 #define VPORT 	2
@@ -4234,6 +4256,11 @@ static int jxFunc(int func, int argc, char *argv[])
                      if (argc > 3)
                         k = atoi(argv[3]);
                      set_jframe_vertical(i, k);
+		     break;
+               case JEXECCMD:  // 104x
+                     if (argc < 3)
+                        return(1);
+                     jExecCmd(argv[2]);
 		     break;
                default:
                      return (0);

--- a/src/vnmrj/src/vnmr/ui/ExpPanel.java
+++ b/src/vnmrj/src/vnmr/ui/ExpPanel.java
@@ -7204,7 +7204,24 @@ public class ExpPanel extends JPanel
         //if(outPort != null)
         //	System.out.println("lost:"+cmd);
 
-        sendToVnmr(cmd);
+        if ( !cmd.contains("$") || cmd.startsWith("jFunc") )
+        {
+           sendToVnmr(cmd);
+        }
+        else
+        {
+           StringBuffer sb = new StringBuffer().append("jFunc(104,`");
+           for (int i=0; i<cmd.length(); i++)
+           {
+              if (cmd.charAt(i) == '`') {
+                 if (i == 0 || cmd.charAt(i-1) != '\\')
+                    sb.append('\\');
+              }
+              sb.append(cmd.charAt(i));
+           }
+           sb.append("`)\n");
+           sendToVnmr(sb.toString());
+        }
     }
 
     public void setCanvasCursor(String c) {


### PR DESCRIPTION
If the Vnmr Command field (vc) of an xml file contained a $variable,
that $variable would be created in the current parameter tree.
If another xml file used the same $variable but as a different
type (string vs real), an error would occur. OVJ now wraps the command
field in a jFunc command so that the parameter stack can be handled
correctly (push and pop).