### PR TITLE
The rm command with 'regex' argument could fail

### DIFF
--- a/src/common/manual/delete
+++ b/src/common/manual/delete
@@ -21,7 +21,8 @@ rm		-       implementation of the UNIX rm command
   If the first argument is 'regex' or 'regextest', then rm expects the next
   argument to be a directory name, without wildcards, and the third
   and last argument to be a "regular expression" to describe which
-  files or directories should be removed. Since "regular expressions" may
+  files or directories should be removed. If the directory does not exist,
+  the rm command will just return. Since "regular expressions" may
   be unfamiliar, the 'regextest' argument is available to just list the
   files and directories that would be removed without actually
   removing them. This is primarily a tool to be used during macro development.

--- a/src/vnmr/shellcmds.c
+++ b/src/vnmr/shellcmds.c
@@ -1391,6 +1391,7 @@ int Rm(int argc, char *argv[], int retc, char *retv[])
           if ( ! Rmfiles(argv[2], argv[3], testOnly) )
              RETURN;
        }
+       RETURN;
     }
     strcpy(cmdstr,"/bin/rm");
     for (i=1; i<argc; i++)


### PR DESCRIPTION
If the directory does not exist, it would try to remove
files named 'regex' and the directory and the filename
regular expression. It now just returns if the directory
does not exist. Updated documentation.