### PR TITLE
shimbutton widget could show overlapped labels

### DIFF
--- a/src/layouts/layout/toolPanels/VertPanArray.xml
+++ b/src/layouts/layout/toolPanels/VertPanArray.xml
@@ -132,7 +132,7 @@
           label="Vert. height"
           justify="Left"
           />
-        <shimbutton loc="155 0" size="110 20"
+        <shimbutton loc="155 0" size="110 22"
           style="PlainText"
           label=" "
           vq="vf"
@@ -146,7 +146,7 @@
           arrowcolor="GraphForeground"
           wrap="false"
           />
-        <shimbutton loc="155 25" size="110 20"
+        <shimbutton loc="155 24" size="110 22"
           style="PlainText"
           label=" "
           vq="vpf"
@@ -221,7 +221,7 @@
           label="Vert. height"
           justify="Left"
           />
-        <shimbutton loc="160 25" size="110 20"
+        <shimbutton loc="160 24" size="110 22"
           style="PlainText"
           label=" "
           vq="vp"
@@ -235,7 +235,7 @@
           arrowcolor="GraphForeground"
           wrap="false"
           />
-        <shimbutton loc="160 0" size="110 20"
+        <shimbutton loc="160 0" size="110 22"
           style="PlainText"
           label=" "
           vq="vs"
@@ -250,7 +250,7 @@
           wrap="false"
           />
       </group>
-      <shimbutton loc="175 50" size="110 20"
+      <shimbutton loc="175 49" size="110 22"
         style="PlainText"
         label=" "
         vq="dss_sc"
@@ -264,7 +264,7 @@
         arrowcolor="GraphForeground"
         wrap="false"
         />
-      <shimbutton loc="175 25" size="110 20"
+      <shimbutton loc="175 24" size="110 22"
         style="PlainText"
         label=" "
         vq="dss_wc"
@@ -372,7 +372,7 @@
           chval="custom"
           />
       </menu>
-      <shimbutton loc="175 50" size="110 20"
+      <shimbutton loc="175 49" size="110 22"
         style="PlainText"
         label=" "
         vq="shownumx"
@@ -386,7 +386,7 @@
         arrowcolor="GraphForeground"
         wrap="false"
         />
-      <shimbutton loc="175 75" size="110 20"
+      <shimbutton loc="175 74" size="110 22"
         style="PlainText"
         label=" "
         vq="shownumy"
@@ -461,7 +461,7 @@
         label="Horizontal"
         justify="Left"
         />
-      <shimbutton loc="175 75" size="110 20"
+      <shimbutton loc="175 74" size="110 22"
         style="PlainText"
         label=" "
         vq="cutoff"
@@ -475,7 +475,7 @@
         arrowcolor="GraphForeground"
         wrap="false"
         />
-      <shimbutton loc="175 50" size="110 20"
+      <shimbutton loc="175 49" size="110 22"
         style="PlainText"
         label=" "
         vq="vo"
@@ -489,7 +489,7 @@
         arrowcolor="GraphForeground"
         wrap="false"
         />
-      <shimbutton loc="175 25" size="110 20"
+      <shimbutton loc="175 24" size="110 22"
         style="PlainText"
         label=" "
         vq="ho"

--- a/src/vnmrj/src/vnmr/bo/VUpDownButton.java
+++ b/src/vnmrj/src/vnmr/bo/VUpDownButton.java
@@ -383,7 +383,7 @@ public class VUpDownButton extends UpDownButton implements VObjIF, VEditIF,
              setLabel(label);
                      break;
           case MIN:
-                 if (limitPar == null) {
+                 if ((limitPar == null) && (c != null)) {
              try {
                  min =  (int)Double.parseDouble(c);
              } catch (NumberFormatException ex) { }
@@ -391,7 +391,7 @@ public class VUpDownButton extends UpDownButton implements VObjIF, VEditIF,
              }
                      break;
           case MAX:
-                 if (limitPar == null) {
+                 if ((limitPar == null) && (c != null)) {
              try {
                  max = (int)Double.parseDouble(c);
              } catch (NumberFormatException ex) { }
@@ -604,7 +604,8 @@ public class VUpDownButton extends UpDownButton implements VObjIF, VEditIF,
         if (rWidth > nWidth)
             rWidth = nWidth;
         fontH2 = (float)curFont.getSize();
-        setFont(curFont);
+	if (((int)fontH2 > (int)fontH+1) || ((int)fontH2 < (int)fontH-1))
+           setFont(curFont);
     }
 
 


### PR DESCRIPTION
This is seen in the vertical array panel for certain displays
Also fixed a null pointer exception