### PR TITLE
autocalibration macro could fail

### DIFF
--- a/src/common/maclib/autocalibration
+++ b/src/common/maclib/autocalibration
@@ -132,6 +132,9 @@ IF ($arg = 'init') THEN
     elseif ($0='F19_calibration') then
 	$atext='Sample : F19 S/N test sample'
 	$page='F19SN'
+    else
+    	$atext=''
+	$page=''
     endif
     atext($atext)
 //    samplename=$probe+'_calib'
@@ -165,8 +168,10 @@ IF ($arg = 'init') THEN
     	if (auto='n') then
 	    savesampglobal('cp')
             SQDisplay('refresh')
-	    vnmrjcmd('setpage','Acquire')
-	    vnmrjcmd('setpage','Acquire',$page)
+            if ($page<>'') then
+	      vnmrjcmd('setpage','Acquire')
+	      vnmrjcmd('setpage','Acquire',$page)
+            endif
     	endif
     else
 	calibmod='yes'


### PR DESCRIPTION
autocalibration with no arguments would try to
use uninitialized variables.