### PR TITLE
Fix more strncpy problems in the solidspack code

### DIFF
--- a/src/solidspack/psglib/babainad2d.c
+++ b/src/solidspack/psglib/babainad2d.c
@@ -30,20 +30,20 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
     
    MPSEQ baba = getbaba("babaX",0,0.0,0.0,0,1);
    MPSEQ babaref = getbaba("babaX",baba.iSuper,baba.phAccum,baba.phInt,1,1);
-   strncpy(baba.ch,"obs",3);
+   strcpy(baba.ch,"obs");
    putCmd("chXbaba='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/br24.c
+++ b/src/solidspack/psglib/br24.c
@@ -24,7 +24,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA br24 = getbr24("br24X");
-   strncpy(br24.ch,"obs",3);
+   strcpy(br24.ch,"obs");
    putCmd("chXbr24='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/br24q.c
+++ b/src/solidspack/psglib/br24q.c
@@ -33,7 +33,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA br24 = getbr24("br24X");
-   strncpy(br24.ch,"obs",3);
+   strcpy(br24.ch,"obs");
    putCmd("chXbr24='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/c7inad2d.c
+++ b/src/solidspack/psglib/c7inad2d.c
@@ -29,20 +29,20 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    MPSEQ c7 = getpostc7("c7X",0,0.0,0.0,0,1);
    MPSEQ c7ref = getpostc7("c7X",c7.iSuper,c7.phAccum,c7.phInt,1,1);
-   strncpy(c7.ch,"obs",3);
+   strcpy(c7.ch,"obs");
    putCmd("chXc7='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/c7inadwdumbogen2d.c
+++ b/src/solidspack/psglib/c7inadwdumbogen2d.c
@@ -45,16 +45,16 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ dumbo = getdumbogen("dumboX","dcf1X",0,0.0,0.0,0,1);
-   strncpy(dumbo.ch,"obs",3); 
+   strcpy(dumbo.ch,"obs"); 
    putCmd("chXdumbo='obs'\n");
 
    MPSEQ c7 = getpostc7("c7X",0,0.0,0.0,0,1);  
    MPSEQ c7ref = getpostc7("c7X",c7.iSuper,c7.phAccum,c7.phInt,1,1);
-   strncpy(c7.ch,"obs",3);
+   strcpy(c7.ch,"obs");
    putCmd("chXc7='obs'\n");
 
    WMPA wdumbo = getwdumbogen("wdumboX","dcfX");
-   strncpy(wdumbo.ch,"obs",3);
+   strcpy(wdumbo.ch,"obs");
    putCmd("chXwdumbo='obs'\n");
 
    double tXzfinit = getval("tXzf");            //Define the Z-filter delay in the sequence

--- a/src/solidspack/psglib/c7inadwdumbot2d.c
+++ b/src/solidspack/psglib/c7inadwdumbot2d.c
@@ -44,16 +44,16 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ dumbo = getdumbo("dumboX",0,0.0,0.0,0,1);
-   strncpy(dumbo.ch,"obs",3); 
+   strcpy(dumbo.ch,"obs"); 
    putCmd("chXdumbo='obs'\n");
 
    MPSEQ c7 = getpostc7("c7X",0,0.0,0.0,0,1);  
    MPSEQ c7ref = getpostc7("c7X",c7.iSuper,c7.phAccum,c7.phInt,1,1);
-   strncpy(c7.ch,"obs",3);
+   strcpy(c7.ch,"obs");
    putCmd("chXc7='obs'\n");
 
    WMPA wdumbot = getwdumbot("wdumbotX");
-   strncpy(wdumbot.ch,"obs",3);
+   strcpy(wdumbot.ch,"obs");
    putCmd("chXwdumbot='obs'\n");
 
    double tXzfinit = getval("tXzf");            //Define the Z-filter delay in the sequence

--- a/src/solidspack/psglib/c7inadwpmlg2d.c
+++ b/src/solidspack/psglib/c7inadwpmlg2d.c
@@ -50,16 +50,16 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ pmlg = getpmlg("pmlgX",0,0.0,0.0,0,1);
-   strncpy(pmlg.ch,"obs",3);
+   strcpy(pmlg.ch,"obs");
    putCmd("chXpmlg='obs'\n");
 
    MPSEQ c7 = getpostc7("c7X",0,0.0,0.0,0,1);
    MPSEQ c7ref = getpostc7("c7X",c7.iSuper,c7.phAccum,c7.phInt,1,1);
-   strncpy(c7.ch,"obs",3);
+   strcpy(c7.ch,"obs");
    putCmd("chXc7='obs'\n");
 
    WMPA wpmlg = getwpmlg("wpmlgX");
-   strncpy(wpmlg.ch,"obs",3);
+   strcpy(wpmlg.ch,"obs");
    putCmd("chXwpmlg='obs'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/codex1d.c
+++ b/src/solidspack/psglib/codex1d.c
@@ -65,21 +65,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
    
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
     
    double srate = getval("srate");

--- a/src/solidspack/psglib/cpcpmg1d.c
+++ b/src/solidspack/psglib/cpcpmg1d.c
@@ -56,13 +56,13 @@ void pulsesequence() {
 //Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    WMPA cpmg = getcpmg("cpmgX");
-   strncpy(cpmg.ch,"obs",3);
+   strcpy(cpmg.ch,"obs");
    putCmd("chXcpmg='obs'\n");
 
    double aXecho = getval("aXecho");  // define the echoX group in the sequence
@@ -75,9 +75,9 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/cpinad2d.c
+++ b/src/solidspack/psglib/cpinad2d.c
@@ -46,8 +46,8 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values 
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
@@ -65,15 +65,15 @@ void pulsesequence() {
    if (d2 < 0.0) d2 = 0.0; 
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ hr = getdseq("Hmix");
-   strncpy(hr.t.ch,"dec",3);
+   strcpy(hr.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(hr.s.ch,"dec",3);
+   strcpy(hr.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/dcp2tan3drad.c
+++ b/src/solidspack/psglib/dcp2tan3drad.c
@@ -39,21 +39,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
      
    CP hy = getcp("HY",0.0,0.0,0,1);
-   strncpy(hy.fr,"dec",3);
-   strncpy(hy.to,"dec2",4);
+   strcpy(hy.fr,"dec");
+   strcpy(hy.to,"dec2");
    putCmd("frHY='dec'\n");
    putCmd("toHY='dec2'\n");
     
    CP yx = getcp("YX",0.0,0.0,0,1);
-   strncpy(yx.fr,"dec2",4);
-   strncpy(yx.to,"obs",3);
+   strcpy(yx.fr,"dec2");
+   strcpy(yx.to,"obs");
    putCmd("frYX='dec2'\n");
    putCmd("toYX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/dcptan.c
+++ b/src/solidspack/psglib/dcptan.c
@@ -33,21 +33,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
      
    CP hy = getcp("HY",0.0,0.0,0,1);
-   strncpy(hy.fr,"dec",3);
-   strncpy(hy.to,"dec2",4);
+   strcpy(hy.fr,"dec");
+   strcpy(hy.to,"dec2");
    putCmd("frHY='dec'\n");
    putCmd("toHY='dec2'\n");
     
    CP yx = getcp("YX",0.0,0.0,0,1);
-   strncpy(yx.fr,"dec2",4);
-   strncpy(yx.to,"obs",3);
+   strcpy(yx.fr,"dec2");
+   strcpy(yx.to,"obs");
    putCmd("frYX='dec2'\n");
    putCmd("toYX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/dcptan3drad.c
+++ b/src/solidspack/psglib/dcptan3drad.c
@@ -39,21 +39,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hy = getcp("HY",0.0,0.0,0,1);
-   strncpy(hy.fr,"dec",3);
-   strncpy(hy.to,"dec2",4);
+   strcpy(hy.fr,"dec");
+   strcpy(hy.to,"dec2");
    putCmd("frHY='dec'\n"); 
    putCmd("toHY='dec2'\n");
 
    CP yx = getcp("YX",0.0,0.0,0,1);
-   strncpy(yx.fr,"dec2",4);
-   strncpy(yx.to,"obs",3);
+   strcpy(yx.fr,"dec2");
+   strcpy(yx.to,"obs");
    putCmd("frYX='dec2'\n");
    putCmd("toYX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/dcptan3dspc5.c
+++ b/src/solidspack/psglib/dcptan3dspc5.c
@@ -39,26 +39,26 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hy = getcp("HY",0.0,0.0,0,1);
-   strncpy(hy.fr,"dec",3);
-   strncpy(hy.to,"dec2",4);
+   strcpy(hy.fr,"dec");
+   strcpy(hy.to,"dec2");
    putCmd("frHY='dec'\n"); 
    putCmd("toHY='dec2'\n");
 
    CP yx = getcp("YX",0.0,0.0,0,1);
-   strncpy(yx.fr,"dec2",4);
-   strncpy(yx.to,"obs",3);
+   strcpy(yx.fr,"dec2");
+   strcpy(yx.to,"obs");
    putCmd("frYX='dec2'\n");
    putCmd("toYX='obs'\n");
    
    MPSEQ spc5 = getspc5("spc5X",0,0.0,0.0,0,1);
    MPSEQ spc5ref = getspc5("spc5X",spc5.iSuper,spc5.phAccum,spc5.phInt,1,1);   
-   strncpy(spc5.ch,"obs",3);
+   strcpy(spc5.ch,"obs");
    putCmd("chXspc5='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/decorcptan2d.c
+++ b/src/solidspack/psglib/decorcptan2d.c
@@ -25,21 +25,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP yx = getcp("YX",0.0,0.0,0,1);
-   strncpy(yx.fr,"dec2",4);
-   strncpy(yx.to,"obs",3);
+   strcpy(yx.fr,"dec2");
+   strcpy(yx.to,"obs");
    putCmd("frYX='dec2'\n");
    putCmd("toYX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ dec2 = getdseq("Y");
-   strncpy(dec2.t.ch,"dec2",4);
+   strcpy(dec2.t.ch,"dec2");
    putCmd("chYtppm='dec2'\n"); 
-   strncpy(dec2.s.ch,"dec2",4);
+   strcpy(dec2.s.ch,"dec2");
    putCmd("chYspinal='dec2'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/dipshftr12dfs.c
+++ b/src/solidspack/psglib/dipshftr12dfs.c
@@ -38,17 +38,17 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    MPSEQ r12 = getr1235("r12H",0,0.0,0.0,0,1);
-   strncpy(r12.ch,"dec",3);
+   strcpy(r12.ch,"dec");
    putCmd("chHr12='dec'\n");
 
    SHAPE dfs = getdfspulse("dfsX",0.0,0.0,0,1);
-   strncpy(dfs.pars.ch,"obs",3);
+   strcpy(dfs.pars.ch,"obs");
    putCmd("chXdfs='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/dipshftsr4dfs.c
+++ b/src/solidspack/psglib/dipshftsr4dfs.c
@@ -40,17 +40,17 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    MPSEQ sr4 = getsr4("sr4H",0,0.0,0.0,0,1);
-   strncpy(sr4.ch,"dec",3);
+   strcpy(sr4.ch,"dec");
    putCmd("chHsr4='dec'\n");
 
    SHAPE dfs = getdfspulse("dfsX",0.0,0.0,0,1);
-   strncpy(dfs.pars.ch,"obs",3);
+   strcpy(dfs.pars.ch,"obs");
    putCmd("chXdfs='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/exsy2d.c
+++ b/src/solidspack/psglib/exsy2d.c
@@ -26,9 +26,9 @@ void pulsesequence() {
    double tXmix=getval("tXmix");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/fsredor.c
+++ b/src/solidspack/psglib/fsredor.c
@@ -34,21 +34,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");   
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ hREDOR = setdseq("R","tppm");
-   strncpy(hREDOR.t.ch,"dec",3);
+   strcpy(hREDOR.t.ch,"dec");
    putCmd("chRtppm='dec'\n"); 
-   strncpy(hREDOR.s.ch,"dec",3);
+   strcpy(hREDOR.s.ch,"dec");
    putCmd("chRspinal='dec'\n");
 
 // Set the Shaped Pulses in n Rotor Periods

--- a/src/solidspack/psglib/grad_profile.c
+++ b/src/solidspack/psglib/grad_profile.c
@@ -25,9 +25,9 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/grad_rec.c
+++ b/src/solidspack/psglib/grad_rec.c
@@ -21,9 +21,9 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/hahnecho1d.c
+++ b/src/solidspack/psglib/hahnecho1d.c
@@ -30,9 +30,9 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/hahnechodfs1d.c
+++ b/src/solidspack/psglib/hahnechodfs1d.c
@@ -26,7 +26,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE dfs = getdfspulse("dfsX",0.0,0.0,0,1);
-   strncpy(dfs.pars.ch,"obs",3);
+   strcpy(dfs.pars.ch,"obs");
    putCmd("chXdfs='obs'\n");
 
 //   dump_shape(dfs);
@@ -41,9 +41,9 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/hetcordumbolgcp2d_1.c
+++ b/src/solidspack/psglib/hetcordumbolgcp2d_1.c
@@ -51,13 +51,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE p1 = getpulse("90H",0.0,0.0,1,0);
-   strncpy(p1.pars.ch,"dec",3);
+   strcpy(p1.pars.ch,"dec");
    putCmd("chH90='dec'\n");
    p1.pars.array = disarry("xx", p1.pars.array);
    p1 = update_shape(p1,0.0,0.0,1);
 
    MPSEQ dh = getdumboxmx("dumboH",0,0.0,0.0,1,0);
-   strncpy(dh.ch,"dec",3);
+   strcpy(dh.ch,"dec");
    putCmd("chHdumbo='dec'\n");
    double pwHdumbo = getval("pwHdumbo");
    dh.nelem = (int) (d2/(pwHdumbo) + 0.1);
@@ -65,7 +65,7 @@ void pulsesequence() {
    dh = update_mpseq(dh,0,p1.pars.phAccum,p1.pars.phInt,1);
 
    SHAPE p2 = getpulse("90H",0.0,0.0,2,0);
-   strncpy(p2.pars.ch,"dec",3);
+   strcpy(p2.pars.ch,"dec");
    putCmd("chH90='dec'\n");
    p2.pars.array = disarry("xx", p2.pars.array);
    p2 = update_shape(p2,dh.phAccum,dh.phInt,2);
@@ -76,15 +76,15 @@ void pulsesequence() {
 // CP hx and DSEQ dec Return to the Reference Phase
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/hetcorlgcp2d.c
+++ b/src/solidspack/psglib/hetcorlgcp2d.c
@@ -38,19 +38,19 @@ void pulsesequence() {
    if (d22 < 0.0) d22 = 0.0;
 
    MPSEQ fh = getfslg("fslgH",0,0.0,0.0,0,1);
-   strncpy(fh.ch,"dec",3);
+   strcpy(fh.ch,"dec");
    putCmd("chHfslg='dec'\n");
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/hetcorlgcp2d_1.c
+++ b/src/solidspack/psglib/hetcorlgcp2d_1.c
@@ -51,13 +51,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE p1 = getpulse("tilt1H",0.0,0.0,1,0);
-   strncpy(p1.pars.ch,"dec",3);
+   strcpy(p1.pars.ch,"dec");
    putCmd("chHtilt1='dec'\n");
    p1.pars.array = disarry("xx", p1.pars.array);
    p1 = update_shape(p1,0.0,0.0,1);
 
    MPSEQ fh = getfslg("fslgH",0,0.0,0.0,1,0);
-   strncpy(fh.ch,"dec",3);
+   strcpy(fh.ch,"dec");
    putCmd("chHfslg='dec'\n");
    double pwHfslg = getval("pwHfslg");   
    fh.nelem = (int) (d2/(2.0*pwHfslg) + 0.1);
@@ -65,13 +65,13 @@ void pulsesequence() {
    fh = update_mpseq(fh,0,p1.pars.phAccum,p1.pars.phInt,1);   
 
    SHAPE p2 = getpulse("tilt2H",0.0,0.0,1,0);
-   strncpy(p2.pars.ch,"dec",3);
+   strcpy(p2.pars.ch,"dec");
    putCmd("chHtilt2='dec'\n");
    p2.pars.array = disarry("xx", p2.pars.array);
    p2 = update_shape(p2,fh.phAccum,fh.phInt,1);
 
    SHAPE p3 = getpulse("tilt3H",0.0,0.0,1,0);
-   strncpy(p3.pars.ch,"dec",3);
+   strcpy(p3.pars.ch,"dec");
    putCmd("chHtilt3='dec'\n");
    p3.pars.array = disarry("xx", p3.pars.array);
    p3 = update_shape(p3,p2.pars.phAccum,p2.pars.phInt,1); 
@@ -82,15 +82,15 @@ void pulsesequence() {
 // CP hx and DSEQ dec Return to the Reference Phase
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/hetcorlgcp2dxyr.c
+++ b/src/solidspack/psglib/hetcorlgcp2dxyr.c
@@ -46,10 +46,10 @@ void pulsesequence() {
    extern int NUMch;
 
    SHAPE p1 = getpulse("tiltH",0.0,0.0,0,1);
-   strncpy(p1.pars.ch,"dec",3);
+   strcpy(p1.pars.ch,"dec");
 
    MPSEQ fh = getfslg("fslgH",0,0.0,0.0,0,1);
-   strncpy(fh.ch,"dec",3);
+   strcpy(fh.ch,"dec");
    putCmd("chHfslg='dec'\n");
    double pwHfslg = getval("pwHfslg");
    fh.nelem = (int) (d2/(2.0*pwHfslg) + 0.1);
@@ -57,7 +57,7 @@ void pulsesequence() {
    fh = update_mpseq(fh,0,p1.pars.phAccum,p1.pars.phInt,1);
 
    SHAPE p2 = getpulse("tiltH",0.0,0.0,0,1);
-   strncpy(p2.pars.ch,"dec",3);
+   strcpy(p2.pars.ch,"dec");
    putCmd("chHtilt='dec'\n");
    p2.pars.hasArray = 1;
    p2 = update_shape(p2,fh.phAccum,fh.phInt,2);
@@ -71,23 +71,23 @@ void pulsesequence() {
 // CP hx RAMP ry and DSEQ dec Return to the Reference Phase
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec2",4);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec2");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec2'\n");
    putCmd("toHX='obs'\n");
 
    RAMP ry = getramp("rampY",0.0,0.0,0,1);
-   strncpy(ry.ch,"dec",3);
+   strcpy(ry.ch,"dec");
    putCmd("chYramp='dec'\n");
-   strncpy(ry.pol,"du",2);
+   strcpy(ry.pol,"du");
    putCmd("chYramp='dec'\n");
    ry.t = getval("tHX");
    putCmd("tYramp = tHX\n");
 
    DSEQ dec2 = getdseq("H");
-   strncpy(dec2.t.ch,"dec2",4);
+   strcpy(dec2.t.ch,"dec2");
    putCmd("chHtppm='dec2'\n"); 
-   strncpy(dec2.s.ch,"dec2",4);
+   strcpy(dec2.s.ch,"dec2");
    putCmd("chHspinal='dec2'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/hetcorpmlgcp2d_1.c
+++ b/src/solidspack/psglib/hetcorpmlgcp2d_1.c
@@ -51,13 +51,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE p1 = getpulse("90H",0.0,0.0,1,0);
-   strncpy(p1.pars.ch,"dec",3);
+   strcpy(p1.pars.ch,"dec");
    putCmd("chH90='dec'\n");
    p1.pars.array = disarry("xx", p1.pars.array);
    p1 = update_shape(p1,0.0,0.0,1);
 
    MPSEQ ph = getpmlgxmx("pmlgH",0,0.0,0.0,1,0);
-   strncpy(ph.ch,"dec",3);
+   strcpy(ph.ch,"dec");
    putCmd("chHpmlg='dec'\n");
    double pwHpmlg = getval("pwHpmlg");
    ph.nelem = (int) (d2/(2.0*pwHpmlg) + 0.1);
@@ -65,7 +65,7 @@ void pulsesequence() {
    ph = update_mpseq(ph,0,p1.pars.phAccum,p1.pars.phInt,1);
 
    SHAPE p2 = getpulse("90H",0.0,0.0,2,0);
-   strncpy(p2.pars.ch,"dec",3);
+   strcpy(p2.pars.ch,"dec");
    putCmd("chH90='dec'\n");
    p2.pars.array = disarry("xx", p2.pars.array);
    p2 = update_shape(p2,ph.phAccum,ph.phInt,2);
@@ -76,15 +76,15 @@ void pulsesequence() {
 // CP hx and DSEQ dec Return to the Reference Phase
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/hetcorsamlgcp2d_1.c
+++ b/src/solidspack/psglib/hetcorsamlgcp2d_1.c
@@ -49,13 +49,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE p1 = getpulse("90H",0.0,0.0,1,0);
-   strncpy(p1.pars.ch,"dec",3);
+   strcpy(p1.pars.ch,"dec");
    putCmd("chH90='dec'\n");
    p1.pars.array = disarry("xx", p1.pars.array);
    p1 = update_shape(p1,0.0,0.0,1);
 
    MPSEQ sh = getsamn("samH",0,0.0,0.0,1,0);
-   strncpy(sh.ch,"dec",3);
+   strcpy(sh.ch,"dec");
    putCmd("chHsam='dec'\n");
    double pwHsam = getval("pwHsam");
    sh.nelem = (int) (d2/(pwHsam) + 0.1);
@@ -63,7 +63,7 @@ void pulsesequence() {
    sh = update_mpseq(sh,0,p1.pars.phAccum,p1.pars.phInt,1);  
 
    SHAPE p2 = getpulse("90H",0.0,0.0,2,0);
-   strncpy(p2.pars.ch,"dec",3);
+   strcpy(p2.pars.ch,"dec");
    putCmd("chH90='dec'\n");
    p2.pars.array = disarry("xx", p2.pars.array);
    p2 = update_shape(p2,sh.phAccum,sh.phInt,2);
@@ -74,15 +74,15 @@ void pulsesequence() {
 // CP hx and DSEQ dec Return to the Reference Phase
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/hetcortancp2d.c
+++ b/src/solidspack/psglib/hetcortancp2d.c
@@ -31,19 +31,19 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ fh = getfslg("fslgH",0,0.0,0.0,0,1);
-   strncpy(fh.ch,"dec",3);
+   strcpy(fh.ch,"dec");
    putCmd("chHfslg='dec'\n");
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/hh2dhdec.c
+++ b/src/solidspack/psglib/hh2dhdec.c
@@ -38,9 +38,9 @@ void pulsesequence() {
    char Xseq[MAXSTR];
    getstr("Xseq",Xseq);
    DSEQ dec = getdseq("X");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chXtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chXspinal='dec'\n");
 
 //---------------------------
@@ -48,7 +48,7 @@ void pulsesequence() {
 //---------------------------
 
    MPDEC homo1 = getmpdec("hdec1H",0,0.0,0.0,0,1);
-   strncpy(homo1.mps.ch,"obs",3);
+   strcpy(homo1.mps.ch,"obs");
    putCmd("chHhdec1='obs'\n"); 
 
 //---------------------------------------------

--- a/src/solidspack/psglib/hssmall.c
+++ b/src/solidspack/psglib/hssmall.c
@@ -24,7 +24,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA hs = gethssmall("hssmallX");
-   strncpy(hs.ch,"obs",3);
+   strcpy(hs.ch,"obs");
    putCmd("chXhssmall='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/idHetcor.c
+++ b/src/solidspack/psglib/idHetcor.c
@@ -73,8 +73,8 @@ void pulsesequence() {
 // --------------------------------
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"obs",3);
-   strncpy(hx.to,"dec",3);
+   strcpy(hx.fr,"obs");
+   strcpy(hx.to,"dec");
    putCmd("frHX='obs'\n"); 
    putCmd("toHX='dec'\n");
    
@@ -83,8 +83,8 @@ void pulsesequence() {
 // --------------------------------
 
    CP xh = getcp("XH",0.0,0.0,0,1);
-   strncpy(xh.fr,"dec",3);
-   strncpy(xh.to,"obs",3);
+   strcpy(xh.fr,"dec");
+   strcpy(xh.to,"obs");
    putCmd("frXH='dec'\n"); 
    putCmd("toXH='obs'\n"); 
 
@@ -95,9 +95,9 @@ void pulsesequence() {
    char Xseq[MAXSTR];
    getstr("Xseq",Xseq);
    DSEQ dec = getdseq("X");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chXtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chXspinal='dec'\n"); 
 
 //--------------------
@@ -109,9 +109,9 @@ void pulsesequence() {
    getstr("Hseq",Hseq);
    if (strcmp(Hseq,"pipulse") != 0) {
       obs = getdseq("H");
-      strncpy(obs.t.ch,"obs",3);
+      strcpy(obs.t.ch,"obs");
       putCmd("chHtppm='obs'\n");
-      strncpy(obs.s.ch,"obs",3);
+      strcpy(obs.s.ch,"obs");
       putCmd("chHspinal='obs'\n");
    }
 // ---------------------------------------------

--- a/src/solidspack/psglib/idInept.c
+++ b/src/solidspack/psglib/idInept.c
@@ -58,8 +58,8 @@ void pulsesequence() {
 // --------------------------------
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"obs",3);
-   strncpy(hx.to,"dec",3);
+   strcpy(hx.fr,"obs");
+   strcpy(hx.to,"dec");
    putCmd("frHX='obs'\n"); 
    putCmd("toHX='dec'\n");
 
@@ -68,8 +68,8 @@ void pulsesequence() {
 // --------------------------------
 
    GP inept = getinept("ineptXH");
-   strncpy(inept.ch1,"dec",3);
-   strncpy(inept.ch2,"obs",3);
+   strcpy(inept.ch1,"dec");
+   strcpy(inept.ch2,"obs");
    putCmd("ch1XHinept='dec'\n");
    putCmd("ch2XHinept='obs'\n");
 
@@ -83,9 +83,9 @@ void pulsesequence() {
    char Xseq[MAXSTR];
    getstr("Xseq",Xseq);
    DSEQ dec = getdseq("X");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chXtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chXspinal='dec'\n"); 
 
 //--------------------
@@ -97,9 +97,9 @@ void pulsesequence() {
    getstr("Hseq",Hseq);
    if (strcmp(Hseq,"pipulse") != 0) {
       obs = getdseq("H");
-      strncpy(obs.t.ch,"obs",3);
+      strcpy(obs.t.ch,"obs");
       putCmd("chHtppm='obs'\n");
-      strncpy(obs.s.ch,"obs",3);
+      strcpy(obs.s.ch,"obs");
       putCmd("chHspinal='obs'\n");
    }
 //-------------------------------------
@@ -107,10 +107,10 @@ void pulsesequence() {
 //-------------------------------------
 
    MPDEC homo1 = getmpdec("hdec1H",0,0.0,0.0,0,1);
-   strncpy(homo1.mps.ch,"obs",3);
+   strcpy(homo1.mps.ch,"obs");
    putCmd("chHhdec1='obs'\n"); 
    MPDEC homo2 = getmpdec("hdec2H",0,0.0,0.0,0,1);
-   strncpy(homo2.mps.ch,"obs",3);
+   strcpy(homo2.mps.ch,"obs");
    putCmd("chHhdec2='obs'\n"); 
 
 // ---------------------------------------------

--- a/src/solidspack/psglib/ineptxyonepul.c
+++ b/src/solidspack/psglib/ineptxyonepul.c
@@ -32,21 +32,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    GP inept = getinept("ineptYX");
-   strncpy(inept.ch1,"dec2",4);
-   strncpy(inept.ch2,"obs",3);
+   strcpy(inept.ch1,"dec2");
+   strcpy(inept.ch2,"obs");
    putCmd("ch1YXinept='dec2'\n");
    putCmd("ch2YXinept='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/ineptxyrefonepul.c
+++ b/src/solidspack/psglib/ineptxyrefonepul.c
@@ -36,21 +36,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    GP inept = getinept("ineptYX");
-   strncpy(inept.ch1,"dec2",4);
-   strncpy(inept.ch2,"obs",3);
+   strcpy(inept.ch1,"dec2");
+   strcpy(inept.ch2,"obs");
    putCmd("ch1YXinept='dec2'\n");
    putCmd("ch2YXinept='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/ineptxyreftancp.c
+++ b/src/solidspack/psglib/ineptxyreftancp.c
@@ -40,27 +40,27 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hy = getcp("HY",0.0,0.0,0,1);
-   strncpy(hy.fr,"dec",3);
-   strncpy(hy.to,"dec2",4);
+   strcpy(hy.fr,"dec");
+   strcpy(hy.to,"dec2");
    putCmd("frHY='dec'\n");
    putCmd("toHY='dec2'\n");
 
    GP inept = getinept("ineptYX");
-   strncpy(inept.ch1,"dec2",4);
-   strncpy(inept.ch2,"obs",3);
+   strcpy(inept.ch1,"dec2");
+   strcpy(inept.ch2,"obs");
    putCmd("ch1YXinept='dec2'\n");
    putCmd("ch2YXinept='obs'\n");
    
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 // Dutycycle Protection

--- a/src/solidspack/psglib/ineptxytancp.c
+++ b/src/solidspack/psglib/ineptxytancp.c
@@ -36,27 +36,27 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hy = getcp("HY",0.0,0.0,0,1);
-   strncpy(hy.fr,"dec",3);
-   strncpy(hy.to,"dec2",4);
+   strcpy(hy.fr,"dec");
+   strcpy(hy.to,"dec2");
    putCmd("frHY='dec'\n");
    putCmd("toHY='dec2'\n");
 
    GP inept = getinept("ineptYX");
-   strncpy(inept.ch1,"dec2",4);
-   strncpy(inept.ch2,"obs",3);
+   strcpy(inept.ch1,"dec2");
+   strcpy(inept.ch2,"obs");
    putCmd("ch1YXinept='dec2'\n");
    putCmd("ch2YXinept='obs'\n");
    
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n"); 
 
 //--------------------------------------

--- a/src/solidspack/psglib/jmascaco2d.c
+++ b/src/solidspack/psglib/jmascaco2d.c
@@ -37,21 +37,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n");
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
    double d22 = d2/2.0;

--- a/src/solidspack/psglib/jmascacoipap2d.c
+++ b/src/solidspack/psglib/jmascacoipap2d.c
@@ -43,21 +43,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n");
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
    double d22 = d2/2.0;

--- a/src/solidspack/psglib/jmascacosh2d.c
+++ b/src/solidspack/psglib/jmascacosh2d.c
@@ -39,31 +39,31 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    PBOXPULSE shca = getpboxpulse("shcaX",0,1);
-   strncpy(shca.ch,"obs",3);
+   strcpy(shca.ch,"obs");
    putCmd("chXshca ='obs'\n");
 
    PBOXPULSE shco = getpboxpulse("shcoX",0,1);
-   strncpy(shco.ch,"obs",3);
+   strcpy(shco.ch,"obs");
    putCmd("chXshco ='obs'\n");
 
    PBOXPULSE shcaco = combine_PBOXPULSE(shca,shco,0,1); 
 
    DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix"); 
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n");
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
    double shcacolen = (shcaco.pw + 2.0*shcaco.t2)/2.0;

--- a/src/solidspack/psglib/jmasnca2d.c
+++ b/src/solidspack/psglib/jmasnca2d.c
@@ -56,33 +56,33 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hy = getcp("HY",0.0,0.0,0,1);
-   strncpy(hy.fr,"dec",3);
-   strncpy(hy.to,"dec2",4);
+   strcpy(hy.fr,"dec");
+   strcpy(hy.to,"dec2");
    putCmd("frHY='dec'\n");
    putCmd("toHY='dec2'\n");
 
    PBOXPULSE shca = getpboxpulse("shcaX",0,1);
-   strncpy(shca.ch,"obs",3);
+   strcpy(shca.ch,"obs");
    putCmd("chXshca ='obs'\n");
 
    PBOXPULSE sh = getpboxpulse("shY",0,1);
-   strncpy(sh.ch,"dec2",4);
+   strcpy(sh.ch,"dec2");
    putCmd("chYsh ='dec2'\n");
 
    PBOXPULSE shco = getpboxpulse("shcoX",0,1);
-   strncpy(shco.ch,"obs",3);
+   strcpy(shco.ch,"obs");
    putCmd("chXshco ='obs'\n"); 
 
    DSEQ dec = getdseq("H");   
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n");
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
    double pwsim = getval("pwX90"); 

--- a/src/solidspack/psglib/jmasnco2d.c
+++ b/src/solidspack/psglib/jmasnco2d.c
@@ -55,33 +55,33 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hy = getcp("HY",0.0,0.0,0,1);
-   strncpy(hy.fr,"dec",3);
-   strncpy(hy.to,"dec2",4);
+   strcpy(hy.fr,"dec");
+   strcpy(hy.to,"dec2");
    putCmd("frHY='dec'\n");
    putCmd("toHY='dec2'\n");
 
    PBOXPULSE shco = getpboxpulse("shcoX",0,1);
-   strncpy(shco.ch,"obs",3);
+   strcpy(shco.ch,"obs");
    putCmd("chXshco ='obs'\n");
 
    PBOXPULSE sh = getpboxpulse("shY",0,1);
-   strncpy(sh.ch,"dec2",4);
+   strcpy(sh.ch,"dec2");
    putCmd("chYsh ='dec2'\n");
 
    PBOXPULSE shca = getpboxpulse("shcaX",0,1);
-   strncpy(shca.ch,"obs",3);
+   strcpy(shca.ch,"obs");
    putCmd("chXshca ='obs'\n");  
  
    DSEQ dec = getdseq("H");  
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n");
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
    double pwsim = getval("pwX90"); 

--- a/src/solidspack/psglib/lgcp.c
+++ b/src/solidspack/psglib/lgcp.c
@@ -27,15 +27,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/lgcp2d.c
+++ b/src/solidspack/psglib/lgcp2d.c
@@ -38,21 +38,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values 
 
    MPSEQ hlg = getlg("lgH",0,0.0,0.0,0,0);
-   strncpy(hlg.ch,"dec",3);
+   strcpy(hlg.ch,"dec");
    putCmd("chHlg = 'dec'\n"); 
    hlg.pw[0] = d2_ + 1.0/sw1;
    hlg = update_mpseq(hlg,0,0.0,0.0,0);
 
    MPSEQ  xlg = getlg("lgX",0,0.0,0.0,0,0);
-   strncpy(xlg.ch,"obs",3);
+   strcpy(xlg.ch,"obs");
    putCmd("chXlg = 'obs'\n");
    xlg.pw[0] = d2_ + 1.0/sw1;
    xlg = update_mpseq(xlg,0,0.0,0.0,0);
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    printf("hithere\n");

--- a/src/solidspack/psglib/lgfmcp1d.c
+++ b/src/solidspack/psglib/lgfmcp1d.c
@@ -26,20 +26,20 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values 
 
    SHAPE xsfm = getsfmpulse("sfmX",0.0,0.0,0,1);
-   strncpy(xsfm.pars.ch,"obs",3);
+   strcpy(xsfm.pars.ch,"obs");
    putCmd("chXsfm = 'obs'\n");
 
    MPSEQ hlg = getlg("lgH",0,0.0,0.0,0,0);
    hlg.pw[0] = xsfm.pars.t; 
    hlg.array = disarry("pwXsfm",hlg.array); 
    hlg = update_mpseq(hlg,0,0.0,0.0,0);
-   strncpy(hlg.ch,"dec",3);
+   strcpy(hlg.ch,"dec");
    putCmd("chHlg = 'dec'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/masapt1d.c
+++ b/src/solidspack/psglib/masapt1d.c
@@ -38,7 +38,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ fh = getfslg("fslgH",0,0.0,0.0,0,1);
-   strncpy(fh.ch,"dec",3);
+   strcpy(fh.ch,"dec");
    putCmd("chHfslg='dec'\n");
 
    double tHXaptfinit = getval("tHXaptf"); //parameters for aptHX implemented
@@ -64,15 +64,15 @@ void pulsesequence() {
    }
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/mashmqc2d.c
+++ b/src/solidspack/psglib/mashmqc2d.c
@@ -57,7 +57,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ fh = getfslg("fslgH",0,0.0,0.0,0,1);
-   strncpy(fh.ch,"dec",3);
+   strcpy(fh.ch,"dec");
    putCmd("chHfslg='dec'\n");
 
    double tHXhmqc = getval("tHXhmqc");     //parameters for hmqcHX implemented
@@ -72,15 +72,15 @@ void pulsesequence() {
    double d22 = d2init/2.0; 
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mashsqc2d.c
+++ b/src/solidspack/psglib/mashsqc2d.c
@@ -161,19 +161,19 @@ void pulsesequence() {
    }
 
    MPSEQ fh = getfslg("fslgH",0,0.0,0.0,0,1);
-   strncpy(fh.ch,"dec",3);
+   strcpy(fh.ch,"dec");
    putCmd("chHfslg='dec'\n");
            
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/moistlkcp.c
+++ b/src/solidspack/psglib/moistlkcp.c
@@ -34,9 +34,9 @@ void pulsesequence() {
 
    double tHX3 = (getval("tHX"))/3.0;   //Define MOIST CP in the Sequence
       DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/mqmas3q2d.c
+++ b/src/solidspack/psglib/mqmas3q2d.c
@@ -27,9 +27,9 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas3qdfs2d.c
+++ b/src/solidspack/psglib/mqmas3qdfs2d.c
@@ -30,13 +30,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE dfs = getdfspulse("dfsX",0.0,0.0,0,1);
-   strncpy(dfs.pars.ch,"obs",3);
+   strcpy(dfs.pars.ch,"obs");
    putCmd("chXdfs='obs'\n");   // Sequence uses pwXdfs and sets pw2Xmqmas
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas3qdfs2spltse2d.c
+++ b/src/solidspack/psglib/mqmas3qdfs2spltse2d.c
@@ -62,11 +62,11 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE dfsp = getdfspulse("dfspX",0.0,0.0,0,1);
-   strncpy(dfsp.pars.ch,"obs",3);
+   strcpy(dfsp.pars.ch,"obs");
    putCmd("chXdfsp='obs'\n");
 
    SHAPE dfs = getdfspulse("dfsX",0.0,0.0,0,1);
-   strncpy(dfs.pars.ch,"obs",3);
+   strcpy(dfs.pars.ch,"obs");
    putCmd("chXdfs='obs'\n");
 
    putCmd("pw2Xmqmas=pwXdfs");    // Sequence uses pwXdfs and sets pw2Xmqmas
@@ -98,9 +98,9 @@ void pulsesequence() {
    if (tXechsel < 0.0) tXechsel = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas3qdfsspltse2d.c
+++ b/src/solidspack/psglib/mqmas3qdfsspltse2d.c
@@ -60,7 +60,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE dfs = getdfspulse("dfsX",0.0,0.0,0,1);
-   strncpy(dfs.pars.ch,"obs",3);
+   strcpy(dfs.pars.ch,"obs");
    putCmd("chXdfs='obs'\n");
 
    putCmd("pw2Xmqmas=pwXdfs");    // Sequence uses pwXdfs and sets pw2Xmqmas
@@ -92,9 +92,9 @@ void pulsesequence() {
    if (tXechsel < 0.0) tXechsel = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas3qdfszf2d.c
+++ b/src/solidspack/psglib/mqmas3qdfszf2d.c
@@ -32,7 +32,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE dfs = getdfspulse("dfsX",0.0,0.0,0,1);
-   strncpy(dfs.pars.ch,"obs",3);
+   strcpy(dfs.pars.ch,"obs");
    putCmd("chXdfs='obs'\n");   // Sequence uses pwXdfs and sets pw2Xmqmas
 
    double tXzfselinit = getval("tXzfsel"); // Adjust the Z-filter Delay for the
@@ -40,9 +40,9 @@ void pulsesequence() {
    if (tXzfsel < 0.0) tXzfsel = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas3qfam2spltse2d.c
+++ b/src/solidspack/psglib/mqmas3qfam2spltse2d.c
@@ -100,9 +100,9 @@ void pulsesequence() {
    if (tXechsel < 0.0) tXechsel = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas3qfamspltse2d.c
+++ b/src/solidspack/psglib/mqmas3qfamspltse2d.c
@@ -97,9 +97,9 @@ void pulsesequence() {
    if (tXechsel < 0.0) tXechsel = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas3qse2d.c
+++ b/src/solidspack/psglib/mqmas3qse2d.c
@@ -66,9 +66,9 @@ void pulsesequence() {
    if (tXechsel < 0.0) tXechsel = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas3qspltse2d.c
+++ b/src/solidspack/psglib/mqmas3qspltse2d.c
@@ -83,9 +83,9 @@ void pulsesequence() {
    if (tXechsel < 0.0) tXechsel = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas3qzf2d.c
+++ b/src/solidspack/psglib/mqmas3qzf2d.c
@@ -37,9 +37,9 @@ void pulsesequence() {
    if (tXzfsel < 0.0) tXzfsel = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas5qzf2d.c
+++ b/src/solidspack/psglib/mqmas5qzf2d.c
@@ -36,9 +36,9 @@ void pulsesequence() {
    double tXzfsel = tXzfselinit - 2.0e-6;  // attenuator switch time. 
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas7qzf2d.c
+++ b/src/solidspack/psglib/mqmas7qzf2d.c
@@ -37,9 +37,9 @@ void pulsesequence() {
    double tXzfsel = tXzfselinit - 2.0e-6;  // attenuator switch time.
    
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mqmas9qzf2d.c
+++ b/src/solidspack/psglib/mqmas9qzf2d.c
@@ -36,9 +36,9 @@ void pulsesequence() {
    double tXzfsel = tXzfselinit - 2.0e-6;  // attenuator switch time.
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/mrev8.c
+++ b/src/solidspack/psglib/mrev8.c
@@ -25,7 +25,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA mrev8 = getmrev8("mrev8X");
-   strncpy(mrev8.ch,"obs",3); 
+   strcpy(mrev8.ch,"obs"); 
    putCmd("chXmrev8='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/mrev8q.c
+++ b/src/solidspack/psglib/mrev8q.c
@@ -33,7 +33,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA mrev8 = getmrev8("mrev8X");
-   strncpy(mrev8.ch,"obs",3); 
+   strcpy(mrev8.ch,"obs"); 
    putCmd("chXmrev8='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepul.c
+++ b/src/solidspack/psglib/onepul.c
@@ -18,9 +18,9 @@ void pulsesequence() {
 
 // Define Variables and Objects and Get Parameter Values
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepulHrr.c
+++ b/src/solidspack/psglib/onepulHrr.c
@@ -35,9 +35,9 @@ void pulsesequence() {
    char Hseq[MAXSTR];
    getstr("Hseq",Hseq);
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n"); 
 
 // ---------------------------------------------

--- a/src/solidspack/psglib/onepulcpm.c
+++ b/src/solidspack/psglib/onepulcpm.c
@@ -26,7 +26,7 @@ void pulsesequence() {
    SHAPE cpm;
    if (decmode > 1) {
       cpm = getcpm("cpmH",0.0,0.0,0,1);
-      strncpy(cpm.pars.ch,"dec",3);
+      strcpy(cpm.pars.ch,"dec");
       putCmd("chHcpm ='dec'\n");
    }
 

--- a/src/solidspack/psglib/onepuldec2.c
+++ b/src/solidspack/psglib/onepuldec2.c
@@ -21,15 +21,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ dec2 = getdseq("Y");
-   strncpy(dec2.t.ch,"dec2",3);
+   strcpy(dec2.t.ch,"dec2");
    putCmd("chYtppm='dec2'\n");
-   strncpy(dec2.s.ch,"dec2",3);
+   strcpy(dec2.s.ch,"dec2");
    putCmd("chYspinal='dec2'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepuldfs.c
+++ b/src/solidspack/psglib/onepuldfs.c
@@ -24,13 +24,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE dfs = getdfspulse("dfsX",0.0,0.0,0,1);
-   strncpy(dfs.pars.ch,"obs",3);
+   strcpy(dfs.pars.ch,"obs");
    putCmd("chXdfs='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    dump_shape(dfs);

--- a/src/solidspack/psglib/onepuldpth.c
+++ b/src/solidspack/psglib/onepuldpth.c
@@ -23,9 +23,9 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepulhs.c
+++ b/src/solidspack/psglib/onepulhs.c
@@ -24,15 +24,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    PBOXPULSE shp1 = getpboxpulse("shp1X",0,1);
-   strncpy(shp1.ch,"obs",3);
+   strcpy(shp1.ch,"obs");
    putCmd("chHshp1 ='obs'\n");
    shp1.t1 = 0.0;
    shp1.t2 = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepulhspl.c
+++ b/src/solidspack/psglib/onepulhspl.c
@@ -19,9 +19,9 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
   
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepulref.c
+++ b/src/solidspack/psglib/onepulref.c
@@ -23,15 +23,15 @@ void pulsesequence() {
    PBOXPULSE shp1 = getpboxpulse("shp1X",0,1); 
 
    DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepulsfs.c
+++ b/src/solidspack/psglib/onepulsfs.c
@@ -27,13 +27,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE sfs = getsfspulse("sfsX",0.0,0.0,0,1);
-   strncpy(sfs.pars.ch,"obs",3);
+   strcpy(sfs.pars.ch,"obs");
    putCmd("chXsfs='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepult1rho.c
+++ b/src/solidspack/psglib/onepult1rho.c
@@ -23,15 +23,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepultoss.c
+++ b/src/solidspack/psglib/onepultoss.c
@@ -30,13 +30,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA toss = gettoss4("tossX");
-   strncpy(toss.ch,"obs",3);
+   strcpy(toss.ch,"obs");
    putCmd("chXtoss='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/onepulxyr.c
+++ b/src/solidspack/psglib/onepulxyr.c
@@ -29,9 +29,9 @@ void pulsesequence() {
    extern int NUMch;
 
    DSEQ dec2 = getdseq("H");
-   strncpy(dec2.t.ch,"dec2",3);
+   strcpy(dec2.t.ch,"dec2");
    putCmd("chHtppm='dec2'\n"); 
-   strncpy(dec2.s.ch,"dec2",3);
+   strcpy(dec2.s.ch,"dec2");
    putCmd("chHspinal='dec2'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/pboxonepul.c
+++ b/src/solidspack/psglib/pboxonepul.c
@@ -30,9 +30,9 @@ void pulsesequence() {
    PBOXPULSE shp3  = getpboxpulse("sft3A",0,1);
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/phasetest.c
+++ b/src/solidspack/psglib/phasetest.c
@@ -21,11 +21,11 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE p1 = getpulse("901X",0.0,0.0,0,1);
-   strncpy(p1.pars.ch,"obs",3);
+   strcpy(p1.pars.ch,"obs");
    putCmd("chX901='obs'\n");
 
    SHAPE p2 = getpulse("902X",0.0,0.0,0,1);
-   strncpy(p1.pars.ch,"obs",3);
+   strcpy(p1.pars.ch,"obs");
    putCmd("chX902='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/pisema2d.c
+++ b/src/solidspack/psglib/pisema2d.c
@@ -33,23 +33,23 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    MPSEQ fh = getfslg("fslgH",0,0.0,0.0,0,1);
-   strncpy(fh.ch,"dec",3);
+   strcpy(fh.ch,"dec");
    putCmd("chHfslg='dec'\n");
 
    MPSEQ fx = getfslg("fslgX",0,0.0,0.0,0,1);
-   strncpy(fx.ch,"obs",3);
+   strcpy(fx.ch,"obs");
    putCmd("chXfslg='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/pisematest1.c
+++ b/src/solidspack/psglib/pisematest1.c
@@ -33,19 +33,19 @@ void pulsesequence() {
    double aHlock = getval("aHlock");
        
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
    
    MPSEQ fx = getfslg("fslgX",0,0.0,0.0,0,1);
-   strncpy(fx.ch,"obs",3);
+   strcpy(fx.ch,"obs");
    putCmd("chXfslg='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/pisematest2.c
+++ b/src/solidspack/psglib/pisematest2.c
@@ -35,19 +35,19 @@ void pulsesequence() {
    double aXlock = getval("aXlock");  // define X decoupling during FSLG
        
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
    
    MPSEQ fh = getfslg("fslgH",0,0.0,0.0,0,1);
-   strncpy(fh.ch,"dec",3);
+   strcpy(fh.ch,"dec");
    putCmd("chHfslg='dec'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/presto1cp.c
+++ b/src/solidspack/psglib/presto1cp.c
@@ -36,14 +36,14 @@ void pulsesequence() {
 
    MPSEQ r18 = getr1825("r18H",0,0.0,0.0,0,1);
    MPSEQ r18ref = getr1825("r18H",r18.iSuper,r18.phAccum,r18.phInt,1,1);
-   strncpy(r18.ch,"dec",3);
-   strncpy(r18ref.ch,"dec",3);
+   strcpy(r18.ch,"dec");
+   strcpy(r18ref.ch,"dec");
    putCmd("chHr18='dec'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/presto2cp.c
+++ b/src/solidspack/psglib/presto2cp.c
@@ -41,14 +41,14 @@ void pulsesequence() {
 
    MPSEQ r18 = getr1825("r18H",0,0.0,0.0,0,1);
    MPSEQ r18ref = getr1825("r18H",r18.iSuper,r18.phAccum,r18.phInt,1,1); 
-   strncpy(r18.ch,"dec",3);
-   strncpy(r18ref.ch,"dec",3);
+   strcpy(r18.ch,"dec");
+   strcpy(r18ref.ch,"dec");
    putCmd("chHr18='dec'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/presto3cp.c
+++ b/src/solidspack/psglib/presto3cp.c
@@ -51,16 +51,16 @@ void pulsesequence() {
 // MPSEQ r18ref3 = getr1825("r18H",r18ref3.iSuper,r18ref3.phAccum,r18ref3.phInt,3,1);
    MPSEQ r18ref2 = getr1825("r18H",r18.iSuper,r18.phAccum,r18.phInt,2,1);
    MPSEQ r18ref3 = getr1825("r18H",r18.iSuper,r18.phAccum,r18.phInt,3,1);
-   strncpy(r18.ch,"dec",3);
-   strncpy(r18ref.ch,"dec",3);
-   strncpy(r18ref2.ch,"dec",3);
-   strncpy(r18ref3.ch,"dec",3);
+   strcpy(r18.ch,"dec");
+   strcpy(r18ref.ch,"dec");
+   strcpy(r18ref2.ch,"dec");
+   strcpy(r18ref3.ch,"dec");
    putCmd("chHr18='dec'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/qcpmg1d.c
+++ b/src/solidspack/psglib/qcpmg1d.c
@@ -33,7 +33,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA cpmg = getcpmg("cpmgX");
-   strncpy(cpmg.ch,"obs",3); 
+   strcpy(cpmg.ch,"obs"); 
    putCmd("chXcpmg='obs'\n");
 
    double aXecho = getval("aXecho");  // define the echoX group in the sequence
@@ -46,9 +46,9 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/qcpmgsh1d.c
+++ b/src/solidspack/psglib/qcpmgsh1d.c
@@ -37,7 +37,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA mp = getcpmg("cpmgX");
-   strncpy(mp.ch,"obs",3); 
+   strcpy(mp.ch,"obs"); 
    putCmd("chXcpmg='obs'\n");
    int chnl = 1;                      
 
@@ -62,9 +62,9 @@ void pulsesequence() {
    putCmd("dbXshp1 = tpwr");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/r14inad2d.c
+++ b/src/solidspack/psglib/r14inad2d.c
@@ -29,20 +29,20 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
     
    MPSEQ r14 = getr1426("r14X",0,0.0,0.0,0,1);
    MPSEQ r14ref = getr1426("r14X",r14.iSuper,r14.phAccum,r14.phInt,1,1);
-   strncpy(r14.ch,"obs",3);
+   strcpy(r14.ch,"obs");
    putCmd("chXr14='obs'\n");
    
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/r2inv1d.c
+++ b/src/solidspack/psglib/r2inv1d.c
@@ -80,21 +80,21 @@ void pulsesequence() {
    }
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n"); 
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ hr = getdseq("Hmix");
-   strncpy(hr.t.ch,"dec",3);
+   strcpy(hr.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n");
-   strncpy(hr.s.ch,"dec",3);
+   strcpy(hr.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 //--------------------------------------
 // Copy Current Parameters to Processed

--- a/src/solidspack/psglib/redor1onepul.c
+++ b/src/solidspack/psglib/redor1onepul.c
@@ -43,15 +43,15 @@ void pulsesequence() {
    double srate = getval("srate");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/redor1tancp.c
+++ b/src/solidspack/psglib/redor1tancp.c
@@ -47,21 +47,21 @@ void pulsesequence() {
    double srate = getval("srate");
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='mix'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='mix'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/redor2onepul.c
+++ b/src/solidspack/psglib/redor2onepul.c
@@ -35,15 +35,15 @@ void pulsesequence() {
    double srate = getval("srate");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='mix'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='mix'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/redor2tancp.c
+++ b/src/solidspack/psglib/redor2tancp.c
@@ -39,21 +39,21 @@ void pulsesequence() {
    double srate = getval("srate");
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec ",3);
-   strncpy(hx.to,"obs ",3);
+   strcpy(hx.fr,"dec ");
+   strcpy(hx.to,"obs ");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='mix'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='mix'\n");
 //--------------------------------------
 // Copy Current Parameters to Processed

--- a/src/solidspack/psglib/redor2tancp.c
+++ b/src/solidspack/psglib/redor2tancp.c
@@ -39,8 +39,8 @@ void pulsesequence() {
    double srate = getval("srate");
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strcpy(hx.fr,"dec ");
-   strcpy(hx.to,"obs ");
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 

--- a/src/solidspack/psglib/repdfs.c
+++ b/src/solidspack/psglib/repdfs.c
@@ -23,13 +23,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    SHAPE dfs = getdfspulse("dfsX",0.0,0.0,0,1);
-   strncpy(dfs.pars.ch,"obs",3);
+   strcpy(dfs.pars.ch,"obs");
    putCmd("chXdfs='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/sammy2d.c
+++ b/src/solidspack/psglib/sammy2d.c
@@ -42,23 +42,23 @@ void pulsesequence() {
 //Define Variables and Objects and Get Parameter Values 
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    MPSEQ sd = getsammyd("smydH",0,0.0,0.0,0,1);
-   strncpy(sd.ch,"dec",3);
+   strcpy(sd.ch,"dec");
    putCmd("chHsmyd='dec'\n");
 
    MPSEQ so = getsammyo("smyoX",0,0.0,0.0,0,1);
-   strncpy(so.ch,"obs",3);
+   strcpy(so.ch,"obs");
    putCmd("chXsmyo='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/sammymstlk2d.c
+++ b/src/solidspack/psglib/sammymstlk2d.c
@@ -53,17 +53,17 @@ void pulsesequence() {
        double tHX3 = (getval("tHX"))/3.0;   //Define MOIST CP in the Sequence
 
    MPSEQ sd = getsammyd("smydH",0,0.0,0.0,0,1);
-   strncpy(sd.ch,"dec",3);
+   strcpy(sd.ch,"dec");
    putCmd("chHsmyd='dec'\n");
 
    MPSEQ so = getsammyo("smyoX",0,0.0,0.0,0,1);
-   strncpy(so.ch,"obs",3);
+   strcpy(so.ch,"obs");
    putCmd("chXsmyo='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    d2 = sd.nelem*sd.telem; 

--- a/src/solidspack/psglib/satrec1d.c
+++ b/src/solidspack/psglib/satrec1d.c
@@ -21,13 +21,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ sat = getsat("satX",0.0,0.0,0,1);
-   strncpy(sat.ch,"obs",3);
+   strcpy(sat.ch,"obs");
    putCmd("chXsat='obs'\n"); 
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/sc14inad2d.c
+++ b/src/solidspack/psglib/sc14inad2d.c
@@ -29,20 +29,20 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    MPSEQ sc14 = getsc14("sc14X",0,0.0,0.0,0,1);
    MPSEQ sc14ref = getsc14("sc14X",sc14.iSuper,sc14.phAccum,sc14.phInt,1,1);
-   strncpy(sc14.ch,"obs",3);
+   strcpy(sc14.ch,"obs");
    putCmd("chXsc14='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/seac71d.c
+++ b/src/solidspack/psglib/seac71d.c
@@ -35,19 +35,19 @@ void pulsesequence() {
    int n;
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    MPSEQ seac7 = getseac7("seac7X",0,0.0,0.0,0,1);
-   strncpy(seac7.ch,"obs",3);
+   strcpy(seac7.ch,"obs");
    putCmd("chXseac7='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set the Gaussian Pulse in n Rotor Periods

--- a/src/solidspack/psglib/shapedtwopul1d.c
+++ b/src/solidspack/psglib/shapedtwopul1d.c
@@ -23,13 +23,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    PBOXPULSE shp1 = getpboxpulse("shp1X",0,1);
-   strncpy(shp1.ch,"obs",3);
+   strcpy(shp1.ch,"obs");
    putCmd("chHshp1 ='obs'\n");
    shp1.t1 = 0.0;
    shp1.t2 = 0.0;    
 
    PBOXPULSE shp2 = getpboxpulse("shp2X",0,1);
-   strncpy(shp2.ch,"obs",3);
+   strcpy(shp2.ch,"obs");
    putCmd("chHshp2 ='obs'\n");
    shp2.t1 = 0.0;
    shp2.t2 = 0.0;  
@@ -39,9 +39,9 @@ void pulsesequence() {
    if (d2 < 0.0) d2 = 0.0; 
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/spc5inad2d.c
+++ b/src/solidspack/psglib/spc5inad2d.c
@@ -31,20 +31,20 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    MPSEQ spc5 = getspc5("spc5X",0,0.0,0.0,0,1);
    MPSEQ spc5ref = getspc5("spc5X",spc5.iSuper,spc5.phAccum,spc5.phInt,1,1);
-   strncpy(spc5.ch,"obs",3);
+   strcpy(spc5.ch,"obs");
    putCmd("chXspc5='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/spsmall.c
+++ b/src/solidspack/psglib/spsmall.c
@@ -28,9 +28,9 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/ssecho1d.c
+++ b/src/solidspack/psglib/ssecho1d.c
@@ -29,9 +29,9 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/ssecho1dhdec.c
+++ b/src/solidspack/psglib/ssecho1dhdec.c
@@ -33,9 +33,9 @@ void pulsesequence() {
    char Xseq[MAXSTR];
    getstr("Xseq",Xseq);
    DSEQ dec = getdseq("X");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chXtppm='dec'\n");
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chXspinal='dec'\n");
 
 //-------------------------------------
@@ -43,7 +43,7 @@ void pulsesequence() {
 //-------------------------------------
 
    MPDEC homo1 = getmpdec("hdec1H",0,0.0,0.0,0,1);
-   strncpy(homo1.mps.ch,"obs",3);
+   strcpy(homo1.mps.ch,"obs");
    putCmd("chHhdec1='obs'\n"); 
 
 // --------------------

--- a/src/solidspack/psglib/stmas2d.c
+++ b/src/solidspack/psglib/stmas2d.c
@@ -39,9 +39,9 @@ void pulsesequence() {
    if (d2 < 0.0) d2 = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/stmasdqfse2d.c
+++ b/src/solidspack/psglib/stmasdqfse2d.c
@@ -61,9 +61,9 @@ void pulsesequence() {
    if (d2 < 0.0) d2 = 0.0;       // switch time, pulses and one selective echo delay
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/stmasdqfspltse2d.c
+++ b/src/solidspack/psglib/stmasdqfspltse2d.c
@@ -122,9 +122,9 @@ void pulsesequence() {
    if (d20 < 0.0) d20 = 0.0;              // switch time, pulses and one selective echo delay
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/stmasse2d1.c
+++ b/src/solidspack/psglib/stmasse2d1.c
@@ -44,9 +44,9 @@ void pulsesequence() {
    if (d2 < 0.0) d2 = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/stmasse2d2.c
+++ b/src/solidspack/psglib/stmasse2d2.c
@@ -51,9 +51,9 @@ void pulsesequence() {
    if (d2 < 0.0) d2 = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/stmasspltse2d1.c
+++ b/src/solidspack/psglib/stmasspltse2d1.c
@@ -96,9 +96,9 @@ void pulsesequence() {
    if (d20 < 0.0) d20 = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/stmasspltse2d2.c
+++ b/src/solidspack/psglib/stmasspltse2d2.c
@@ -107,9 +107,9 @@ void pulsesequence() {
    if (d20 < 0.0) d20 = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/stmaszf2d.c
+++ b/src/solidspack/psglib/stmaszf2d.c
@@ -46,9 +46,9 @@ void pulsesequence() {
    if (d2 < 0.0) d2 = 0.0;
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/super2d.c
+++ b/src/solidspack/psglib/super2d.c
@@ -49,13 +49,13 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    MPSEQ super = getsuper("superX",0,0.0,0.0,0,1);
-   strncpy(super.ch,"obs",3);
+   strcpy(super.ch,"obs");
    putCmd("chXsuper='obs'\n");
    putCmd("chXtoss='obs'\n");
 
@@ -76,15 +76,15 @@ void pulsesequence() {
    settable(tXinczf,4,delaytable);
 
    DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/swwhh4.c
+++ b/src/solidspack/psglib/swwhh4.c
@@ -33,7 +33,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA swwhh4 = getswwhh4("swwhh4X");
-   strncpy(swwhh4.ch,"obs",3); 
+   strcpy(swwhh4.ch,"obs"); 
    putCmd("chXswwhh4='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancp1dfprfdr.c
+++ b/src/solidspack/psglib/tancp1dfprfdr.c
@@ -27,26 +27,26 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    printf("hithere\n");
    MPSEQ fp = getfprfdr("fprfdrX",0,0.0,0.0,0,1);
-   strncpy(fp.ch,"obs",3);
+   strcpy(fp.ch,"obs");
    putCmd("chXfprfdr='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 // Round tXmix to the element length, 12*pwXfprfdr

--- a/src/solidspack/psglib/tancp1dptrfdr.c
+++ b/src/solidspack/psglib/tancp1dptrfdr.c
@@ -30,29 +30,29 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
    
    MPSEQ pt = getptrfdr("ptrfdrX",0,0.0,0.0,0,1);
-   strncpy(pt.ch,"obs",3);
+   strcpy(pt.ch,"obs");
    putCmd("chXptrfdr='obs'\n");
    
    MPSEQ fp = getfprfdr("fprfdrX",pt.iSuper,pt.phAccum,pt.phInt,0,1);
-   strncpy(fp.ch,"obs",3);
+   strcpy(fp.ch,"obs");
    putCmd("chXfprfdr='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n"); 
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 // Round tXmix and tXtotal to the element length, based on 36.0*pwXfprfdr.

--- a/src/solidspack/psglib/tancp2drad.c
+++ b/src/solidspack/psglib/tancp2drad.c
@@ -28,15 +28,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1); 
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Mixing Period to N Rotor Cycles 

--- a/src/solidspack/psglib/tancp2dspc5.c
+++ b/src/solidspack/psglib/tancp2dspc5.c
@@ -28,19 +28,19 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
    MPSEQ spc5 = getspc5("spc5X",0,0.0,0.0,0,1);
    MPSEQ spc5ref = getspc5("spc5X",spc5.iSuper,spc5.phAccum,spc5.phInt,1,1); 
-   strncpy(spc5.ch,"obs",3);
+   strcpy(spc5.ch,"obs");
    putCmd("chXspc5='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/tancpechocpmg1d.c
+++ b/src/solidspack/psglib/tancpechocpmg1d.c
@@ -58,7 +58,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA cpmg = getcpmg("cpmgX");
-   strncpy(cpmg.ch,"obs",3); 
+   strcpy(cpmg.ch,"obs"); 
    putCmd("chXcpmg='obs'\n");
 
    double aXecho = getval("aXecho");  // define the echoX group in the sequence
@@ -71,15 +71,15 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    CP hx = getcp("HX",0.0,0.0,0,1); 
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n"); 
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpht1.c
+++ b/src/solidspack/psglib/tancpht1.c
@@ -25,15 +25,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpht1rho.c
+++ b/src/solidspack/psglib/tancpht1rho.c
@@ -24,15 +24,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpx.c
+++ b/src/solidspack/psglib/tancpx.c
@@ -26,15 +26,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
    
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxblew.c
+++ b/src/solidspack/psglib/tancpxblew.c
@@ -22,12 +22,12 @@ void pulsesequence() {
 
 // Define Variables and Objects and Get Parameter Values
    MPSEQ dec = getblew("blewH",0,0.0,0.0,0,1);
-   strncpy(dec.ch,"dec",3);
+   strcpy(dec.ch,"dec");
    putCmd("chHblew='dec'\n");
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 

--- a/src/solidspack/psglib/tancpxcpm.c
+++ b/src/solidspack/psglib/tancpxcpm.c
@@ -27,15 +27,15 @@ void pulsesequence() {
    int decmode = getval("decmode");
 
    CP hx = getcp("HX",0.0,0.0,0,1); 
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    SHAPE cpm;
    if (decmode > 1) {
       cpm = getcpm("cpmH",0.0,0.0,0,1);
-      strncpy(cpm.pars.ch,"dec",3);
+      strcpy(cpm.pars.ch,"dec");
       putCmd("chHcpm ='dec'\n");
    }
 

--- a/src/solidspack/psglib/tancpxdec2.c
+++ b/src/solidspack/psglib/tancpxdec2.c
@@ -27,21 +27,21 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
    
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ dec2 = getdseq("Y"); 
-   strncpy(dec2.t.ch,"dec2",3);
+   strcpy(dec2.t.ch,"dec2");
    putCmd("chYtppm='dec2'\n"); 
-   strncpy(dec2.s.ch,"dec2",3);
+   strcpy(dec2.s.ch,"dec2");
    putCmd("chYspinal='dec2'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxdumbo.c
+++ b/src/solidspack/psglib/tancpxdumbo.c
@@ -23,12 +23,12 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ dec = getdumbo("dumboH",0,0.0,0.0,0,1);
-   strncpy(dec.ch,"dec",3);
+   strcpy(dec.ch,"dec");
    putCmd("chHdumbo='dec'\n");
 
    CP hx = getcp("HX",0.0,0.0,0,1); 
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 

--- a/src/solidspack/psglib/tancpxecho.c
+++ b/src/solidspack/psglib/tancpxecho.c
@@ -36,15 +36,15 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxedit.c
+++ b/src/solidspack/psglib/tancpxedit.c
@@ -37,15 +37,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
    
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H"); 
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxflip.c
+++ b/src/solidspack/psglib/tancpxflip.c
@@ -27,15 +27,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxfslg.c
+++ b/src/solidspack/psglib/tancpxfslg.c
@@ -23,12 +23,12 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ dec = getfslg("fslgH",0,0.0,0.0,0,1);
-   strncpy(dec.ch,"dec",3);
+   strcpy(dec.ch,"dec");
    putCmd("chHfslg='dec'\n");
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 

--- a/src/solidspack/psglib/tancpxhahnecho.c
+++ b/src/solidspack/psglib/tancpxhahnecho.c
@@ -36,15 +36,15 @@ void pulsesequence() {
    if (t2Xecho < 0.0) t2Xecho = 0.0;
 
    CP hx = getcp("HX",0.0,0.0,0,1); 
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n"); 
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxhdec.c
+++ b/src/solidspack/psglib/tancpxhdec.c
@@ -35,8 +35,8 @@ void pulsesequence() {
 // --------------------------------  
  
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n"); 
    putCmd("toHX='obs'\n");
 
@@ -47,9 +47,9 @@ void pulsesequence() {
    char Hseq[MAXSTR];
    getstr("Hseq",Hseq);
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n"); 
 
 //-----------------
@@ -61,9 +61,9 @@ void pulsesequence() {
    getstr("Xseq",Xseq);
    if (strcmp(Xseq,"pipulse") != 0) {
       obs = getdseq("X");
-      strncpy(obs.t.ch,"obs",3);
+      strcpy(obs.t.ch,"obs");
       putCmd("chXtppm='obs'\n"); 
-      strncpy(obs.s.ch,"obs",3);
+      strcpy(obs.s.ch,"obs");
       putCmd("chXspinal='obs'\n"); 
    }
 
@@ -76,7 +76,7 @@ void pulsesequence() {
 //--------------------------------------------
    
    MPDEC homo1 = getmpdec("hdec1H",0,0.0,0.0,0,1);
-   strncpy(homo1.mps.ch,"dec",3);
+   strcpy(homo1.mps.ch,"dec");
    putCmd("chHhdec1='dec'\n"); 
 
 //----------------------------------

--- a/src/solidspack/psglib/tancpxhdeccpmg.c
+++ b/src/solidspack/psglib/tancpxhdeccpmg.c
@@ -65,7 +65,7 @@ void pulsesequence() {
    getstr("onXcpmg",onXcpmg);
    if (!strcmp(onXcpmg,"y")) {
       cpmg = getcpmg("cpmgX"); 
-      strncpy(cpmg.ch,"obs",3);
+      strcpy(cpmg.ch,"obs");
       putCmd("chXcpmg='obs'\n");
    } 
 
@@ -74,8 +74,8 @@ void pulsesequence() {
 // --------------------------------  
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n"); 
    putCmd("toHX='obs'\n");
 
@@ -86,9 +86,9 @@ void pulsesequence() {
    char Hseq[MAXSTR];
    getstr("Hseq",Hseq);
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n"); 
 
 //-----------------
@@ -100,9 +100,9 @@ void pulsesequence() {
    getstr("Xseq",Xseq);
    if (strcmp(Xseq,"pipulse") != 0) {
       obs = getdseq("X");
-      strncpy(obs.t.ch,"obs",3);
+      strcpy(obs.t.ch,"obs");
       putCmd("chXtppm='obs'\n");
-      strncpy(obs.s.ch,"obs",3);
+      strcpy(obs.s.ch,"obs");
       putCmd("chXspinal='obs'\n");
    }
 
@@ -115,7 +115,7 @@ void pulsesequence() {
 //--------------------------------------------
    
    MPDEC homo1 = getmpdec("hdec1H",0,0.0,0.0,0,1);
-   strncpy(homo1.mps.ch,"dec",3);
+   strcpy(homo1.mps.ch,"dec");
    putCmd("chHhdec1='dec'\n"); 
 
 //----------------------------------

--- a/src/solidspack/psglib/tancpxidref.c
+++ b/src/solidspack/psglib/tancpxidref.c
@@ -33,19 +33,19 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n"); 
    putCmd("toHX='obs'\n");
 
    WMPA ref = getidref("idrefX");
-   strncpy(ref.ch,"obs",3);
+   strcpy(ref.ch,"obs");
    putCmd("chXidref='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxpips.c
+++ b/src/solidspack/psglib/tancpxpips.c
@@ -26,13 +26,13 @@ void pulsesequence() {
    double aHpips = getval("aHpips");
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    MPSEQ pips = getpipsxy("pipsH",0,0.0,0.0,0,1);
-   strncpy(pips.ch,"dec",3);
+   strcpy(pips.ch,"dec");
    putCmd("chHpips='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxpmlg.c
+++ b/src/solidspack/psglib/tancpxpmlg.c
@@ -23,12 +23,12 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    MPSEQ dec = getpmlg("pmlgH",0,0.0,0.0,0,1);
-   strncpy(dec.ch,"dec",3);
+   strcpy(dec.ch,"dec");
    putCmd("chHpmlg='dec'\n");
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 

--- a/src/solidspack/psglib/tancpxref.c
+++ b/src/solidspack/psglib/tancpxref.c
@@ -26,23 +26,23 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    PBOXPULSE shp1 = getpboxpulse("shp1X",0,1); 
 
    DSEQ dec = getdseq("H");    
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ mix = getdseq("Hmix");
-   strncpy(mix.t.ch,"dec",3);
+   strcpy(mix.t.ch,"dec");
    putCmd("chHmixtppm='dec'\n");
-   strncpy(mix.s.ch,"dec",3);
+   strcpy(mix.s.ch,"dec");
    putCmd("chHmixspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxt1.c
+++ b/src/solidspack/psglib/tancpxt1.c
@@ -30,15 +30,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
    
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxt1rho.c
+++ b/src/solidspack/psglib/tancpxt1rho.c
@@ -25,15 +25,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n"); 
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxtoss.c
+++ b/src/solidspack/psglib/tancpxtoss.c
@@ -35,19 +35,19 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    WMPA toss = gettoss4("tossX");
-   strncpy(toss.ch,"obs",3);
+   strcpy(toss.ch,"obs");
    putCmd("chXtoss='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxtoss5.c
+++ b/src/solidspack/psglib/tancpxtoss5.c
@@ -50,19 +50,19 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    WMPA toss = gettoss5("tossX");
-   strncpy(toss.ch,"obs",3);
+   strcpy(toss.ch,"obs");
    putCmd("chXtoss='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/tancpxyr.c
+++ b/src/solidspack/psglib/tancpxyr.c
@@ -35,23 +35,23 @@ void pulsesequence() {
    extern int NUMch;
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec2",4);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec2");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec2'\n");
    putCmd("toHX='obs'\n");
 
    RAMP ry = getramp("rampY",0.0,0.0,0,1);
-   strncpy(ry.ch,"dec",3);
+   strcpy(ry.ch,"dec");
    putCmd("chYramp='dec'\n");
-   strncpy(ry.pol,"du",2);
+   strcpy(ry.pol,"du");
    putCmd("chYramp='dec'\n");
    ry.t = getval("tHX");
    putCmd("tYramp = tHX\n");
 
    DSEQ dec2 = getdseq("H");
-   strncpy(dec2.t.ch,"dec2",3);
+   strcpy(dec2.t.ch,"dec2");
    putCmd("chHtppm='dec2'\n"); 
-   strncpy(dec2.s.ch,"dec2",3);
+   strcpy(dec2.s.ch,"dec2");
    putCmd("chHspinal='dec2'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/trapdor1d.c
+++ b/src/solidspack/psglib/trapdor1d.c
@@ -30,9 +30,9 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/trapdorycpx.c
+++ b/src/solidspack/psglib/trapdorycpx.c
@@ -27,15 +27,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1); 
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n"); 
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/twopul.c
+++ b/src/solidspack/psglib/twopul.c
@@ -21,9 +21,9 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/wdumbo1d.c
+++ b/src/solidspack/psglib/wdumbo1d.c
@@ -33,7 +33,7 @@ void pulsesequence() {
    double phXprep1 = getval("phXprep1");
 
    WMPA wdumbo = getwdumbo("wdumboX");
-   strncpy(wdumbo.ch,"obs",3);
+   strcpy(wdumbo.ch,"obs");
    putCmd("chXwdumbo='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/wdumbogen1d.c
+++ b/src/solidspack/psglib/wdumbogen1d.c
@@ -34,7 +34,7 @@ void pulsesequence() {
    double phXprep1 = getval("phXprep1");
 
    WMPA wdumbo = getwdumbogen("wdumboX","dcfX");
-   strncpy(wdumbo.ch,"obs",3);
+   strcpy(wdumbo.ch,"obs");
    putCmd("chXwdumbo='obs'\n");
 
 //-------------------------------------

--- a/src/solidspack/psglib/wdumbot1d.c
+++ b/src/solidspack/psglib/wdumbot1d.c
@@ -29,7 +29,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA wdumbot = getwdumbot("wdumbotX");
-   strncpy(wdumbot.ch,"obs",3);
+   strcpy(wdumbot.ch,"obs");
    putCmd("chXwdumbot='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/wdumboxmx1d.c
+++ b/src/solidspack/psglib/wdumboxmx1d.c
@@ -30,7 +30,7 @@ void pulsesequence() {
    double phvXprep = getval("phXprep");
 
    WMPA wdumbo = getwdumboxmx("wdumboX");
-   strncpy(wdumbo.ch,"obs",3);
+   strcpy(wdumbo.ch,"obs");
    putCmd("chXwdumbo='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/wiselgcp2d.c
+++ b/src/solidspack/psglib/wiselgcp2d.c
@@ -34,20 +34,20 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
    DSEQ xdec = getdseq("X");
-   strncpy(xdec.t.ch,"obs",3);    // These four statements assure 
-   strncpy(xdec.s.ch,"obs",3);    // that the X decoupling will
+   strcpy(xdec.t.ch,"obs");       // These four statements assure 
+   strcpy(xdec.s.ch,"obs");       // that the X decoupling will
    putCmd("chXtppm='obs'\n");     // be on X for either TPPM or 
    putCmd("chXspinal='obs'\n");   // SPINAL. 
 

--- a/src/solidspack/psglib/wisetancp2d.c
+++ b/src/solidspack/psglib/wisetancp2d.c
@@ -30,15 +30,15 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    CP hx = getcp("HX",0.0,0.0,0,1);
-   strncpy(hx.fr,"dec",3);
-   strncpy(hx.to,"obs",3);
+   strcpy(hx.fr,"dec");
+   strcpy(hx.to,"obs");
    putCmd("frHX='dec'\n");
    putCmd("toHX='obs'\n");
 
    DSEQ dec = getdseq("H");
-   strncpy(dec.t.ch,"dec",3);
+   strcpy(dec.t.ch,"dec");
    putCmd("chHtppm='dec'\n"); 
-   strncpy(dec.s.ch,"dec",3);
+   strcpy(dec.s.ch,"dec");
    putCmd("chHspinal='dec'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/wpmlg1d.c
+++ b/src/solidspack/psglib/wpmlg1d.c
@@ -33,7 +33,7 @@ void pulsesequence() {
    double phXprep1 = getval("phXprep1");
 
    WMPA wpmlg = getwpmlg("wpmlgX");
-   strncpy(wpmlg.ch,"obs",3); 
+   strcpy(wpmlg.ch,"obs"); 
    putCmd("chXwpmlg='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/wpmlg2d.c
+++ b/src/solidspack/psglib/wpmlg2d.c
@@ -49,11 +49,11 @@ void pulsesequence() {
    }
 
    MPSEQ pmlg = getpmlg("pmlgX",0,0.0,0.0,0,1);
-   strncpy(pmlg.ch,"obs",3);
+   strcpy(pmlg.ch,"obs");
    putCmd("chXpmlg='obs'\n");
 
    WMPA wpmlg = getwpmlg("wpmlgX");
-   strncpy(wpmlg.ch,"obs",3);
+   strcpy(wpmlg.ch,"obs");
    putCmd("chXwpmlg='obs'\n");
 
 // Set Constant-time Period for d2. 

--- a/src/solidspack/psglib/wpmlgxmx1d.c
+++ b/src/solidspack/psglib/wpmlgxmx1d.c
@@ -30,7 +30,7 @@ void pulsesequence() {
    double phvXprep = getval("phXprep");
 
    WMPA wpmlg = getwpmlgxmx("wpmlgX");
-   strncpy(wpmlg.ch,"obs",3); 
+   strcpy(wpmlg.ch,"obs"); 
    putCmd("chXwpmlg='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/wpmlgxmx1d1.c
+++ b/src/solidspack/psglib/wpmlgxmx1d1.c
@@ -34,7 +34,7 @@ void pulsesequence() {
    double phvXprep = getval("phXprep");
 
    WMPSEQ wpmlg = getwpmlgxmx1("wpmlgX");
-   strncpy(wpmlg.wvsh.mpseq.ch,"obs",3); 
+   strcpy(wpmlg.wvsh.mpseq.ch,"obs"); 
    putCmd("chXwpmlg='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/wsam1d.c
+++ b/src/solidspack/psglib/wsam1d.c
@@ -30,7 +30,7 @@ void pulsesequence() {
    double phvXprep = getval("phXprep");
 
    WMPA wsam = getwsamn("wsamX");
-   strncpy(wsam.ch,"obs",3); 
+   strcpy(wsam.ch,"obs"); 
    putCmd("chXwsam='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/xmx.c
+++ b/src/solidspack/psglib/xmx.c
@@ -26,7 +26,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA xmx = getxmx("xmxX");
-   strncpy(xmx.ch,"obs",3); 
+   strcpy(xmx.ch,"obs"); 
    putCmd("chXxmx='obs'\n");
 
 //--------------------------------------

--- a/src/solidspack/psglib/xx.c
+++ b/src/solidspack/psglib/xx.c
@@ -25,7 +25,7 @@ void pulsesequence() {
 // Define Variables and Objects and Get Parameter Values
 
    WMPA xx = getxx("xxX");
-   strncpy(xx.ch,"obs",3);
+   strcpy(xx.ch,"obs");
    putCmd("chXxx='obs'\n");
 
 //--------------------------------------


### PR DESCRIPTION
There are numerous places in the soldispack code that make the same strncpy errors that we fixed with ah*.c files a day or two ago. I think this code needs to go in place soon. There were a number of places where strncpy(chan,"dec2",3) were present (with "dec2" getting chopped off and thus chan just being set to "dec"). Also there were hundreds of non-NULL terminated strings in the pulse sequences.