### PR TITLE
spExec failed with a write error

### DIFF
--- a/src/common/maclib/spExec
+++ b/src/common/maclib/spExec
@@ -223,8 +223,9 @@ elseif (spStage = 'rampfill2') then
   cat(curexp+'/poly3')
   lookup('mfile',curexp+'/poly3','seek','number','filekey'):$key
   lookup('mfile',$key,'delimiter',' =\n','seek','a1','read','skip','read','skip','read'):$c,$b,$a,$res
-  substr(spParNames,1):$dacname
-  if ($res<>3) then
+  format($a,$b,$c,'isfinite'):$isFin
+  if ($res<>3 or not $isFin) then
+    substr(spParNames,1):$dacname
     $curDac = spLo
     write('line3','No solution: resetting %s = %d',$dacname,$curDac)
     write('file',spLogFile,'No solution: resetting %s = %d',$dacname,$curDac)

--- a/src/common/manual/format
+++ b/src/common/manual/format
@@ -3,6 +3,7 @@
 format	-	formats a real number into a nice string for output
 format	-	converts a string into upper case or lower case for output
 format	-	tests a string to determine if it can represent a real number
+                or a finite number
 format	-	interconverts string representations of real numbers and real
                 numbers
 format  -       expand a string to remove tabs.
@@ -14,16 +15,23 @@ format  -       expand a string to remove tabs.
   argument to all upper case characters.
   If the second argument is 'lower', this command will convert the first
   argument to all lower case characters.
-  If the second argument is 'isreal', this command will test the first argument
-  to see if it satisfies the rules for a real number.  It will return a 1 in the
-  first argument can represent a real number and a 0 otherwise.
   If the second argument is 'expand', this command will convert all tabs ('\t')
   into the equivalent number of spaces (' ')
 
   Usage  -  format(stringvar,'upper'):stringvar
             format(stringvar,'lower'):stringvar
             format(stringvar,'expand'):stringvar
-            format(stringvar,'isreal'):ans
+
+  If the command is given two or more arguments and the last argument is either
+  'isreal' or 'isfinite', the preceeding arguments will be tested to see if they
+  satisfy the rules for a real number or a finite number. It will return a 1
+  if all preceeding arguments represent a real number (for 'isreal') or
+  a finite number (for 'isfinite') and a 0 otherwise. The difference between
+  'isreal' and 'isfinite' is only in the handling of the strings 'inf' and '-inf'.
+  The 'isreal' case will return a 1 and the 'isfinite' case will return a 0.
+
+  Usage  -  format($a,$b,'isreal'):$ans
+            format($a,$b,'isfinite'):$ans
 
   If the command is given three arguments, the first argument must be a
   real number or string holding a real number. If it is a string variable,

--- a/src/vnmr/builtin.c
+++ b/src/vnmr/builtin.c
@@ -1530,7 +1530,61 @@ static void vnmrToUpper(char *s)
 
 int format(int argc, char *argv[], int retc, char *retv[])
 {
-    if (argc == 4)
+    if ( (argc >= 3) && (strcmp(argv[argc-1],"isreal") == 0) )
+    {
+       int i = 1;
+       int isRe = 1;
+  
+       if (1 <= retc)
+       {
+          while ( (i < argc-1) && isRe)
+          {
+             isRe = isReal(argv[i]);
+             i++;
+          }
+          retv[0] = intString(isRe);
+       }
+       else
+       {
+          while (i < argc-1)
+          {
+             isRe = isReal(argv[i]);
+             Winfoprintf("%s %s a real number",
+                argv[i],(isRe == 1) ? "is" : "is not");
+             i++;
+          }
+          clearRets(retc,retv);
+       }
+       RETURN;
+    }
+    else if ( (argc >= 3) && (strcmp(argv[argc-1],"isfinite") == 0) )
+    {
+       int i = 1;
+       int isRe = 1;
+  
+       if (1 <= retc)
+       {
+          while ( (i < argc-1) && isRe)
+          {
+             isRe = isFinite(argv[i]);
+             i++;
+          }
+          retv[0] = intString(isRe);
+       }
+       else
+       {
+          while (i < argc-1)
+          {
+             isRe = isFinite(argv[i]);
+             Winfoprintf("%s %s a finite number",
+                argv[i],(isRe == 1) ? "is" : "is not");
+             i++;
+          }
+          clearRets(retc,retv);
+       }
+       RETURN;
+    }
+    else if (argc == 4)
     {   char forstr[32];
         char retstr[66];
         int  length,precision;
@@ -1594,17 +1648,6 @@ int format(int argc, char *argv[], int retc, char *retv[])
        {
           strcpy(retstr,argv[1]);
           vnmrToUpper(retstr);
-       }
-       else if (strcmp(argv[2],"isreal") == 0)
-       {
-          int res = isReal(argv[1]);
-          if (1 <= retc)
-             retv[0] = intString(res);
-          else
-          {  Winfoprintf("%s %s a real number",argv[1],(res == 1) ? "is" : "is not");
-             clearRets(retc,retv);
-          }
-          RETURN;
        }
        else if (strcmp(argv[2],"expand") == 0)
        {

--- a/src/vnmr/tools.c
+++ b/src/vnmr/tools.c
@@ -263,6 +263,7 @@ const char *msg(const char *m)
 |
 |	This function returns true (non-zero) if the given string can be
 |	converted to a real.  It returns false (zero) otherwise.
+|       The string 'inf' returns true.
 |
 +-----------------------------------------------------------------------------*/
 
@@ -284,6 +285,36 @@ int isReal(char *s)
     }
 
     return(! isnan(tmp));
+}
+
+/*------------------------------------------------------------------------------
+|
+|	isFinite/1
+|
+|	This function returns true (non-zero) if the given string can be
+|	converted to a real.  It returns false (zero) otherwise.
+|       The string 'inf' returns false.
+|
++-----------------------------------------------------------------------------*/
+
+int isFinite(char *s)
+{   double tmp;
+    char *end;
+    register char *end2;
+
+    errno = 0;
+    tmp = strtod(s, &end);
+    if ((end == s) || (errno != 0))
+	return(0);
+    end2 = s + strlen(s);
+    while ((end < end2) && isspace((unsigned char) *end)) {
+        end++;
+    }
+    if (end != end2) {
+	return(0);
+    }
+
+    return(isfinite(tmp));
 }
 
 /****************************************************/

--- a/src/vnmr/tools.h
+++ b/src/vnmr/tools.h
@@ -36,6 +36,7 @@ extern char   *rtoa(double d, char *buf, int size);
 extern char   *realString(double d);
 extern double  stringReal(char *s);
 extern int     isReal(char *s);
+extern int     isFinite(char *s);
 extern void    space(FILE *f, int n);
 extern int     verify_fname(char *fnptr);
 


### PR DESCRIPTION
Lookup was returning 'inf' as a numeric value. This caused the write command to fail. Added a test to check the values before trying to write them. However, format with the 'isreal' option treats 'inf' as a real. Added 'isfinite' option to format which returns that 'inf' is not a finite number. Documented format changes.