### PR TITLE
Make sure memory allocated in solidchoppers.h is freed

### DIFF
--- a/src/nvpsg/solidchoppers.h
+++ b/src/nvpsg/solidchoppers.h
@@ -265,6 +265,7 @@ SHAPE make_shape(SHAPE s)
    }
    s.pars.phAccum = ph; 
    fclose(fp);                                        
+   free(pstub);
    return s;
 }
 
@@ -510,6 +511,7 @@ SHAPE make_shape1(SHAPE s)
    }
    s.pars.phAccum = ph; 
    fclose(fp);                                        
+   free(pstub);
    return s;
 }
 
@@ -918,6 +920,7 @@ MPSEQ MPchopper(MPSEQ seq)
    }
    seq.phAccum = ph;
    fclose(fp);
+   free(pstub);
    return seq;
 }
 
@@ -1175,5 +1178,6 @@ CP make_cp(CP cp)
    }
    cp.phAccum = ph; 
    fclose(fp);                                        
+   free(pstub);
    return cp;
 }


### PR DESCRIPTION
In solidchoppers.h there are four routines thay allocate a var called pstub that it uses to communicate to Bridge.cpp and through there to RFCController.cpp some data points. This memory is never freed after use. You can trace into Bridge and RFC controller to see the passed memory is read but not stored nor freed on the C++ side.