### PR TITLE
ping could fail on some systems.

### DIFF
--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -123,7 +123,7 @@ done
 
 if [[ $ovjRepo -eq 0 ]] && [[ $noPing -eq 0 ]]
 then
-  ping -W 1 -c 1 google.com > /dev/null 2>&1
+  ping -4 -W 1 -c 1 google.com > /dev/null 2>&1
   if [ $? -ne 0 ]
   then
     echo "Must be connected to the internet for $0 to function"

--- a/src/scripts/ovjBuild.sh
+++ b/src/scripts/ovjBuild.sh
@@ -60,7 +60,7 @@ do
 done
 
 URL="www.github.com"
-ping -c 1 -q -W 1 $URL > /dev/null 2>&1
+ping -4 -c 1 -q -W 1 $URL > /dev/null 2>&1
 if [[ $? -eq 0 ]] || [[ $noPing -eq 1 ]] ; then
     echo "Test for internet access to $URL passed"
 else

--- a/src/scripts/ovjDiag.sh
+++ b/src/scripts/ovjDiag.sh
@@ -10,7 +10,11 @@
 #
 # set -x
 
-ping -W 1 -c 1 $(hostname) > /dev/null 2>&1
+if [ x$(uname -s) = "xDarwin" ]; then
+   ping -W 1 -c 1 $(hostname) > /dev/null 2>&1
+else
+   ping -4 -W 1 -c 1 $(hostname) > /dev/null 2>&1
+fi
 if [[ $? -ne 0 ]]; then
   echo "Unable to ping $(hostname)"
   echo "This hostname should be added to the /etc/hosts file"

--- a/src/scripts/ovjGetFidlib.sh
+++ b/src/scripts/ovjGetFidlib.sh
@@ -73,7 +73,7 @@ while [ $# -gt 0 ]; do
         -l|--log)               OVJ_LOG="$2"; shift     ;;
         -nv|--no-verbose)       OVJ_VECHO=":" ;;
         -v|--verbose)           OVJ_VECHO="echo" ;;
-        noPing)                 noPing=1; shift ;;
+        noPing)                 noPing=1; ;;
         -vv|--debug)            set -x ;;
         *)
             # unknown option
@@ -145,7 +145,11 @@ downloadFiles() {
 
 checkNetwork() {
    local URL="www.dropbox.com"
-   ping -c 1 -q -W 1 $URL > /dev/null 2>&1
+   if [ x$(uname -s) = "xDarwin" ]; then
+      ping -c 1 -q -W 1 $URL > /dev/null 2>&1
+   else
+      ping -4 -c 1 -q -W 1 $URL > /dev/null 2>&1
+   fi
    if [[ $? -eq 0 ]] || [[ $noPing -eq 1 ]] ; then
       $OVJ_VECHO "Test for internet access to $URL passed"
       return 0

--- a/src/scripts/ovjGetManuals.sh
+++ b/src/scripts/ovjGetManuals.sh
@@ -73,7 +73,7 @@ while [ $# -gt 0 ]; do
         -l|--log)               OVJ_LOG="$2"; shift     ;;
         -nv|--no-verbose)       OVJ_VECHO=":" ;;
         -v|--verbose)           OVJ_VECHO="echo" ;;
-        noPing)                 noPing=1; shift ;;
+        noPing)                 noPing=1; ;;
         -vv|--debug)            set -x ;;
         *)
             # unknown option
@@ -145,7 +145,11 @@ downloadFiles() {
 
 checkNetwork() {
    local URL="www.dropbox.com"
-   ping -c 1 -q -W 1 $URL > /dev/null 2>&1
+   if [ x$(uname -s) = "xDarwin" ]; then
+      ping -c 1 -q -W 1 $URL > /dev/null 2>&1
+   else
+      ping -4 -c 1 -q -W 1 $URL > /dev/null 2>&1
+   fi
    if [[ $? -eq 0 ]] || [[ $noPing -eq 1 ]] ; then
       $OVJ_VECHO "Test for internet access to $URL passed"
       return 0

--- a/src/scripts/ovjGetVB.sh
+++ b/src/scripts/ovjGetVB.sh
@@ -37,7 +37,7 @@ while [ $# -gt 0 ]; do
     key="$1"
     case $key in
         -h|--help)              ovj_usage                   ;;
-        noPing)                 noPing=1; shift ;;
+        noPing)                 noPing=1; ;;
         -vv|--debug)            set -x ;;
         *)
             # unknown option
@@ -82,7 +82,7 @@ checkNetwork() {
 #   The below seems to have disabled ping. Use google instead
     local URL="google.com"
     local pingRecv=0
-    pingRecv=`ping -c 1 -q -W 1 $URL | grep received | awk '{ print $4 }'`
+    pingRecv=`ping -4 -c 1 -q -W 1 $URL | grep received | awk '{ print $4 }'`
          
     if [[ ${pingRecv} -eq 1 ]] || [[ $noPing -eq 1 ]] ; then
         echo "Test for internet access passed"

--- a/src/scripts/ovjGetpipe.sh
+++ b/src/scripts/ovjGetpipe.sh
@@ -75,7 +75,7 @@ while [ $# -gt 0 ]; do
         -nv|--no-verbose)       OVJ_VECHO=":" ;;
         -t|--test)              OVJ_PIPETEST="$2"; shift    ;;
         -v|--verbose)           OVJ_VECHO="echo" ;;
-        noPing)                 noPing=1; shift ;;
+        noPing)                 noPing=1; ;;
         -vv|--debug)            set -x ;;
         *)
             # unknown option
@@ -225,7 +225,11 @@ checkNetwork() {
 #   local URL="www.ibbr.umd.edu"
     local URL="google.com"
     local pingRecv=0
-    pingRecv=`ping -c 1 -q -W 1 $URL | grep received | awk '{ print $4 }'`
+    if [ x$(uname -s) = "xDarwin" ]; then
+       pingRecv=`ping -c 1 -q -W 1 $URL | grep received | awk '{ print $4 }'`
+    else
+       pingRecv=`ping -4 -c 1 -q -W 1 $URL | grep received | awk '{ print $4 }'`
+    fi
          
     if [[ ${pingRecv} -eq 1 ]] || [[ $noPing -eq 1 ]] ; then
         $OVJ_VECHO "Test for internet access passed"

--- a/src/scripts/setacq.sh
+++ b/src/scripts/setacq.sh
@@ -524,7 +524,7 @@ installConsole() {
    fi
 
 #   ping master1 (once [-c1]), if no answer ask to check and rerun $0
-   ping -c1 -q master1 > /dev/null
+   ping -4 -c1 -q master1 > /dev/null
    if [[ $? -ne 0 ]] ; then
      echo ""
      echo Please check that the console and host are connected

--- a/src/scripts/vnmrsetup.sh
+++ b/src/scripts/vnmrsetup.sh
@@ -366,10 +366,12 @@ rm -f /tmp/reboot
 # loop though the arguments and check for the install option key word
 # noPing, NOTE this must be the first argument
 # Otherwise the user name, group and destination args will be incorrect
+noPing=""
 for arg in "$@"
 do
    if [ "x$arg" = "xnoPing" ]
    then
+      noPing="noPing"
       shift
    fi
 done
@@ -584,9 +586,9 @@ if [ -e /tmp/.ovj_installed ]; then
    if [ "x$ans" = "xy" -o "x$ans" = "xY" ] ; then
       echo "Installing NMRPipe" >> $insLog
       if [ x$distroType = "xdebian" ]; then
-         sudo -i -u $nmr_user /vnmr/bin/ovjGetpipe -l $insLog
+         sudo -i -u $nmr_user /vnmr/bin/ovjGetpipe $noPing -l $insLog
       else
-         su - $nmr_user -c "/vnmr/bin/ovjGetpipe -l $insLog"
+         su - $nmr_user -c "/vnmr/bin/ovjGetpipe $noPing -l $insLog"
       fi
       echo " "
    elif [[ x$oldVnmr != "x" ]] ; then
@@ -616,9 +618,9 @@ if [ -e /tmp/.ovj_installed ]; then
       if [ "x$ans" = "xy" -o "x$ans" = "xY" ] ; then
          echo "Installing VnmrJ manuals" >> $insLog
          if [ x$distroType = "xdebian" ]; then
-            sudo -i -u $nmr_user /vnmr/bin/ovjGetManuals -l $insLog
+            sudo -i -u $nmr_user /vnmr/bin/ovjGetManuals $noPing -l $insLog
          else
-            su - $nmr_user -c "/vnmr/bin/ovjGetManuals -l $insLog"
+            su - $nmr_user -c "/vnmr/bin/ovjGetManuals $noPing -l $insLog"
          fi
          echo " "
       else
@@ -642,9 +644,9 @@ if [ -e /tmp/.ovj_installed ]; then
       if [ "x$ans" = "xy" -o "x$ans" = "xY" ] ; then
          echo "Installing VnmrJ fidlib" >> $insLog
          if [ x$distroType = "xdebian" ]; then
-            sudo -i -u $nmr_user /vnmr/bin/ovjGetFidlib
+            sudo -i -u $nmr_user /vnmr/bin/ovjGetFidlib $noPing
          else
-            su - $nmr_user -c "/vnmr/bin/ovjGetFidlib"
+            su - $nmr_user -c "/vnmr/bin/ovjGetFidlib $noPing"
          fi
          echo " "
       else


### PR DESCRIPTION
IPv6 was being used for ping. Now force IPv4.
If noPing was supplied as an argument to ovjGet... scripts, subsequent arguments failed. If noPing is given to the load.nmr (vnmrsetup) script, it is also passed to any ovjGet... scripts that are called as part of the installation