### PR TITLE
Replaced strncpy with strcpy in biosolidspack pulse sequences

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,6 +1,18 @@
 OpenVnmrJ Release Notes.
 
 Oct 2021 -
+    Replaced strncpy with strcpy in biosolidspack pulse sequences
+    Allow XY positioning of popup windows
+    Added manual page for the fidarea command.
+    Added manual page for the cmdHistory command.
+    Operator password changes would not take effect until
+      OpenVnmrJ was exited and restarted.
+    Bug fix: spExec failed with a write error
+      added 'isfinite' option to format (see manual/format)
+      to handle case where values may be 'inf' or '-inf'
+    can set axis label with fn_label parameter
+    Bug fix: cat command may not show entire file written by Vnmrbg
+      It requires a call to sync to write memory to the disk.
     added silencing option to listenoff
       Corrected the man page for listenon
     ping could fail on some systems. It was using IPv6.

--- a/src/biosolidspack/psglib/ahX.c
+++ b/src/biosolidspack/psglib/ahX.c
@@ -116,8 +116,8 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 

--- a/src/biosolidspack/psglib/ahXX.c
+++ b/src/biosolidspack/psglib/ahXX.c
@@ -99,8 +99,8 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
@@ -130,10 +130,10 @@ void pulsesequence() {
       getstr("dqfXspc5",dqfXspc5);
       spc5 = getspc5("spc5X",0,0.0,0.0,0,1);
       tXspc5ret = spc5.t;
-      strncpy(spc5.ch,"obs",3);
+      strcpy(spc5.ch,"obs");
       if (!strcmp(dqfXspc5,"y")) {
          spc5ref = getspc5("spc5X",spc5.iSuper,spc5.phAccum,spc5.phInt,1,1); 
-         strncpy(spc5ref.ch,"obs",3);
+         strcpy(spc5ref.ch,"obs");
          tXspc5ret = tXspc5ret + spc5.t;
       }
       putCmd("chXspc5='obs'\n");
@@ -149,10 +149,10 @@ void pulsesequence() {
       getstr("dqfXc7",dqfXc7);
       c7 = getpostc7("c7X",0,0.0,0.0,0,1);
       tXc7ret = c7.t;
-      strncpy(c7.ch,"obs",3);
+      strcpy(c7.ch,"obs");
       if (!strcmp(dqfXc7,"y")) {
          c7ref = getpostc7("c7X",c7.iSuper,c7.phAccum,c7.phInt,1,1);
-         strncpy(c7ref.ch,"obs",3);
+         strcpy(c7ref.ch,"obs");
          tXc7ret = tXc7ret + c7.t;
       }
       putCmd("chXc7='obs'\n");
@@ -168,10 +168,10 @@ void pulsesequence() {
       getstr("dqfXc6",dqfXc6);
       c6 = getpostc6("c6X",0,0.0,0.0,0,1);
       tXc6ret = c6.t;
-      strncpy(c6.ch,"obs",3);
+      strcpy(c6.ch,"obs");
       if (!strcmp(dqfXc6,"y")) {
          c6ref = getpostc6("c6X",c6.iSuper,c6.phAccum,c6.phInt,1,1);
-         strncpy(c6ref.ch,"obs",3);
+         strcpy(c6ref.ch,"obs");
          tXc6ret = tXc6ret + c6.t;
       }
       putCmd("chXc6='obs'\n");
@@ -184,7 +184,7 @@ void pulsesequence() {
    if (!strcmp(mMix,"rfdr")) {
       rfdr = getrfdrxy8("rfdrX",0,0.0,0.0,0,1);
       tXrfdrret = rfdr.t;
-      strncpy(rfdr.ch,"obs",3);
+      strcpy(rfdr.ch,"obs");
       putCmd("chXrfdr='obs'\n");
       putCmd("tXrfdrret = %f\n",tXrfdrret*1.0e6);
    }

--- a/src/biosolidspack/psglib/ahXYX.c
+++ b/src/biosolidspack/psglib/ahXYX.c
@@ -125,20 +125,20 @@ void pulsesequence() {
 // Define Variables and Modules and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",4);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n"); 
    putCmd("toHX='obs'\n");
 
    CP xy = getcp("XY",0.0,0.0,0,1);
-   strncpy(xy.fr,"obs",4);
-   strncpy(xy.to,"dec2",3);
+   strcpy(xy.fr,"obs");
+   strcpy(xy.to,"dec2");
    putCmd("frXY='obs'\n");
    putCmd("toXY='dec2'\n");
 
    CP yx = getcp("YX",0.0,0.0,0,1);
-   strncpy(yx.fr,"dec2",4);
-   strncpy(yx.to,"obs",3);
+   strcpy(yx.fr,"dec2");
+   strcpy(yx.to,"obs");
    putCmd("frYX='dec2'\n");
    putCmd("toYX='obs'\n");
 
@@ -158,7 +158,7 @@ void pulsesequence() {
    char mMix[MAXSTR];
    getstr("mMix",mMix);
 
-   strncpy(mMix,"darr",5);
+   strcpy(mMix,"darr");
    putCmd("mMix='darr'\n");
 
 // Get pwX90 and pwY90 to Adjust For Composite and Simpulses

--- a/src/biosolidspack/psglib/ahYXX.c
+++ b/src/biosolidspack/psglib/ahYXX.c
@@ -153,14 +153,14 @@ void pulsesequence() {
 // Define Variables and Modules and Get Parameter Values
      
    CP hy = getcp("HY",0.0,0.0,0,1);
-   strncpy(hy.fr,"dec",3);
-   strncpy(hy.to,"dec2",4);      
+   strcpy(hy.fr,"dec");
+   strcpy(hy.to,"dec2");      
    putCmd("frHY='dec'\n");
    putCmd("toHY='dec2'\n");
    
    CP yx = getcp("YX",0.0,0.0,0,1);
-   strncpy(yx.fr,"dec2",4);
-   strncpy(yx.to,"obs",3);
+   strcpy(yx.fr,"dec2");
+   strcpy(yx.to,"obs");
    putCmd("frYX='dec2'\n");
    putCmd("toYX='obs'\n");
 
@@ -190,10 +190,10 @@ void pulsesequence() {
       getstr("dqfXspc5",dqfXspc5);
       spc5 = getspc5("spc5X",0,0.0,0.0,0,1);
       tXspc5ret = spc5.t;
-      strncpy(spc5.ch,"obs",3);
+      strcpy(spc5.ch,"obs");
       if (!strcmp(dqfXspc5,"y")) {
          spc5ref = getspc5("spc5X",spc5.iSuper,spc5.phAccum,spc5.phInt,1,1); 
-         strncpy(spc5ref.ch,"obs",3);
+         strcpy(spc5ref.ch,"obs");
          tXspc5ret = tXspc5ret + spc5.t;
       }
       putCmd("chXspc5='obs'\n");
@@ -209,10 +209,10 @@ void pulsesequence() {
       getstr("dqfXc7",dqfXc7);
       c7 = getpostc7("c7X",0,0.0,0.0,0,1);
       tXc7ret = c7.t;
-      strncpy(c7.ch,"obs",3);
+      strcpy(c7.ch,"obs");
       if (!strcmp(dqfXc7,"y")) {
          c7ref = getpostc7("c7X",c7.iSuper,c7.phAccum,c7.phInt,1,1);
-         strncpy(c7ref.ch,"obs",3);
+         strcpy(c7ref.ch,"obs");
          tXc7ret = tXc7ret + c7.t;
       }
       putCmd("chXc7='obs'\n");


### PR DESCRIPTION
The strncpy sometimes did not copy the entire string Updated Notes.txt