### PR TITLE
The show arrays panel would not show all array values

### DIFF
--- a/src/common/maclib/showarrays
+++ b/src/common/maclib/showarrays
@@ -5,7 +5,10 @@ else $arg='redisplay' endif
 getMaxIndex:$maxindex
 //$stop=$maxindex
 
-//if celem=0 then $stop=arraydim else $stop=celem endif
+if (celem<$maxindex) then
+  setvalue('celem',$maxindex,'current')
+  setvalue('celem',$maxindex,'processed')
+endif
 
 exists('showarray','parameter'):$e
 module('add','showarrays','basic')
@@ -104,7 +107,7 @@ elseif $arg='redisplay' then
 
 
   exists('dsSelect','parameter'):$e
-  if($e and ($n2 = 'dss')) then
+  if($e and ($n2 = 'dss') and (appmode='imaging')) then
     $dss=$dcmd+'(`select`)'
     exec($dss)
     if shownumbers='v' or shownumbers='s' then
@@ -126,11 +129,6 @@ elseif $arg='redisplay' then
     endif
   endif
   if arraydscale='y' then
-/*
-      if showcontent='f' then dscale(-vo*arraystop/arraydelta)
-      else dscale
-      endif
-*/
     dscale
   endif
 

--- a/src/vnmr/dsww.c
+++ b/src/vnmr/dsww.c
@@ -817,14 +817,14 @@ int dsww(int argc, char *argv[], int retc, char *retv[])
   integral = 0;
 
 // now set arraystart, arraystop, arraydelta parameters
-  if(!P_getreal(CURRENT,"arraystart",&d,1) && firstindex != (int)d) {
+  if(!P_getreal(CURRENT,"arraystart",&d,1) && firstindex > (int)d) {
   	P_setreal(CURRENT,"arraystart", (double)firstindex, 1);
 #ifdef VNMRJ
         appendJvarlist("arraystart");
   	// writelineToVnmrJ("pnew", "1 arraystart");
 #endif
   }
-  if(!P_getreal(CURRENT,"arraystop",&d,1) && lastindex != (int)d) {
+  if(!P_getreal(CURRENT,"arraystop",&d,1) && lastindex < (int)d) {
   	P_setreal(CURRENT,"arraystop", (double)lastindex, 1);
 #ifdef VNMRJ
         appendJvarlist("arraystop");


### PR DESCRIPTION
If celem was incorrect, it would limit the number of array elements that could be displayed. Also, the section in showarrays macro that uses dsSelect is only for CSI data (appmode='imaging')