### PR TITLE
Corrected listenon manual

### DIFF
--- a/src/common/maclib/listenoff
+++ b/src/common/maclib/listenoff
@@ -3,4 +3,6 @@
 "            from send2Vnmr.                     "
 
 rm(userdir+'/.talk'):$x
-write('line3','Receipt of external messages is now disabled')
+if ($## = 0) then
+  write('line3','Receipt of external messages is now disabled')
+endif

--- a/src/common/manual/listenoff
+++ b/src/common/manual/listenoff
@@ -4,7 +4,9 @@ listenoff -        disable the receipt of messages from send2Vnmr
 *******************************************************************************
 
 This macro deletes the $vnmruser/.talk file, thereby disallowing
-send2Vnmr to send commands to Vnmr. 
+send2Vnmr to send commands to OpenVnmrJ.  Appending a return value, as in
+   listenoff:$e
+suppresses notification about disabling external messages
 
 
 See also: listenon

--- a/src/common/manual/listenon
+++ b/src/common/manual/listenon
@@ -3,10 +3,14 @@
 listenon -        enable the receipt of messages from send2Vnmr
 *******************************************************************************
 
-This macro writes a files with the Vnmr port number that
-/vnmr/acqbin/send2Vnmr needs to talk to Vnmr. The proper
-command to send commands to Vnmr then is
+This macro writes a files with the OpenVnmrJ port number that
+/vnmr/bin/send2Vnmr needs to talk to OpenVnmrJ. The proper
+command to send commands to OpenVnmrJ then is
 
-   /vnmr/acqbin/send2Vnmr $vnmruser/.talk commandstring
+   /vnmr/bin/send2Vnmr $vnmruser/.talk commandstring
+
+Appending a return value, as in
+   listenon:$e
+suppresses notification about enabling external messages
 
 See also: listenoff


### PR DESCRIPTION
It had send2Vnmr in /vnmr/acqbin rather than /vnmr/bin. Added option to listenoff to suppess messages