### PR TITLE
ft3d was failing on Linux

### DIFF
--- a/src/3D/SConstruct
+++ b/src/3D/SConstruct
@@ -57,9 +57,9 @@ getPlFileList    = ['plextract.c']
 cmprsFidFileList = ['compressfid.c']
 
 # build environments
-env = Environment(CCFLAGS    = '-O3 -Wall -m64 ',
+env = Environment(CCFLAGS    = '-O3 -Wall -m32 ',
                   CPPDEFINES = ['LINUX','FT3DIO','NOASYNC'],
-                  LINKFLAGS  = '-m64 -DLINUX ',
+                  LINKFLAGS  = '-m32 -DLINUX ',
                   CPPPATH    = cwd)
 
 if (platform=="darwin"):
@@ -74,7 +74,7 @@ if (platform=="darwin"):
 
 buildMethods.makeSymLinks(env, getplaneTarget, cwd, vnmrPath, vnmrHdrList)
 
-lpEnv = env.Clone(CCFLAGS = '-O3 -m64 -Wall ')
+lpEnv = env.Clone(CCFLAGS = '-O3 -m32 -Wall ')
 lpEnv.Append(CPPDEFINES = ['FT3D'])
 
 if (platform=="darwin"):


### PR DESCRIPTION
THe ft3d program needs to be build as 32-bit, the same as Vnmrbg. On MacOS, it needs to be 64-bit. This is so a structure written to the procdat file can be read correctly. The structure contains a pointer (32 or 64 bit).