### PR TITLE
Fixed VNMRS version of Recvproc for Ubuntu 22

### DIFF
--- a/src/nvacq/NDDS_Obj.c
+++ b/src/nvacq/NDDS_Obj.c
@@ -558,7 +558,7 @@ static int participant_shutdown( DDS_DomainParticipant *participant)
     return status;
 }
 
-NDDS_Shutdown( NDDS_OBJ *pNddsObj )
+void NDDS_Shutdown( NDDS_OBJ *pNddsObj )
 {
    participant_shutdown(pNddsObj->pParticipant);
 }

--- a/src/nvacq/NDDS_Obj.h
+++ b/src/nvacq/NDDS_Obj.h
@@ -131,7 +131,7 @@ extern int createPublisher(NDDS_ID pNDDS_Obj);
 extern int createSubscriber(NDDS_ID pNDDS_Obj);
 
 #ifdef RTI_NDDS_4x
-extern NDDS_Shutdown( NDDS_OBJ *pNddsObj );
+extern void NDDS_Shutdown( NDDS_OBJ *pNddsObj );
 extern DDS_Publisher *PublisherCreate(DDS_DomainParticipant *participant);
 extern DDS_Subscriber *SubscriberCreate(DDS_DomainParticipant *participant);
 extern DDS_Topic *RegisterAndCreateTopic(NDDS_ID pNDDS_Obj);

--- a/src/nvrecvproc/NDDS_DataFuncs.c
+++ b/src/nvrecvproc/NDDS_DataFuncs.c
@@ -1039,7 +1039,7 @@ setDiscardIssues()
    /* discardIssues = 1;  */
 }
 
-clearDiscardIssues()
+void clearDiscardIssues()
 {
    SHARED_DATA_ID pSharedData;
    pSharedData = (SHARED_DATA_ID) lockSharedData(&TheMemBarrier);
@@ -1454,7 +1454,7 @@ void initiateDataPub()
 #endif  /* THREADED */
  
 
-shutdownComm()
+void shutdownComm()
 {
 #ifndef RTI_NDDS_4x
    RTINtpTime sleepTime = { 0, 0 };

--- a/src/nvrecvproc/SConstruct
+++ b/src/nvrecvproc/SConstruct
@@ -6,8 +6,14 @@ import sys
 sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
 import buildMethods
 
+cwd = os.getcwd()
 ovjtools=os.getenv('OVJ_TOOLS')
 if not ovjtools:
+# If not defined, try the default location
+    print("OVJ_TOOLS env not found. Trying default location.")
+    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
+
+if not os.path.exists(ovjtools):
     print("OVJ_TOOLS env not found.")
     print("For bash and variants, use export OVJ_TOOLS=<path>")
     print("For csh and variants,  use setenv OVJ_TOOLS <path>")
@@ -18,10 +24,6 @@ Import("*")
 
 # define target file names
 nvRecvProcTarget = 'Recvproc'
-
-# we need to specify an absolute path so this SConstruct file
-# can be called from any other SConstruct file
-cwd = os.getcwd()
 
 javaPath = os.path.join(ovjtools, 'java', 'bin')
 


### PR DESCRIPTION
The VNMRS version of Recvproc used the same byte-swapping style as the Inova version, which was fixed in PR #720. Fixed it for VNMRS version in the same way. Fixed all warnings in recvfuncs.c.