### PR TITLE
Allow XY positioning of popup windows

### DIFF
--- a/src/vnmrj/src/vnmr/ui/ExpPanel.java
+++ b/src/vnmrj/src/vnmr/ui/ExpPanel.java
@@ -5066,6 +5066,8 @@ public class ExpPanel extends JPanel
         String mode = "";
         String xmlfile = "";
         String location = "";
+        String xlocation = "";
+        String ylocation = "";
         String strHelpFile = "";
         String strPnew = "";
         String strCancel = "";
@@ -5102,6 +5104,14 @@ public class ExpPanel extends JPanel
             }
             if(par1.startsWith("location:")) {
                 location = par1.substring(9);
+                continue;
+            }
+            if(par1.startsWith("x:")) {
+                xlocation = par1.substring(2);
+                continue;
+            }
+            if(par1.startsWith("y:")) {
+                ylocation = par1.substring(2);
                 continue;
             }
             if (par1.startsWith(strRebuild)) {
@@ -5221,7 +5231,10 @@ public class ExpPanel extends JPanel
 				bRebuild, strHelpFile,
 				strCancel, strOK, strPnew);
             modalPopup.setOnTop(bOnTop);
-            modalPopup.showDialogAndSetParms(location);
+            if (! xlocation.equals("") && ! ylocation.equals("") )
+               modalPopup.showDialogXYAndSetParms(xlocation,ylocation);
+            else
+               modalPopup.showDialogAndSetParms(location);
         } else if (mode.startsWith("modeless") && xmlfile != null) {
 
             /* stop modal popups from blocking communication with Vnmrbg/Vnmrj */
@@ -5268,7 +5281,10 @@ public class ExpPanel extends JPanel
                    popup = new ModelessPopup(sshare, this, appIf, title,
                               xmlfile, width, height, bRebuild, strHelpFile, strClose);
                 popup.setOnTop(bOnTop);
-                popup.showDialogAndSetParms(location);
+                if (! xlocation.equals("") && ! ylocation.equals("") )
+                    popup.showDialogXYAndSetParms(xlocation,ylocation);
+                else
+                    popup.showDialogAndSetParms(location);
                 modelessPopups.put(xmlfile, popup);
             } else {
                 if (bFrameType)
@@ -5278,7 +5294,10 @@ public class ExpPanel extends JPanel
                    popup = new ModelessPopup(sshare, this, appIf, title,
                               xmlfile, width, height, bRebuild, strHelpFile, strClose);
                 popup.setOnTop(bOnTop);
-                popup.showDialogAndSetParms(location);
+                if (! xlocation.equals("") && ! ylocation.equals("") )
+                    popup.showDialogXYAndSetParms(xlocation,ylocation);
+                else
+                    popup.showDialogAndSetParms(location);
                 modelessPopups.put(xmlfile, popup);
             }
         }

--- a/src/vnmrj/src/vnmr/util/ModalPopup.java
+++ b/src/vnmrj/src/vnmr/util/ModalPopup.java
@@ -338,6 +338,33 @@ public class ModalPopup extends ModalDialog implements ActionListener, VObjDef {
         transferFocus();
     }
 
+    public void showDialogXYAndSetParms(String xloc, String yloc) {
+        Point location;
+        int x;
+        try {
+          x = Integer.parseInt(xloc);
+        }
+        catch (NumberFormatException e) {
+          x = 0;
+        }
+        int y;
+        try {
+          y = Integer.parseInt(yloc);
+        }
+        catch (NumberFormatException e) {
+          y = 0;
+        }
+        location = new Point(x, y);
+        setLocation(location);
+
+        // Show the dialog and wait for the results. (Blocking call)
+        showDialogWithThread();
+
+        // If I don't do this, and the user hits a 'return' on the keyboard
+        // the dialog comes visible again.
+        transferFocus();
+    }
+
     private void updateGrpAllValue(JComponent p) {
         int nums = p.getComponentCount();
         for(int i = 0; i < nums; i++) {

--- a/src/vnmrj/src/vnmr/util/ModelessPopup.java
+++ b/src/vnmrj/src/vnmr/util/ModelessPopup.java
@@ -271,6 +271,36 @@ public class ModelessPopup extends ModelessDialog
         transferFocus();
     }
 
+    public void showDialogXYAndSetParms(String xloc, String yloc) {
+        Point location;
+
+        int x;
+        try {
+          x = Integer.parseInt(xloc);
+        }
+        catch (NumberFormatException e) {
+          x = 0;
+        }
+        int y;
+        try {
+          y = Integer.parseInt(yloc);
+        }
+        catch (NumberFormatException e) {
+          y = 0;
+        }
+        location = new Point(x, y);
+        setLocation(location);
+
+        // Show the dialog and wait for the results. (Blocking call)
+        //showDialogWithThread();
+
+        setVisible(true);
+
+        // If I don't do this, and the user hits a 'return' on the keyboard
+        // the dialog comes visible again.
+        transferFocus();
+    }
+
    /**********
     private void updateGrpAllValue (JComponent p) {
         int nums = p.getComponentCount();


### PR DESCRIPTION
The x: and y: attributes can be used as an alternative to the location: attribute for the vnmrjcmd('popup',...)
command. Setting 'x:0', 'y:0', will place the popup in the upper left corner of the screen.