### PR TITLE
Updated ROI creation

### DIFF
--- a/src/Asp/AspRoiList.C
+++ b/src/Asp/AspRoiList.C
@@ -155,10 +155,11 @@ void AspRoiList::addRoi(spAspRoi_t roi) {
                roi->cursor1->resonances[1].freq,
                roi->cursor2->resonances[1].freq);
    } else if(rank==1) {
-       sprintf(str,"%s %.4f %.4f",
+       sprintf(str,"%s %.4f %.4f %d",
                roi->cursor1->resonances[0].name.c_str(),
                roi->cursor1->resonances[0].freq,
-               roi->cursor2->resonances[0].freq);
+               roi->cursor2->resonances[0].freq,
+               roi->height);
    }
    string key = string(str);
    roiList->erase(key);
@@ -283,7 +284,7 @@ void AspRoiList::saveRois(char *path) {
 	freq1 = itr1->second->cursor1->resonances[0].freq;
 	freq2 = itr1->second->cursor2->resonances[0].freq;
 
-	roi = getRoi(freq1,freq2);
+	roi = getRoi(freq1,freq2,itr1->second->height);
 	if(roi == nullAspRoi)
         {
            continue;
@@ -373,7 +374,10 @@ void AspRoiList::deleteSelRoi() {
    AspRoiMap::iterator ri;
    for (ri = roiList->begin();  ri != roiList->end(); ++ri) {
         if(ri->second->selected)
-	   roiList->erase(ri->first);
+        {
+	        roiList->erase(ri->first);
+           break;
+        }
    }
 }
 
@@ -710,14 +714,15 @@ list<double> *AspRoiList::getRoiFreqs(int dim) {
    return roiFreqs;    
 }
 
-spAspRoi_t AspRoiList::getRoi(double freq1, double freq2) {
+spAspRoi_t AspRoiList::getRoi(double freq1, double freq2, int ht) {
    AspRoiMap::iterator ri;
    spAspRoi_t roi;
    for (roi= getFirstRoi(ri); roi != nullAspRoi; roi= getNextRoi(ri)) {
-	if((roi->cursor1->resonances[0].freq == freq1 &&
+	if(((roi->cursor1->resonances[0].freq == freq1 &&
 		roi->cursor2->resonances[0].freq == freq2) ||
 	  (roi->cursor1->resonances[0].freq == freq2 &&
-                roi->cursor2->resonances[0].freq == freq1) ) return roi;
+                roi->cursor2->resonances[0].freq == freq1)) &&
+       (roi->height == ht ) ) return roi;
    }
    return nullAspRoi;
 }

--- a/src/Asp/AspRoiList.h
+++ b/src/Asp/AspRoiList.h
@@ -40,7 +40,7 @@ public:
     int getNumRois();
     void removeRois();
     spAspRoi_t getRoi(int id);
-    spAspRoi_t getRoi(double freq1, double freq2);
+    spAspRoi_t getRoi(double freq1, double freq2, int ht);
     spAspRoi_t getFirstRoi(AspRoiMap::iterator& roiItr);
     spAspRoi_t getNextRoi(AspRoiMap::iterator& roiItr);
 

--- a/src/common/manual/aspRoi
+++ b/src/common/manual/aspRoi
@@ -26,6 +26,8 @@ ROIs can be loaded from a file, or created interactively in ROI "create" mode.
 aspSetState(3) command sets "band" mode to create 1D ROIs. 
 aspSetState(5) sets "box" mode to create 2D ROIs.
 To creating multiple ROIs, drag mouse cursor while holding ctrl key.
+Unique rois in "band" mode are defined by their two chemical shifts and height.
+Unique rois in "box" mode are defined by their four chemical shifts.
 
 Release mouse without ctrl key will exit create mode.
 
@@ -82,3 +84,13 @@ The first two frequencies are for the first nucleus, the next two frequencies ar
 The following defines 2D ROIs over a 1D spectrum:
 2 H1 amp        9.904   9.103   0.171   0.288   Roi9 2 30
 The third and fourth floating values are vertical height in absolute value.
+
+The aspRoi command can be used to query rois.
+aspRoi:$e,$num
+will set $e =1 if rois are being displayed, 0 otherwise. The optional
+$num will return the number of rois.
+aspRoi($index):$f1,$f2,$ht
+where $index goes from 1 to $num will return the frequencies and height
+of the $index roi.
+aspRoi($f1,$f2,$ht):$index will return the index of the roi corresponding
+to the given frequencies and height. If none match, a 0 will be returned.


### PR DESCRIPTION
Unique band ROIs were defined by their two frequencies. They are
now defined by their two frequencies and height. Added some ROI query
options to aspRoi command. Documented the changes.