### PR TITLE
Fix all the off by one index errors around sequence names

### DIFF
--- a/src/nvpsg/mpobjects.h
+++ b/src/nvpsg/mpobjects.h
@@ -421,7 +421,7 @@ WMPA getbr24(char *seqName)
 {
    WMPA mp; 
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getbr24 Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -506,7 +506,7 @@ WMPA getmrev8(char *seqName)
 {
    WMPA mp; 
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getmrev8 Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -591,7 +591,7 @@ WMPA getswwhh4(char *seqName)
 {
    WMPA mp; 
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getswwhh4 Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -676,7 +676,7 @@ WMPA getxx(char *seqName)
 {
    WMPA mp; 
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getxx Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }   
@@ -761,7 +761,7 @@ WMPA getxmx(char *seqName)
 {
    WMPA mp; 
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getxmx Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }   
@@ -846,7 +846,7 @@ WMPA gettoss4(char *seqName)
 {
    WMPA mp; 
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("gettoss4 Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -893,7 +893,7 @@ WMPA getidref(char *seqName)
 {
    WMPA mp;
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getidref Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -937,7 +937,7 @@ WMPA getwpmlg(char *seqName)
 {
    WMPA mp; 
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwpmlg Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1064,7 +1064,7 @@ WMPA getwdumbo(char *seqName)
 {
    WMPA mp; 
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwdumbo Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1196,7 +1196,7 @@ WMPA getwdumbot(char *seqName)
 {
    WMPA mp; 
    char *var; 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwdumbot Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }

--- a/src/nvpsg/pboxpulse.h
+++ b/src/nvpsg/pboxpulse.h
@@ -263,7 +263,7 @@ PBOXPULSE getpboxpulse(char *seqName, int iRec, int calc)
    PBOXPULSE shp;
    char *var;
    char cmd[MAXSTR];
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getpboxpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -371,7 +371,7 @@ PBOXPULSE getrefpboxpulse(char *seqName, int iRec, int calc)
    PBOXPULSE shp;
    char *var;
    char cmd[MAXSTR];
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getpsoftpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }

--- a/src/nvpsg/solidchoppers.h
+++ b/src/nvpsg/solidchoppers.h
@@ -520,7 +520,7 @@ SHAPE make_shape1(SHAPE s)
 SHAPE genericInitShape(SHAPE s, char *name, double p, double phint, int iRec)
 {
    char *var;
-   if ((strlen(name) > NSUFFIX) || (strlen(name)) < 2) {
+   if ((strlen(name) >= NSUFFIX) || (strlen(name)) < 2) {
       printf("Error in genericInitShape()! The  name %s is invalid !\n",name);
       psg_abort(-1);
    }
@@ -582,7 +582,7 @@ SHAPE genericInitShape(SHAPE s, char *name, double p, double phint, int iRec)
 SHAPE genericInitShape1(SHAPE s, char *name, double p, double phint, int iRec)
 {
    char *var;
-   if ((strlen(name) > NSUFFIX) || (strlen(name)) < 2) {
+   if ((strlen(name) >= NSUFFIX) || (strlen(name)) < 2) {
       printf("Error in genericInitShape()! The  name %s is invalid !\n",name);
       psg_abort(-1);
    }

--- a/src/nvpsg/solidhhdec.h
+++ b/src/nvpsg/solidhhdec.h
@@ -833,7 +833,7 @@ MPSEQ getpmlgsuper(char *seqName, int iph ,double p, double phint, int iRec, int
    char *var;
    extern MPSEQ MPchopper(MPSEQ pm);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getpmlgsuper(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }

--- a/src/nvpsg/solidmisc.h
+++ b/src/nvpsg/solidmisc.h
@@ -355,7 +355,7 @@ MPSEQ getr1426(char *seqName, int iph, double p, double phint, int iRec )
    MPSEQ r; 
    extern MPSEQ MPchopper(MPSEQ r);
    char *var;   
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
         printf("Error in makeMPSEQ! The type name %s is invalid !\n",seqName);
         exit(-1);
    } 
@@ -427,7 +427,7 @@ MPSEQ getr1825(char *seqName, int iph, double p, double phint, int iRec )
    MPSEQ r; 
    extern MPSEQ MPchopper(MPSEQ r);
    char *var;   
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
         printf("Error in makeMPSEQ! The type name %s is invalid !\n",seqName);
         exit(-1);
    } 
@@ -498,7 +498,7 @@ MPSEQ getspc5(char *seqName, int iph, double p, double phint, int iRec )
    extern MPSEQ MPchopper(MPSEQ spc5);
    char *var;
    
-    if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
         printf("Error in makeMPSEQ! The type name %s is invalid !\n",seqName);
         exit(-1);
    }   
@@ -581,7 +581,7 @@ MPSEQ getpostc7(char *seqName, int iph, double p, double phint, int iRec)
    extern MPSEQ MPchopper(MPSEQ c7);
    int i;
  
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
         printf("Error in makeMPSEQ! The type name %s is invalid !\n",seqName);
         exit(-1);
    }  
@@ -664,7 +664,7 @@ MPSEQ1 getfslg1(char *seqName, int iph, double p, double phint, int iRec)
    MPSEQ1 f;
    extern MPSEQ1 MPchopper1(MPSEQ1 f);
    
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
         printf("Error in makeMPSEQ1! The type name %s is invalid !\n",seqName);
         exit(-1);
    }  
@@ -746,7 +746,7 @@ MPSEQ getpmlg(char *seqName, int iph,double p, double phint, int iRec)
    char *var; 
    extern MPSEQ MPchopper(MPSEQ pm); 
    
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
       printf("Error in makeMPSEQ! The type name %s is invalid !\n",seqName);
       exit(-1);
    }  
@@ -853,7 +853,7 @@ MPSEQ getblew(char *seqName, int iph,double p, double phint, int iRec)
    char *var; 
    extern MPSEQ MPchopper(MPSEQ pm); 
    
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
       printf("Error in makeMPSEQ! The type name %s is invalid !\n",seqName);
       exit(-1);
    }  
@@ -938,7 +938,7 @@ MPSEQ getdumbo(char *seqName, int iph,double p, double phint, int iRec)
    char *var; 
    extern MPSEQ MPchopper(MPSEQ pm); 
    
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
       printf("Error in makeMPSEQ! The type name %s is invalid !\n",seqName);
       exit(-1);
    }  
@@ -1038,7 +1038,7 @@ WMPSEQ getbaba(char *seqName, int iph, double p, double phint, int iRec)
    WMPSEQ baba;
    extern WMPSEQ WMPchopper(WMPSEQ baba);
    
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
         printf("Error in makeWMPSEQ! The type name %s is invalid !\n",seqName);
         exit(-1);
    }  
@@ -1154,7 +1154,7 @@ WMPSEQ getxy8(char *seqName, int iph, double p, double phint, int iRec)
    WMPSEQ xy8;
    extern WMPSEQ WMPchopper(WMPSEQ xy8);
    
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1){
         printf("Error in makeWMPSEQ! The type name %s is invalid !\n",seqName);
         exit(-1);
    }  
@@ -1252,7 +1252,7 @@ CP getcp(char *seqName, double p, double phint, int iRec)
    cp.phInt = phint;
    cp.nRec = iRec;
    
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 2){
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 2){
       printf("Error in makeCP! The type name %s is invalid !\n",seqName);
       exit(-1);
    }

--- a/src/nvpsg/solidmpseqs.h
+++ b/src/nvpsg/solidmpseqs.h
@@ -80,7 +80,7 @@ RAMP getramp(char *seqName, double p, double phint, int iRec, int calc)
    r.offstdelay = WFG_OFFSET_DELAY;
    r.apdelay = PWRF_DELAY;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 2) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 2) {
       printf("Error in getramp(). The sequence name %s is invalid!\n",seqName);
       psg_abort(-1);
    }
@@ -175,7 +175,7 @@ MPSEQ getms(char *seqName, int iph, double p, double phint, int iRec, int calc)
    extern MPSEQ MPchopper(MPSEQ m);
    char *var;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 2) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 2) {
       printf("Error in getms(). The sequence name %s is invalid!\n",seqName);
       psg_abort(-1);
    }
@@ -300,7 +300,7 @@ MPSEQ getpul(char *seqName, int iph, double p, double phint, int iRec, int calc)
    extern MPSEQ MPchopper(MPSEQ pul);
    char *var;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 2) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 2) {
       printf("Error in getpuls(). The sequence name %s is invalid!\n",seqName);
       psg_abort(-1);
    }
@@ -415,7 +415,7 @@ MPSEQ getpasl(char *seqName,int iph,double p, double phint, int iRec, int calc)
    f.iSuper = iph;
    f.nRec = iRec;
    f.phInt = phint;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 2) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 2) {
       printf("Error in getpuls(). The sequence name %s is invalid!\n",seqName);
       psg_abort(-1);
    }
@@ -545,7 +545,7 @@ MPSEQ getr1235(char *seqName, int iph, double p, double phint, int iRec, int cal
    r.iSuper = iph;
    r.nRec = iRec;
    r.phInt = phint;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getr1235(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    } 
@@ -685,7 +685,7 @@ MPSEQ getr1426(char *seqName, int iph, double p, double phint, int iRec, int cal
    MPSEQ r;
    extern MPSEQ MPchopper(MPSEQ r);
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getr1426(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -802,7 +802,7 @@ MPSEQ getr1825(char *seqName, int iph, double p, double phint, int iRec, int cal
    MPSEQ r;
    extern MPSEQ MPchopper(MPSEQ r);
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getr1825(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -917,7 +917,7 @@ MPSEQ getspc5(char *seqName, int iph, double p, double phint, int iRec, int calc
    extern MPSEQ MPchopper(MPSEQ spc5);
    char *var;
 
-    if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getspc5(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -1044,7 +1044,7 @@ MPSEQ getpostc7(char *seqName, int iph, double p, double phint, int iRec, int ca
    extern MPSEQ MPchopper(MPSEQ c7);
    int i;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getpostc7(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -1164,7 +1164,7 @@ MPSEQ getfslg(char *seqName, int iph, double p, double phint, int iRec, int calc
    MPSEQ f;
    extern MPSEQ MPchopper(MPSEQ f);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getfslg1(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -1288,7 +1288,7 @@ MPSEQ getpmlg(char *seqName, int iph ,double p, double phint, int iRec, int calc
    char *var;
    extern MPSEQ MPchopper(MPSEQ pm);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getpmlg(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -1435,7 +1435,7 @@ MPSEQ getblew(char *seqName, int iph, double p, double phint, int iRec, int calc
    char *var;
    extern MPSEQ MPchopper(MPSEQ pm);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getblew(). The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1564,7 +1564,7 @@ MPSEQ getdumbo(char *seqName, int iph, double p, double phint, int iRec, int cal
    int i;
    char *var;
    extern MPSEQ MPchopper(MPSEQ pm);
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getdumbo(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -1705,7 +1705,7 @@ MPSEQ getbaba(char *seqName, int iph, double p, double phint, int iRec, int calc
    MPSEQ baba;
    extern MPSEQ MPchopper(MPSEQ baba);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getbaba(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -1862,7 +1862,7 @@ MPSEQ getxy8(char *seqName, int iph, double p, double phint, int iRec, int calc)
    MPSEQ xy8;
    extern MPSEQ MPchopper(MPSEQ xy8);
    
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getxy8(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -1998,7 +1998,7 @@ CP getcp(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    extern CP make_cp(CP cp);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 2) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 2) {
       printf("Error in getcp(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -2129,7 +2129,7 @@ DREAM getdream(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    extern DREAM make_dream(DREAM d);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getdream! The sequence name %s is invalid !\n",seqName);
       psg_abort(-1);
    }
@@ -2283,7 +2283,7 @@ MPSEQ getdraws(char *seqName, int iph, double p, double phint, int iRec, int cal
    extern MPSEQ MPchopper(MPSEQ r);
    char *var;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getdraws(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -2426,7 +2426,7 @@ MPSEQ getrapt(char *seqName, double p, double phint, int iRec, int calc)
    extern MPSEQ MPchopper(MPSEQ r);
    char *var;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getrapt(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -2554,7 +2554,7 @@ MPSEQ getgrapt(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    int i;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getgrapt(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -2721,7 +2721,7 @@ MPSEQ getpipsxy(char *seqName, int iph, double p, double phint, int iRec, int ca
    char *var;
    MPSEQ pips;
    extern MPSEQ MPchopper(MPSEQ pips);
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getpips(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -2859,7 +2859,7 @@ MPSEQ getsr4(char *seqName, int iph, double p, double phint, int iRec, int calc)
    MPSEQ r;
    extern MPSEQ MPchopper(MPSEQ r);
    char *var;   
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getsr4(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -2994,7 +2994,7 @@ MPSEQ getsammyd(char *seqName, int iph, double p, double phint, int iRec, int ca
    char *var;
    MPSEQ sd;
    extern MPSEQ MPchopper(MPSEQ sd);
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getsammyd(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -3152,7 +3152,7 @@ MPSEQ getsammyo(char *seqName, int iph, double p, double phint, int iRec, int ca
    char *var;
    MPSEQ so;
    extern MPSEQ MPchopper(MPSEQ so);
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getsammyo(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -3286,7 +3286,7 @@ MPSEQ getlg(char *seqName, int iph, double p, double phint, int iRec, int calc)
    char *var;
    MPSEQ f;
    extern MPSEQ MPchopper(MPSEQ f);
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getlg(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -3403,7 +3403,7 @@ MPSEQ getrfdrxy8(char *seqName, int iph, double p, double phint, int iRec, int c
    char *var;
    MPSEQ xy8;
    extern MPSEQ MPchopper(MPSEQ xy8);
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getrfdrxy8(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -3547,7 +3547,7 @@ MPSEQ getseac7(char *seqName, int iph, double p, double phint, int iRec, int cal
    char *var;
    extern MPSEQ MPchopper(MPSEQ seac7);
    int i,j,k;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getseac7(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -3714,7 +3714,7 @@ MPSEQ getsc14(char *seqName, int iph, double p, double phint, int iRec, int calc
    extern MPSEQ MPchopper(MPSEQ sc14);
    char *var;
    int i;
-    if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getsc14(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
     }
@@ -3827,7 +3827,7 @@ MPSEQ getptrfdr(char *seqName, int iph, double p, double phint, int iRec, int ca
    MPSEQ pt;
    extern MPSEQ MPchopper(MPSEQ pt);
    int index;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getptrfdr(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -3962,7 +3962,7 @@ MPSEQ getfprfdr(char *seqName, int iph, double p, double phint, int iRec, int ca
    MPSEQ fp;
    extern MPSEQ MPchopper(MPSEQ fp);
    int index;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getfprfdr(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -4095,7 +4095,7 @@ MPSEQ getspnl(char *seqName, int iph, double p, double phint, int iRec, int calc
    MPSEQ spnl;
    extern MPSEQ MPchopper(MPSEQ spnl);
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getspnl(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -4240,7 +4240,7 @@ MPSEQ getr1817(char *seqName, int iph, double p, double phint, int iRec, int cal
    MPSEQ r;
    extern MPSEQ MPchopper(MPSEQ r);
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getr1817(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -4345,7 +4345,7 @@ MPSEQ gettmrev5(char *seqName, int iph, double p, double phint, int iRec, int ca
    char *var;
    MPSEQ tm;
    extern MPSEQ MPchopper(MPSEQ tm);
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in gettmrev(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -4489,7 +4489,7 @@ MPSEQ getpxy(char *seqName, int iph, double p, double phint, int iRec, int calc)
    char *var;
    MPSEQ pxy;
    extern MPSEQ MPchopper(MPSEQ pxy);
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getpxy(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -4607,7 +4607,7 @@ MPSEQ getsamn(char *seqName, int iph, double p, double phint, int iRec, int calc
    char *var;
    extern MPSEQ MPchopper(MPSEQ pm);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getsamn(). The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -4737,7 +4737,7 @@ MPSEQ getpmlgxmx(char *seqName, int iph ,double p, double phint, int iRec, int c
    char *var;
    extern MPSEQ MPchopper(MPSEQ pm);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getpmlgxmx(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -4884,7 +4884,7 @@ MPSEQ getsuper(char *seqName, int iph, double p, double phint, int iRec, int cal
    MPSEQ super;
    extern MPSEQ MPchopper(MPSEQ super);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getsuper(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -5087,7 +5087,7 @@ MPSEQ getdumboxmx(char *seqName, int iph, double p, double phint, int iRec, int 
    int i;
    char *var;
    extern MPSEQ MPchopper(MPSEQ pm);
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getdumbo(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -5238,7 +5238,7 @@ MPSEQ getdumbogen(char *seqName, char *coeffName, int iph, double p, double phin
    char *var;
    extern MPSEQ MPchopper(MPSEQ dumbo);
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getdumbogeneric(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -5437,7 +5437,7 @@ MPSEQ getsat(char *seqName, double p, double phint, int iRec, int calc)
    MPSEQ s;
    char *var;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getsat(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
@@ -5568,7 +5568,7 @@ MPSEQ getpostc6(char *seqName, int iph, double p, double phint, int iRec, int ca
    extern MPSEQ MPchopper(MPSEQ c6);
    int i;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
         printf("Error in getpostc6(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }

--- a/src/nvpsg/solidobjects.h
+++ b/src/nvpsg/solidobjects.h
@@ -489,7 +489,7 @@ WMPA getbr24(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getbr24() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -574,7 +574,7 @@ WMPA getmrev8(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getmrev8() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -659,7 +659,7 @@ WMPA getswwhh4(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getswwhh4() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -744,7 +744,7 @@ WMPA getxx(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getxx() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -829,7 +829,7 @@ WMPA getxmx(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getxmx() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -914,7 +914,7 @@ WMPA gettoss4(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("gettoss4() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -966,7 +966,7 @@ WMPA gettoss5(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("gettoss5() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1030,7 +1030,7 @@ WMPA getidref(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getidref() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1074,7 +1074,7 @@ WMPA getwpmlg(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwpmlg() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1201,7 +1201,7 @@ GP getinept(char *seqName)
 {
    GP in;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getinept() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1276,7 +1276,7 @@ WMPA getwdumbo(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwdumbo() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1408,7 +1408,7 @@ WMPA getwdumbot(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwdumbot() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1547,7 +1547,7 @@ WMPA getcpmg(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getcpmg() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1634,7 +1634,7 @@ GP gethmqc(char *seqName)
 {
    GP hmqc;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("gethmqc() Error: The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -1691,7 +1691,7 @@ WMPA gethssmall(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("gethssmall() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1796,7 +1796,7 @@ WMPA getxmxwpmlg(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwpmlg() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -1933,7 +1933,7 @@ WMPA getwsamn(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwsamn() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -2060,7 +2060,7 @@ WMPA getwpmlgxmx(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwpmlgxmx() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -2193,7 +2193,7 @@ WMPA getwdumboxmx(char *seqName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwdumboxmx() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -2334,7 +2334,7 @@ WMPA getwdumbogen(char *seqName, char *coeffName)
 {
    WMPA mp;
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwdumbogen() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }

--- a/src/nvpsg/solidpulses.h
+++ b/src/nvpsg/solidpulses.h
@@ -28,7 +28,7 @@ SHAPE getpulse(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    s.get_state = const_state;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -79,7 +79,7 @@ SHAPE getdfspulse(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    s.get_state = dfs_state;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getdfspulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -147,7 +147,7 @@ SHAPE getsfspulse(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    s.get_state = sfs_state;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getsfspulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -215,7 +215,7 @@ SHAPE getsfmpulse(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    s.get_state = sfm_state;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getsfmpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -269,7 +269,7 @@ SHAPE getsinc(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    s.get_state = sinc_state;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getsinc(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -331,7 +331,7 @@ SHAPE gettanramp(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    s.get_state = tanramp_state;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getsfmpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -403,7 +403,7 @@ SHAPE getcpm(char *seqName, double p, double phint, int iRec, int calc)
    char *var;
    s.get_state = cpm_state;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getcpm(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
@@ -464,7 +464,7 @@ SHAPE getdumbogenshp(char *seqName, char *coeffName, double p, double phint, int
    char *var;
    s.get_state = dumbo_state;
 
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("Error in getdumbogenshp(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -1837,7 +1837,7 @@ SHAPE make_shape(SHAPE s)
 SHAPE genericInitShape(SHAPE s, char *name, double p, double phint, int iRec)
 {
    char *var;
-   if ((strlen(name) > NSUFFIX) || (strlen(name)) < 2) {
+   if ((strlen(name) >= NSUFFIX) || (strlen(name)) < 2) {
       printf("Error in genericInitShape! The  name %s is invalid !\n",name);
       psg_abort(-1);
    }

--- a/src/nvpsg/solidwshapes.h
+++ b/src/nvpsg/solidwshapes.h
@@ -81,7 +81,7 @@ WMPSEQ getwdumbogen1(char *seqName, char *coeffName)
 
    //printf("dumbo dur: %f\n",mp.wvsh.mpseq.t);
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwdumbogen() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -190,7 +190,7 @@ WMPSEQ getwdumbogen2(char *seqName, char *coeffName)
 
    //printf("dumbo dur: %f\n",mp.wvsh.mpseq.t);
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwdumbogen() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -381,7 +381,7 @@ WMPSEQ getwpmlgxmx1(char *seqName)
    mp.wvsh.mpseq=getpmlg(seqName,0,0,0,0,1);
 
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwpmlg() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
@@ -504,7 +504,7 @@ WMPSEQ getwsamn1(char *seqName)
    WMPSEQ mp;
    mp.wvsh.mpseq=getsamn(seqName,0,0,0,0,1);
    char *var;
-   if (strlen(seqName) > NSUFFIX  || strlen(seqName) < 1) {
+   if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
       printf("getwsamn() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }


### PR DESCRIPTION
There is a lot of testing in the nvpsg .h files against name length > NSUFFIX. This is the size of the internal structures that store the names. But the test is forgetting the loss of one char to store the NULL char at the end of the string. So I've made all tests check room to include the terminating NULL char of the string. As it is now a string of length NSUFFIX chars will overwrite memory.