### PR TITLE
Documented cmdHistory command

### DIFF
--- a/src/common/manual/cmdHistory
+++ b/src/common/manual/cmdHistory
@@ -1,0 +1,24 @@
+
+cmdHistory - keep a command history
+
+    cmdHistory<:$global,$local>   - display or return current history files
+    cmdHistory('on')              - start new global command history file
+    cmdHistory('append')          - append to existing global history file
+    cmdHistory('off')             - stop the global history file
+    cmdHistory('on',filename)     - start new local command history file
+    cmdHistory('append',filename) - append to existing local history file
+    cmdHistory('off',filename)    - stop the local history file
+    cmdHistory('skip')            - do not put current macro into command history
+
+    cmdHistory will save commands executed from the command line or as a result
+    using interface items such as buttons or menus.  Two separate command histories
+    can be kept: a global file and a local file.  Typically, the global file would
+    keep the complete history. The global file name is userdir+'/cmdHistory'.
+    The local file might be used to capture inputs to build a macro or to capture
+    interactions involved in a specific operation. The name of the local file is
+    passed as an argument.
+
+    A macro can avoid being added to the history files by calling cmdHistory
+    with the 'skip' argument. The cmdHistory files are not kept for any background
+    operations.
+

--- a/src/vnmrbg/smagic.c
+++ b/src/vnmrbg/smagic.c
@@ -301,7 +301,7 @@ static int  cmdLineOK = 1;  /* command line is enabled */
 static char escChar = '\033';
 static char *vjWinInfo = NULL;
 static char evalStr[ MAXPATH ];
-static char showStr[ MAXPATH ];
+static char showStr[ MAXPATH+16 ];
 static char tmpStr[ MAXPATH ];
 static char jexprDummyVar[ MAXPATH ] = "$VALUE";
 
@@ -2388,7 +2388,7 @@ static void jAutoSendIfGlobal(char *param )
 {
         int i, j, k, l, tree = NOTREE;
         int num;
-        char mstr[MAXPATH+1], paramb[MAXPATH+1];
+        char mstr[MAXPATH+16], paramb[MAXPATH+16];
 	char *plist;
         double dval;
         vInfo info;
@@ -2916,7 +2916,7 @@ void jsendParamMaxMin(int num, char *param, char *tree )
 
 static void vnmrj_express_real(char *mstr, char *format, double dval )
 {
-  char rstr[8];
+  char rstr[16];
   int ig;
   if (strcmp(format,"")==0)
     sprintf(mstr, "%g", dval);
@@ -3632,7 +3632,7 @@ static void jExecExpression(char *key, char *exnum, char *express, char *format 
 static void jEvaluateExpression(int exnum, char *express )
 {
 	char jstr[ 8*MAXPATH ];
-	char rstr[ MAXPATH ];
+	char rstr[ MAXPATH+8 ];
 
 	jExpressUse = 1;
 	jExError = 0;
@@ -3817,6 +3817,7 @@ int isimagebrowser(int argc, char *argv[], int retc, char *retv[])
 
    (void) argc;
    (void) argv;
+   doThisCmdHistory = 0;
    aip = (aipOwnsScreen()) ? 1 : 0;
    if (retc)
    {
@@ -3955,7 +3956,7 @@ static int jxFunc(int func, int argc, char *argv[])
        switch (func) {
                case JPNEWLOC:  // 41x
                     if (argc > 2) {
-                         char mstr[MAXPATH], key[6]="vloc";
+                         char mstr[MAXPATH+16], key[6]="vloc";
                          if (argc > 4)
                          {
                             sprintf(mstr, "%s=%s", jexprDummyVar, argv[3]);
@@ -4811,6 +4812,7 @@ int jMove(int argc, char *argv[], int retc, char *retv[])
 {
    (void) retc;
    (void) retv;
+   doThisCmdHistory = 0;
    if (argc > 3) {
       jvnmr_sync(0, 0);
       processJMouse(argc, argv);
@@ -4823,6 +4825,7 @@ int jMove2(int argc, char *argv[], int retc, char *retv[])
 {
    (void) retc;
    (void) retv;
+   doThisCmdHistory = 0;
    if (argc > 3) {
       jvnmr_sync(0, 1);
       process_csi_JMouse(argc, argv);


### PR DESCRIPTION
Also fixed problem where cmdHistory would not return the history file names. Prevent jMove and isimagebrowser from being added to the history files. Fixed issue where a macro that ended the history was not being put into the history log.