### PR TITLE
VeriPulse was failing

### DIFF
--- a/src/common/maclib/probeidez
+++ b/src/common/maclib/probeidez
@@ -932,15 +932,16 @@ elseif ($1='target') then
 elseif ($1='get') then
     $attr='' $id=probeidattr[4]
     if $#>1 then $attr=$2 endif
-    if $#>2 then $id=$3 endif
     
-    if $id='' or $id=' ' then return endif
+    if $id='' or $id=' ' then
+      if ($#>=3) then return($3) else return endif
+    endif
     $probeid_cache=$probeid_probes+'/'+$id
     $probeid_path=$probeid_cache+'/'+$probeid_file
     exists($probeid_cache,'directory'):$d
     if not $d then
-      write('line3','Warning: Probe file '+probe+': probe with ID '+$id+' is not initialized on this system')
-      return(size($3))
+      write('line3','Warning: Probe ID for '+probe+' with ID '+$id+' is not initialized on this system.')
+      if ($#>=3) then return($3) else return endif
     endif
     $pid_attr='' $pid_val=''
     readfile($probeid_path,'$pid_attr','$pid_val','','local'):$pid_sz
@@ -951,7 +952,7 @@ elseif ($1='get') then
       if $##=0 then write('line3',$pid_val[$i]) endif
       if $i then return($pid_val[$i]) endif
     endif
-    return(0)
+    if ($#>=3) then return($3) else return endif
 
 elseif ($1='getTargets') then
     //-- initialize probe calibration target specs.

--- a/src/veripulse/maclib/IPpopup
+++ b/src/veripulse/maclib/IPpopup
@@ -67,7 +67,9 @@ if ($function='nextstudy') then
    if (traymax>0) then
 
       if (atune<>'y') then
-         if VPprobestyle<>'atb' then
+         $probestyle=''
+         getparam('style','Probe'):$probestyle
+         if $probestyle<>'atb' then
        	   if (($nuc1<>'NA') and ($nuc2<>'NA')) then
              write('line3','Please do the following:\n\n1. Wait for the %s sample to be inserted into the magnet\n2. Tune the probe for %s and %s\n3. Click \'Close\' when done\n\n\n    DO NOT CLOSE THIS WINDOW UNTIL YOU ARE READY',$sampdesc,$nuc1,$nuc2):$message
 	   elseif ($nuc1<>'NA') then

--- a/src/veripulse/templates/vnmrj/interface/VPpopup.xml
+++ b/src/veripulse/templates/vnmrj/interface/VPpopup.xml
@@ -5009,8 +5009,7 @@
         set="$VALUE=probe"
         />
       <group loc="121 96" size="192 35"
-        vq="probestyle"
-        show="probeidez('lookup'):$probe_has_id,$id if ($probe_has_id) then $ENABLE=1 else $ENABLE=0 endif"
+        show="if (probeiden=1) and (IPprobesn&lt;&gt;'') then $ENABLE=1 else $ENABLE=0 endif"
         border="None"
         tab="no"
         enable="no"
@@ -5027,7 +5026,7 @@
           />
       </group>
       <group loc="126 96" size="180 36"
-        show="probeidez('lookup'):$probe_has_id,$id if ($probe_has_id) then $ENABLE=0 else $ENABLE=1 endif"
+        show="if (probeiden=0) or (IPprobesn='') then $ENABLE=1 else $ENABLE=0 endif"
         border="None"
         tab="no"
         enable="no"


### PR DESCRIPTION
A couple of macros used undefined parameters.
Allow setting probe SN if it is a null string.
Bugs reported in SpinSights.