### PR TITLE
Use safe string methods throughout the src/nvpsg code

### DIFF
--- a/src/nvpsg/AcodeBuffer.cpp
+++ b/src/nvpsg/AcodeBuffer.cpp
@@ -20,6 +20,12 @@ using namespace std;
 #include "ACode32.h"
 #include "AcodeBuffer.h"
 
+extern "C" {
+
+#include "safestring.h"
+
+};
+
 extern int bgflag;
 extern int checkflag;
 
@@ -48,8 +54,8 @@ AcodeBuffer::AcodeBuffer(size_t array_size, char *array_name, char *stage, int u
   ssWind  = 0;
   ssIndex = 0;
   subSectionInUse=false;
-  strcpy(acodeName, array_name);
-  strcpy(acodeStage,stage);
+  OSTRCPY( acodeName, sizeof(acodeName), array_name);
+  OSTRCPY( acodeStage, sizeof(acodeStage), stage);
   acodeUniqueID = uID;
   cHeader.comboID_and_Number = UNDEFINEDHEADER;
   cHeader.sizeInBytes = 0;
@@ -236,7 +242,7 @@ int AcodeBuffer::openAcodeFile(int option)
   }
   else
   {
-     sprintf(buffer,"%s.%s.%s",infopath,acodeStage,acodeName);
+     OSPRINTF( buffer, sizeof(buffer), "%s.%s.%s", infopath, acodeStage, acodeName);
      ofs.open(buffer,ios::out|ios::binary);
   }
 

--- a/src/nvpsg/AcodeManager.cpp
+++ b/src/nvpsg/AcodeManager.cpp
@@ -15,6 +15,13 @@
 #include "Console.h"
 #include "cpsg.h"
 
+extern "C" {
+
+#include "safestring.h"
+
+}
+
+
 extern int bgflag;
 
 bool          AcodeManager::instanceAMflag = false;
@@ -46,7 +53,6 @@ AcodeManager* AcodeManager::getInstance()
 AcodeManager::AcodeManager()
 {
   pArrayAcodeBufs = NULL;
-
   acodeStage = 0;
   cntrlr = 0;
   numcntrlrs = 0;
@@ -73,10 +79,10 @@ AcodeManager::AcodeManager(int numcntrls)
   cntrlr=0;
   numcntrlrs = numcntrls;
   acodesz   = 4096;
-  strcpy(acodeStageNames[0],"init");
-  strcpy(acodeStageNames[1],"pre");
-  strcpy(acodeStageNames[2],"ps");
-  strcpy(acodeStageNames[3],"post");
+  OSTRCPY( acodeStageNames[0], sizeof(acodeStageNames[0]), "init");
+  OSTRCPY( acodeStageNames[1], sizeof(acodeStageNames[1]), "pre");
+  OSTRCPY( acodeStageNames[2], sizeof(acodeStageNames[2]), "ps");
+  OSTRCPY( acodeStageNames[3], sizeof(acodeStageNames[3]), "post");
   acodeStageWriteFlag[ACODE_INIT]=0;
   acodeStageWriteFlag[ACODE_PRE] =0;
   acodeStageWriteFlag[ACODE_PS]  =0;

--- a/src/nvpsg/Bridge.cpp
+++ b/src/nvpsg/Bridge.cpp
@@ -22,6 +22,12 @@
 #include "cpsg.h"
 #include "RFController.h"
 
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 extern unsigned int ix;
 extern int dps_flag;
 extern int statusindx;
@@ -1868,7 +1874,7 @@ void sharedChannelWfgHDec()
   if (P_getstring(CURRENT, (char*) "dseq", hdseq, 1, 256) == 0 )
     getstr("dseq",hdseq);
   else
-    strcpy(hdseq,"garp1");
+    OSTRCPY( hdseq, sizeof(hdseq), "garp1");
   //-- should just use dmf or fetch from object
   hdmf = getval("dmf");
   if ( (hdmf > 50000.0) && !nomessageflag )
@@ -2071,7 +2077,7 @@ void ShapedXmtNAcquire(char *aname, double pw, int phase, double rof1,int chan)
   int startWord,stopWord,divs,i;
   cPatternEntry *patDes;
   char tname[200];
-  strcpy(tname,aname);
+  OSTRCPY( tname, sizeof(tname), aname);
   RFController *observeCh = (RFController *) P2TheConsole->getRFControllerByLogicalIndex(chan);
   freq = observeCh->getBaseFrequency();
   if (freq > 150.0)
@@ -2566,7 +2572,10 @@ void genRFShapedPulse(double pw, char *name, int rtvar, double rof1, double rof2
    P2TheConsole->newEvent();
    RFController *ShapedChan = (RFController *) P2TheConsole->getRFControllerByLogicalIndex(rfch);
 
-   if (strcmp(name,"") == 0) strcpy(pname,"hard"); else strcpy(pname,name);
+   if (strcmp(name,"") == 0)
+     OSTRCPY( pname, sizeof(pname), "hard");
+   else
+     OSTRCPY( pname, sizeof(pname), name);
 
    tmp = ShapedChan->resolveRFPattern(pname,1,"genRFShapedPulse",1);
    // this element allows the ShapedChan to time independently...
@@ -2624,7 +2633,10 @@ void genRFShapedPulseWithOffset(double pw, char *name, int rtvar, double rof1, d
    P2TheConsole->newEvent();
    RFController *ShapedChan = (RFController *) P2TheConsole->getRFControllerByLogicalIndex(rfch);
 
-   if (strcmp(name,"") == 0) strcpy(pname,"hard"); else strcpy(pname,name);
+   if (strcmp(name,"") == 0)
+     OSTRCPY( pname, sizeof(pname), "hard");
+   else
+     OSTRCPY( pname, sizeof(pname), name);
    //
    refPat = ShapedChan->resolveRFPattern(pname,1,"genRFSpecific_Reference",1);
    //
@@ -2740,7 +2752,10 @@ double gen_shapelistpw(char  *baseshape, double pw, int rfch)
      return 0.0;
 
    RFController *ShapedChan = (RFController *) P2TheConsole->getRFControllerByLogicalIndex(rfch);
-   if (strcmp(baseshape,"") == 0) strcpy(pname,"hard"); else strcpy(pname,baseshape);
+   if (strcmp(baseshape,"") == 0)
+     OSTRCPY( pname, sizeof(pname), "hard");
+   else
+     OSTRCPY( pname, sizeof(pname), baseshape);
 
    numberStates = ShapedChan->analyzeRFPattern(pname,1,"gen_shapelistpw",1);
    if (numberStates <= 0)
@@ -2826,7 +2841,10 @@ void gen_shapedpulseoffset(char *name, double pw, int rtvar, double rof1, double
 
    P2TheConsole->newEvent();
 
-   if (strcmp(name,"") == 0) strcpy(pname,"hard"); else strcpy(pname,name);
+   if (strcmp(name,"") == 0)
+     OSTRCPY( pname, sizeof(pname), "hard");
+   else
+     OSTRCPY( pname, sizeof(pname), name);
 
    refPat = ShapedChan->resolveRFPattern(pname,1,"gen_shapedpulseoffset",1);
    if (refPat == NULL)
@@ -3650,14 +3668,13 @@ void gensim2shaped_pulse(char *name1, char *name2, double width1, double width2,
 
    // if shape name blank, use hard.RF
    if (strcmp(name1,""))
-     strcpy(shp1,name1);
+     OSTRCPY( shp1, sizeof(shp1), name1);
    else
-     strcpy(shp1,"hard");
+     OSTRCPY( shp1, sizeof(shp1), "hard");
    if (strcmp(name2,""))
-     strcpy(shp2,name2);
+     OSTRCPY( shp2, sizeof(shp2), name2);
    else
-     strcpy(shp2,"hard");
-
+     OSTRCPY( shp2, sizeof(shp2), "hard");
 
    // sort out the active rf channels
    // rf1Active = 1 means rf1 participates in event
@@ -3869,17 +3886,17 @@ void gensim3shaped_pulse(char *name1, char *name2, char *name3, double width1, d
 
    // if shape name blank, use hard.RF
    if (strcmp(name1,""))
-     strcpy(shp1,name1);
+     OSTRCPY( shp1, sizeof(shp1), name1);
    else
-     strcpy(shp1,"hard");
+     OSTRCPY( shp1, sizeof(shp1), "hard");
    if (strcmp(name2,""))
-     strcpy(shp2,name2);
+     OSTRCPY( shp2, sizeof(shp2), name2);
    else
-     strcpy(shp2,"hard");
+     OSTRCPY( shp2, sizeof(shp2), "hard");
    if (strcmp(name3,""))
-     strcpy(shp3,name3);
+     OSTRCPY( shp3, sizeof(shp3), name3);
    else
-     strcpy(shp3,"hard");
+     OSTRCPY( shp3, sizeof(shp3), "hard");
 
 
    // sort out the active rf channels
@@ -4304,13 +4321,13 @@ void zgradpulse(double amp, double duration)
   if (duration < 2.4e-6) return;  // won't work - used as skip .. no error
 
   if ( P_getstring(GLOBAL,(char*) "gradientdisable",gstr,1,2) != 0)
-    strcpy(gstr,"n");
+    OSTRCPY( gstr, sizeof(gstr), "n");
 
   if (strcmp(gstr,"y") == 0)
     amp = 0.0;
 
   if ( P_getstring(GLOBAL,(char*) "gradientshaping",gstr,1,2) != 0 )
-    strcpy(gstr,"s");
+    OSTRCPY( gstr, sizeof(gstr), "s");
   if (gstr[0]!='y')
     {
       rgradient('z',amp);
@@ -4909,7 +4926,7 @@ void splineonoff(int whichone,int state)
     abort_message("sp line #%d invalid\n",whichone);
   ch = (whichone - 1) / 3 + 1;
   l = (whichone - 1) % 3 + 1;
-  sprintf(stub,"rf%d",ch);
+  OSPRINTF( stub, sizeof(stub), "rf%d", ch);
   //cout << "stub = " << stub << endl;
   rfC = (RFController *)(P2TheConsole->getControllerByID(stub));
   if (rfC->isAsync())
@@ -5371,7 +5388,7 @@ int parmToRcvrMask(const char *parName, int calltype)
         if (calltype == 1)
            P_getstring(CURRENT, parName, rcvrStr, 1, MAXSTR) ;
         else
-           strcpy(rcvrStr,parName);
+           OSTRCPY( rcvrStr, sizeof(rcvrStr), parName);
 
         int c;
         int n;
@@ -5396,11 +5413,11 @@ int isRcvrActive(int n)
     rtn = (parmToRcvrMask("rcvrs",1) >> n) & 1;
     return rtn;
 }
-//
-//
-//
+
 char *RcvrMapStr(const char *parmname, char *mapstr)
 {
+  // BDZ: note that parmname is never referenced: bug?
+  
   int mrMask;
   int i,nRcvrs,fstflag;
   char tmpstr[256];
@@ -5414,7 +5431,11 @@ char *RcvrMapStr(const char *parmname, char *mapstr)
   {
      nRcvrs = (int)tmp;
   }
-
+  
+  // BDZ: maybe parmname is supposed to be passed into this next method
+  //   instead of "rcvrs"? That is what usage in the rest of the program
+  //   kind of implies. Or parname param should just go away.
+  
   mrMask = parmToRcvrMask((char*) "rcvrs", 1);
   fstflag = 1;
   for (i=0;i < nRcvrs; i++)
@@ -5422,10 +5443,13 @@ char *RcvrMapStr(const char *parmname, char *mapstr)
      if ( (mrMask >> i) & 1 )
      {
        if (fstflag)
-         sprintf(tmpstr,"ddr%d",i+1);
+         OSPRINTF( tmpstr, sizeof(tmpstr), "ddr%d", i+1);
        else
-         sprintf(tmpstr,",ddr%d",i+1);
-       strcat(mapstr,tmpstr);
+         OSPRINTF( tmpstr, sizeof(tmpstr), ",ddr%d", i+1);
+                    
+       // BDZ - UNSAFE - could fix if this routine took mapstr's size as a param
+       strcat( mapstr, tmpstr);
+       
        fstflag = 0;
      }
   }
@@ -5592,7 +5616,7 @@ void modifyRFGroupName(int list, int gnum, char *newName)
   // get Controller Data is 1 to MAXINGROUP
   p2s = p2g->getControllerData(gnum);
   if (p2s == NULL) abort_message("Group Pulse: Controller not found");
-  strcpy(p2s->shapeName,newName);
+  OSTRCPY( p2s->shapeName, sizeof(p2s->shapeName), newName);
 }
 
 // - tested

--- a/src/nvpsg/Console.cpp
+++ b/src/nvpsg/Console.cpp
@@ -20,6 +20,12 @@
 #include "MasterController.h"
 #include "Bridge.h"
 
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 extern int bgflag;
 extern int ptsval[];
 extern char gradtype[];
@@ -229,21 +235,21 @@ void Console::build(const char *nm)
   RFController* rfc ;
   for (i = 0; i < (int)numrfchan; i++)
   {
-    sprintf(tbuff,"rf%d",i+1);
+    OSPRINTF( tbuff, sizeof(tbuff), "rf%d", i+1);
     rfc = new RFController(tbuff,ptsval[i]);
-    sprintf(tmpStr,"maxattench%d",i+1);
+    OSPRINTF( tmpStr, sizeof(tmpStr), "maxattench%d", i+1);
     PhysicalTable[nValid++] = (Controller *)   rfc;
     RFUserTable[i]     = (RFController *) rfc;
     if ( P_getreal(GLOBAL,tmpStr,&rfpwr,1) == 0)
       rfc->setMaxUserLevel(rfpwr);
 //  power additions  rf1pop, rf1elimit, rf1pcal etc.
-    sprintf(tmpStr,"%spop",tbuff);
+    OSPRINTF( tmpStr, sizeof(tmpStr), "%spop", tbuff);
     getRealSetDefault(GLOBAL, tmpStr, &pop,3.0);
-    sprintf(tmpStr,"%selimit",tbuff);
+    OSPRINTF( tmpStr, sizeof(tmpStr), "%selimit", tbuff);
     getRealSetDefault(GLOBAL, tmpStr, &alvl,15.0);
-    sprintf(tmpStr,"%spcal",tbuff);
+    OSPRINTF( tmpStr, sizeof(tmpStr), "%spcal", tbuff);
     getRealSetDefault(GLOBAL, tmpStr, &pcal, 2.0);
-    sprintf(tmpStr,"%sptc",tbuff);
+    OSPRINTF( tmpStr, sizeof(tmpStr), "%sptc", tbuff);
     getRealSetDefault(GLOBAL, tmpStr, &ptc, 10.0);
     // set the no safe request 
     if (safetyoff) pop = 0.0; //
@@ -266,7 +272,7 @@ void Console::build(const char *nm)
   numActiveRcvrs = 0;
   for (i = 0; i < (int)numddrchan; i++)
     {
-      sprintf(tbuff,"ddr%d",i+1);
+      OSPRINTF( tbuff, sizeof(tbuff), "ddr%d", i+1);
       rcvrActive = isRcvrActive(i);
       if (rcvrActive)
       {
@@ -326,7 +332,7 @@ void Console::build(const char *nm)
 
   nActive = nValid;
 
-  strncpy(configName,nm,400);
+  OSTRCPY( configName, sizeof(configName), nm);
 
   setLogicalParamNames();
 
@@ -407,80 +413,80 @@ void Console::getChannelBits(int *channelbits)
 
 void Console::setLogicalParamNames()
 {
-  strcpy(obsStr[0],"obs");
-  strcpy(obsStr[1],"tof");
-  strcpy(obsStr[2],"tpwr");
-  strcpy(obsStr[3],"tpwrf");
-  strcpy(obsStr[4],"xm");
-  strcpy(obsStr[5],"xmm");
-  strcpy(obsStr[6],"xmf");
-  strcpy(obsStr[7],"xseq");
-  strcpy(obsStr[8],"xhomo");
-  strcpy(obsStr[9],"sfrq");
-  strcpy(obsStr[10],"xres");
-  strcpy(obsStr[11],"tpwrt");
-  strcpy(obsStr[12],"tpwrm");
-  strcpy(obsStr[13],"tn");
+  OSTRCPY( obsStr[0],  sizeof(obsStr[0]),  "obs"   );
+  OSTRCPY( obsStr[1],  sizeof(obsStr[1]),  "tof"   );
+  OSTRCPY( obsStr[2],  sizeof(obsStr[2]),  "tpwr"  );
+  OSTRCPY( obsStr[3],  sizeof(obsStr[3]),  "tpwrf" );
+  OSTRCPY( obsStr[4],  sizeof(obsStr[4]),  "xm"    );
+  OSTRCPY( obsStr[5],  sizeof(obsStr[5]),  "xmm"   );
+  OSTRCPY( obsStr[6],  sizeof(obsStr[6]),  "xmf"   );
+  OSTRCPY( obsStr[7],  sizeof(obsStr[7]),  "xseq"  );
+  OSTRCPY( obsStr[8],  sizeof(obsStr[8]),  "xhomo" );
+  OSTRCPY( obsStr[9],  sizeof(obsStr[9]),  "sfrq"  );
+  OSTRCPY( obsStr[10], sizeof(obsStr[10]), "xres"  );
+  OSTRCPY( obsStr[11], sizeof(obsStr[11]), "tpwrt" );
+  OSTRCPY( obsStr[12], sizeof(obsStr[12]), "tpwrm" );
+  OSTRCPY( obsStr[13], sizeof(obsStr[13]), "tn"    );
 
-  strcpy(decStr[0],"dec");
-  strcpy(decStr[1],"dof");
-  strcpy(decStr[2],"dpwr");
-  strcpy(decStr[3],"dpwrf");
-  strcpy(decStr[4],"dm");
-  strcpy(decStr[5],"dmm");
-  strcpy(decStr[6],"dmf");
-  strcpy(decStr[7],"dseq");
-  strcpy(decStr[8],"homo");
-  strcpy(decStr[9],"dfrq");
-  strcpy(decStr[10],"dres");
-  strcpy(decStr[11],"dpwrt");
-  strcpy(decStr[12],"dpwrm");
-  strcpy(decStr[13],"dn");
+  OSTRCPY( decStr[0],  sizeof(decStr[0]),  "dec"   );
+  OSTRCPY( decStr[1],  sizeof(decStr[1]),  "dof"   );
+  OSTRCPY( decStr[2],  sizeof(decStr[2]),  "dpwr"  );
+  OSTRCPY( decStr[3],  sizeof(decStr[3]),  "dpwrf" );
+  OSTRCPY( decStr[4],  sizeof(decStr[4]),  "dm"    );
+  OSTRCPY( decStr[5],  sizeof(decStr[5]),  "dmm"   );
+  OSTRCPY( decStr[6],  sizeof(decStr[6]),  "dmf"   );
+  OSTRCPY( decStr[7],  sizeof(decStr[7]),  "dseq"  );
+  OSTRCPY( decStr[8],  sizeof(decStr[8]),  "homo"  );
+  OSTRCPY( decStr[9],  sizeof(decStr[9]),  "dfrq"  );
+  OSTRCPY( decStr[10], sizeof(decStr[10]), "dres"  );
+  OSTRCPY( decStr[11], sizeof(decStr[11]), "dpwrt" );
+  OSTRCPY( decStr[12], sizeof(decStr[12]), "dpwrm" );
+  OSTRCPY( decStr[13], sizeof(decStr[13]), "dn"    );
 
-  strcpy(dec2Str[0],"dec2");
-  strcpy(dec2Str[1],"dof2");
-  strcpy(dec2Str[2],"dpwr2");
-  strcpy(dec2Str[3],"dpwrf2");
-  strcpy(dec2Str[4],"dm2");
-  strcpy(dec2Str[5],"dmm2");
-  strcpy(dec2Str[6],"dmf2");
-  strcpy(dec2Str[7],"dseq2");
-  strcpy(dec2Str[8],"homo2");
-  strcpy(dec2Str[9],"dfrq2");
-  strcpy(dec2Str[10],"dres2");
-  strcpy(dec2Str[11],"dpwrt2");
-  strcpy(dec2Str[12],"dpwrm2");
-  strcpy(dec2Str[13],"dn2");
+  OSTRCPY( dec2Str[0],  sizeof(dec2Str[0]),  "dec2"   );
+  OSTRCPY( dec2Str[1],  sizeof(dec2Str[1]),  "dof2"   );
+  OSTRCPY( dec2Str[2],  sizeof(dec2Str[2]),  "dpwr2"  );
+  OSTRCPY( dec2Str[3],  sizeof(dec2Str[3]),  "dpwrf2" );
+  OSTRCPY( dec2Str[4],  sizeof(dec2Str[4]),  "dm2"    );
+  OSTRCPY( dec2Str[5],  sizeof(dec2Str[5]),  "dmm2"   );
+  OSTRCPY( dec2Str[6],  sizeof(dec2Str[6]),  "dmf2"   );
+  OSTRCPY( dec2Str[7],  sizeof(dec2Str[7]),  "dseq2"  );
+  OSTRCPY( dec2Str[8],  sizeof(dec2Str[8]),  "homo2"  );
+  OSTRCPY( dec2Str[9],  sizeof(dec2Str[9]),  "dfrq2"  );
+  OSTRCPY( dec2Str[10], sizeof(dec2Str[10]), "dres2"  );
+  OSTRCPY( dec2Str[11], sizeof(dec2Str[11]), "dpwrt2" );
+  OSTRCPY( dec2Str[12], sizeof(dec2Str[12]), "dpwrm2" );
+  OSTRCPY( dec2Str[13], sizeof(dec2Str[13]), "dn2"    );
 
-  strcpy(dec3Str[0],"dec3");
-  strcpy(dec3Str[1],"dof3");
-  strcpy(dec3Str[2],"dpwr3");
-  strcpy(dec3Str[3],"dpwrf3");
-  strcpy(dec3Str[4],"dm3");
-  strcpy(dec3Str[5],"dmm3");
-  strcpy(dec3Str[6],"dmf3");
-  strcpy(dec3Str[7],"dseq3");
-  strcpy(dec3Str[8],"homo3");
-  strcpy(dec3Str[9],"dfrq3");
-  strcpy(dec3Str[10],"dres3");
-  strcpy(dec3Str[11],"dpwrt3");
-  strcpy(dec3Str[12],"dpwrm3");
-  strcpy(dec3Str[13],"dn3");
+  OSTRCPY( dec3Str[0],  sizeof(dec3Str[0]),  "dec3"   );
+  OSTRCPY( dec3Str[1],  sizeof(dec3Str[1]),  "dof3"   );
+  OSTRCPY( dec3Str[2],  sizeof(dec3Str[2]),  "dpwr3"  );
+  OSTRCPY( dec3Str[3],  sizeof(dec3Str[3]),  "dpwrf3" );
+  OSTRCPY( dec3Str[4],  sizeof(dec3Str[4]),  "dm3"    );
+  OSTRCPY( dec3Str[5],  sizeof(dec3Str[5]),  "dmm3"   );
+  OSTRCPY( dec3Str[6],  sizeof(dec3Str[6]),  "dmf3"   );
+  OSTRCPY( dec3Str[7],  sizeof(dec3Str[7]),  "dseq3"  );
+  OSTRCPY( dec3Str[8],  sizeof(dec3Str[8]),  "homo3"  );
+  OSTRCPY( dec3Str[9],  sizeof(dec3Str[9]),  "dfrq3"  );
+  OSTRCPY( dec3Str[10], sizeof(dec3Str[10]), "dres3"  );
+  OSTRCPY( dec3Str[11], sizeof(dec3Str[11]), "dpwrt3" );
+  OSTRCPY( dec3Str[12], sizeof(dec3Str[12]), "dpwrm3" );
+  OSTRCPY( dec3Str[13], sizeof(dec3Str[13]), "dn3"    );
 
-  strcpy(dec4Str[0],"dec4");
-  strcpy(dec4Str[1],"dof4");
-  strcpy(dec4Str[2],"dpwr4");
-  strcpy(dec4Str[3],"dpwrf4");
-  strcpy(dec4Str[4],"dm4");
-  strcpy(dec4Str[5],"dmm4");
-  strcpy(dec4Str[6],"dmf4");
-  strcpy(dec4Str[7],"dseq4");
-  strcpy(dec4Str[8],"homo4");
-  strcpy(dec4Str[9],"dfrq4");
-  strcpy(dec4Str[10],"dres4");
-  strcpy(dec4Str[11],"dpwrt4");
-  strcpy(dec4Str[12],"dpwrm4");
-  strcpy(dec4Str[13],"dn4");
+  OSTRCPY( dec4Str[0],  sizeof(dec4Str[0]),  "dec4"   );
+  OSTRCPY( dec4Str[1],  sizeof(dec4Str[1]),  "dof4"   );
+  OSTRCPY( dec4Str[2],  sizeof(dec4Str[2]),  "dpwr4"  );
+  OSTRCPY( dec4Str[3],  sizeof(dec4Str[3]),  "dpwrf4" );
+  OSTRCPY( dec4Str[4],  sizeof(dec4Str[4]),  "dm4"    );
+  OSTRCPY( dec4Str[5],  sizeof(dec4Str[5]),  "dmm4"   );
+  OSTRCPY( dec4Str[6],  sizeof(dec4Str[6]),  "dmf4"   );
+  OSTRCPY( dec4Str[7],  sizeof(dec4Str[7]),  "dseq4"  );
+  OSTRCPY( dec4Str[8],  sizeof(dec4Str[8]),  "homo4"  );
+  OSTRCPY( dec4Str[9],  sizeof(dec4Str[9]),  "dfrq4"  );
+  OSTRCPY( dec4Str[10], sizeof(dec4Str[10]), "dres4"  );
+  OSTRCPY( dec4Str[11], sizeof(dec4Str[11]), "dpwrt4" );
+  OSTRCPY( dec4Str[12], sizeof(dec4Str[12]), "dpwrm4" );
+  OSTRCPY( dec4Str[13], sizeof(dec4Str[13]), "dn4"    );
 }
 
 
@@ -620,12 +626,12 @@ int Console::RFConfigMap()
      return(1);  //
   if (strlen(probeConnect) < 3) return(1);
   if(P_getstring(GLOBAL,"preAmpConfig",preAmpConfig,1,MAXSTR) < 0)
-     strcpy(preAmpConfig,"HLXXX"); // system default
+     OSTRCPY( preAmpConfig, sizeof(preAmpConfig), "HLXXX"); // system default
   // makes the readily assigned associations
   for (i = 0; i < numRFChan; i++)  // actually iterates tn,dn,dn2...
   {
       if (P_getstring(CURRENT,use[i],tmpstr,1,MAXSTR))
-        strcpy(tmpstr,"");
+        OSTRCPY( tmpstr, sizeof(tmpstr), "");
       index = posIndex(probeConnect,tmpstr);
       if ((!strcmp(tmpstr,"H1") || !strcmp("F19",tmpstr)))
       {
@@ -691,7 +697,7 @@ void Console::setRcvrsConfigMap()
   char rcvrsString[MAXSTR], rcvrsTypeStr[MAXSTR], tempCh[MAXSTR];
 
   getStringSetDefault(CURRENT,"rcvrs",rcvrsString,"ynnnn");
-//  strcpy(trInterconnect.rcvrS,rcvrStr);
+//  OSTRCPY(trInterconnect.rcvrS, sizeof(trInterconnect.rcvrS), rcvrStr);
   int charnum = countSpecificChars(rcvrsString, 'y');
   if (charnum == 0)
     abort_message("error in receiver configuration variable rcvrs. abort!\n");
@@ -736,7 +742,7 @@ void Console::setRcvrsConfigMap()
   tempCh[0]=rfChannelStr[0]; tempCh[1]='\0';
   if ( (receiverConfig == MULTNUCRCVR_SINGACQ)  && (atoi(tempCh) == RCVR2_RF_LO_CHANNEL) )
   {
-     strcpy(rcvrsString,"ny");
+     OSTRCPY( rcvrsString, sizeof(rcvrsString), "ny");
      P_setstring(CURRENT, "rcvrs", rcvrsString, 1);
      // cout << "setRvcrsConfigMap(): setting rcvrs to ny\n" << endl;
   }
@@ -787,23 +793,23 @@ void Console::setChannelMapping()
   if (ans == 0)
   {
      //fprintf(stdout,"rf chan equivalent => %1d%1d%1d%1d%1d\n",OBSch,DECch,DEC2ch,DEC3ch,DEC4ch);
-     sprintf(rfChannelStr,"%1d%1d%1d%1d%1d",OBSch,DECch,DEC2ch,DEC3ch,DEC4ch);
+     OSPRINTF( rfChannelStr, sizeof(rfChannelStr), "%1d%1d%1d%1d%1d", OBSch, DECch, DEC2ch, DEC3ch, DEC4ch);
   }
   else
   {
     /* brute force rfchannels */
 
     if (P_getstring(CURRENT,"rfchannel",rfChannelStr,1,(numRFChan+1)))
-       strcpy(rfChannelStr,"");
+       OSTRCPY( rfChannelStr, sizeof(rfChannelStr), "");
     if (strcmp(rfChannelStr, "") == 0)
     {
-      strcpy(rfChannelStr,"123456789");
+      OSTRCPY( rfChannelStr, sizeof(rfChannelStr), "123456789");
       OBSch = 1; DECch =2;  DEC2ch = 3; DEC3ch = 4; DEC4ch = 5;
       // fix the low band observe and tn = lk case..
       if ((sfrq < bandsw) && (numRFChan >1))
       {
-	    strcpy(rfChannelStr,"213456789");
-            OBSch = 2; DECch =1;
+        OSTRCPY( rfChannelStr, sizeof(rfChannelStr), "213456789");
+        OBSch = 2; DECch = 1;
       }
     }
     else
@@ -817,7 +823,7 @@ void Console::setChannelMapping()
   //  rf grouped pulse support.
   if((P_getstring(GLOBAL,"rfGroupMap",tmp,1,MAXSTR) < 0) || (strlen(tmp) < 2))
     {
-      strcpy(tmp,"000000000000000000000000000000000000000000");
+      OSTRCPY( tmp, sizeof(tmp), "000000000000000000000000000000000000000000");
   }
   else
   {
@@ -961,20 +967,20 @@ void Console::setChannelMapping()
 
     // get nucleus names into an array to set rfchnuclei parameter
     char nucleiNameStr[MAXSTR], nucname[MAXSTR];
-    strcpy(nucleiNameStr,"'");
+    OSTRCPY( nucleiNameStr, sizeof(nucleiNameStr), "'");
     ((RFController *)RFUserTable[0])->getNucleusName(nucname);
     if (strcmp(nucname,"") == 0)
-       strcpy(nucname,"-");
-    strcat(nucleiNameStr, nucname);
+       OSTRCPY( nucname, sizeof(nucname), "-");
+    OSTRCAT( nucleiNameStr, sizeof(nucleiNameStr), nucname);
     for (int i=1; i<numRFChan; i++)
     {
-      strcat(nucleiNameStr, " ");
+      OSTRCAT( nucleiNameStr, sizeof(nucleiNameStr), " ");
       ((RFController *)RFUserTable[i])->getNucleusName(nucname);
       if (strcmp(nucname,"") == 0)
-         strcpy(nucname,"-");
-      strcat(nucleiNameStr, nucname);
+         OSTRCPY( nucname, sizeof(nucname), "-");
+      OSTRCAT( nucleiNameStr, sizeof(nucleiNameStr), nucname);
     }
-    strcat(nucleiNameStr,"'");
+    OSTRCAT( nucleiNameStr, sizeof(nucleiNameStr), "'");
     if (P_getstring(CURRENT, "rfchnuclei", nucname, 1, 255) >= 0)
     {
        putCmd("rfchnuclei = %s",nucleiNameStr);
@@ -984,12 +990,12 @@ void Console::setChannelMapping()
     RollCallString[0] = '\0';
     for (k=0; k < nValid; k++)
     {
-      strcpy(tmp, PhysicalTable[k]->getName());
+      OSTRCPY( tmp, sizeof(tmp), PhysicalTable[k]->getName());
       // don't add master1 or lock1 to the list.
       if ((strcmp(tmp,"master1")!=0) && (strcmp(tmp,"lock1")!=0))
       {
-        strcat(RollCallString,tmp);
-        strcat(RollCallString," ");
+        OSTRCAT( RollCallString, sizeof(RollCallString), tmp);
+        OSTRCAT( RollCallString, sizeof(RollCallString), " ");
       }
     }
 
@@ -1478,7 +1484,7 @@ void Console::printSyncStatus()
     {
       if ( !PhysicalTable[i]->isOff() )
         {
-          strcpy(id,PhysicalTable[i]->getName());
+          OSTRCPY( id, sizeof(id), PhysicalTable[i]->getName());
           tks = PhysicalTable[i]->getBigTicker();
 #ifndef __INTERIX
           cout << setiosflags(ios::left) << setw(10) <<  id << setiosflags(ios::right) << setw(12) << tks << endl;
@@ -1765,16 +1771,17 @@ int Console::turnOffRFDuplicates()
    const char *parN[] = {"dn","dn2","dn3","dn4","dn5"};
    int i;
    if ((numRFChan < 2) || (numRFChan > 5)) return(1);
-   strcpy(baseStr,"");  // matches are errors
+   // matches are errors
+   OSTRCPY( baseStr, sizeof(baseStr), "");
    P_getstring(CURRENT,"tn",tmpstr,1,MAXSTR);
    if (strcmp(tmpstr,"none"))
-     strcpy(baseStr,tmpstr);
+     OSTRCPY( baseStr, sizeof(baseStr), tmpstr);
    for (i = 0; i < numRFChan-1; i++)
    {
      getStringSetDefault(CURRENT,parN[i],tmpstr,"none");
      if ((strlen(tmpstr)) && (strcmp(tmpstr,"none")))
      {
-       strcat(baseStr," ");
+       OSTRCAT( baseStr, sizeof(baseStr), " ");
        if (strstr(baseStr,tmpstr) != 0)
        {
          if ( ! dps_flag)
@@ -1782,7 +1789,7 @@ int Console::turnOffRFDuplicates()
          P_setstring(CURRENT, parN[i], "none", 1);
        }
        else  // no duplicate -
-         strcat(baseStr,tmpstr);
+         OSTRCAT( baseStr, sizeof(baseStr), tmpstr);
      }
    }
    return(2);

--- a/src/nvpsg/Controller.cpp
+++ b/src/nvpsg/Controller.cpp
@@ -23,6 +23,7 @@
 extern "C" {
 #include "vnmrsys.h"
 #include "vfilesys.h"
+#include "safestring.h"
 extern char curexp[];
 extern int dps_flag;
 }
@@ -45,7 +46,7 @@ int cPatternEntry::patID = 1;
 
 cPatternEntry::cPatternEntry()
 {
-   strcpy(name,"none");
+   OSTRCPY( name, sizeof(name), "none");
    keys=0; numberWords = 0;
    numberStates = 0;
    durationWord = 0L;
@@ -63,7 +64,7 @@ cPatternEntry::cPatternEntry()
 //
 cPatternEntry::cPatternEntry(const char *nm, int ky, int nstates, int nW)
 {
-   strcpy(name,nm);
+   OSTRCPY( name, sizeof(name), nm);
    keys = ky;
    numberWords = nW;
    numberStates = nstates;
@@ -82,7 +83,7 @@ cPatternEntry::cPatternEntry(const char *nm, int ky, int nstates, int nW)
 //
 cPatternEntry::cPatternEntry(const char *nm, int ky, int refID, int nstates, int nW)
 {
-   strcpy(name,nm);
+   OSTRCPY( name, sizeof(name), nm);
    keys = ky;
    numberWords = nW;
    numberStates = nstates;
@@ -97,7 +98,7 @@ cPatternEntry::cPatternEntry(const char *nm, int ky, int refID, int nstates, int
 
 cPatternEntry::cPatternEntry(cPatternEntry *orig)
 {
-   strcpy(name,orig->name);
+   OSTRCPY( name, sizeof(name), orig->name);
    keys = orig->keys;
    numberWords = orig->numberWords;
    numberStates = orig->numberStates;
@@ -239,8 +240,8 @@ int cPatternEntry::getLastElement()
 
 PowerMonitor::PowerMonitor(double tc, double al, const char *msg)
 {
-   strncpy(message,msg,256);
-   strncpy(message2,msg,256);
+   OSTRCPY( message, sizeof(message), msg);
+   OSTRCPY( message2, sizeof(message2), msg);
    energyMax = 0.0;   // largest recorded value..
    energyAccumulated = 0.0;
    eventStartEnergyAccumulated = energyAccumulated;
@@ -398,7 +399,7 @@ void PowerMonitor::setAlarmLevel(double threshold,int action, const char *emsg)
 {
   alarmLevel = threshold;
   trip_action = action;
-  strncpy(message2,emsg,256);
+  OSTRCPY( message2, sizeof(message2), emsg);
 }
 
 void PowerMonitor::setTimeConstant(double tc)
@@ -526,7 +527,7 @@ int Controller::SeqID= 0;
 //
 Controller::Controller()
 {
-    strcpy(Name,"generic");
+    OSTRCPY( Name, sizeof(Name), "generic");
     kind = GENERIC_TAG;
     usage = SYNCHRONOUS;  // default to SYNCHRONOUS
     dataWordCount = 0;
@@ -560,7 +561,7 @@ Controller::Controller()
 
 Controller::Controller(const char *nm, int num)
 {
-    strcpy(Name,nm);
+    OSTRCPY( Name, sizeof(Name), nm);
     kind = GENERIC_TAG;
     dataWordCount = 0;
     bigTicker = 0;
@@ -617,9 +618,9 @@ void Controller::setWaveformBuffer()
 AcodeBuffer* Controller::setAcodeBuffer(const char *type)
 {
   char fileName[64];
-  strcpy(fileName,type);
-  strcat(fileName,".");
-  strcat(fileName,Name);
+  OSTRCPY( fileName, sizeof(fileName), type);
+  OSTRCAT( fileName, sizeof(fileName), ".");
+  OSTRCAT( fileName, sizeof(fileName), Name);
   AcodeBuffer *pSpecialBuf = pAcodeMgr->setAcodeBuffer(fileName,UniqueID);
   pSpecialBuf->cHeader.comboID_and_Number = UNDEFINEDHEADER;
   return pSpecialBuf;

--- a/src/nvpsg/DDRController.cpp
+++ b/src/nvpsg/DDRController.cpp
@@ -31,6 +31,12 @@
 #include "stdio.h"
 #include "acqparms.h"
 
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 #define WriteWord( x ) pAcodeBuf->putCode( x )
 
 //#define USE_AQTM   // undefine to disable filter reflection at end of fid

--- a/src/nvpsg/GradientBase.cpp
+++ b/src/nvpsg/GradientBase.cpp
@@ -16,6 +16,12 @@
 #include "cpsg.h"
 #include "acqparms.h"
 
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 //
 #define WriteWord( x ) pAcodeBuf->putCode( x )
 #define putPattern( x ) pWaveformBuf->putCode( x )
@@ -220,8 +226,8 @@ int GradientBase::create_rotation_list(char *nm, double* angle_set, int num_sets
       abort_message("number of gradient rotation angle sets in create_rotation_list command too large. abort!\n");
   
    char listName[MAXSTR];
-   strcpy(listName, nm);
-   strcat(listName,"_vrot");
+   OSTRCPY( listName, sizeof(listName), nm);
+   OSTRCAT( listName, sizeof(listName), "_vrot");
 
    cPatternEntry *tmp = find(listName, 0);
    if (tmp !=  NULL)
@@ -338,8 +344,8 @@ int GradientBase::create_angle_list(char *name, double *angle_set, int num_sets)
  
    char listName[MAXSTR];
    /* CHECK the size of name string */
-   strcpy(listName, name);
-   strcat(listName,"_vangle");
+   OSTRCPY( listName, sizeof(listName), name);
+   OSTRCAT( listName, sizeof(listName), "_vangle");
 
    cPatternEntry *tmp = find(listName, 0);
    if (tmp !=  NULL)

--- a/src/nvpsg/GradientBridge.cpp
+++ b/src/nvpsg/GradientBridge.cpp
@@ -19,6 +19,12 @@
 #include "GradientBridge.h"
 #include "cpsg.h"
 
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 extern unsigned int ix;
 extern int bgflag;
 extern "C" char gradtype[];
@@ -461,32 +467,32 @@ void phase_encode3_oblshapedgradient(char *pat1, char *pat2, char *pat3, double 
    int tempType=0;
 
    char gradPwrId[512], swidth[256];
-   strcpy(gradPwrId,"OblPEShp ");
+   OSTRCPY( gradPwrId, sizeof(gradPwrId), "OblPEShp ");
 
    // if shape name blank, that logical axis has no gradient
 
    if (strcmp(pat1,"") != 0)
    {
      tempType |= 0x1;
-     strcat(gradPwrId,pat1);
-     strcat(gradPwrId," ");
+     OSTRCAT( gradPwrId, sizeof(gradPwrId), pat1);
+     OSTRCAT( gradPwrId, sizeof(gradPwrId), " ");
    }
 
    if (strcmp(pat2,"") != 0)
    {
      tempType |= 0x2;
-     strcat(gradPwrId,pat2);
-     strcat(gradPwrId," ");
+     OSTRCAT( gradPwrId, sizeof(gradPwrId), pat2);
+     OSTRCAT( gradPwrId, sizeof(gradPwrId), " ");
    }
 
    if (strcmp(pat3,"") != 0)
    {
      tempType |= 0x4;
-     strcat(gradPwrId,pat3);
-     strcat(gradPwrId," ");
+     OSTRCAT( gradPwrId, sizeof(gradPwrId), pat3);
+     OSTRCAT( gradPwrId, sizeof(gradPwrId), " ");
    }
-   sprintf(swidth,"%5.4f",width);
-   strcat(gradPwrId,swidth);
+   OSPRINTF( swidth, sizeof(swidth), "%5.4f", width);
+   OSTRCAT( gradPwrId, sizeof(gradPwrId), swidth);
 
     P2TheConsole->newEvent();
     gC->clearSmallTicker();
@@ -1006,7 +1012,7 @@ void settmpgradtype(char *tmpgradname)
          {
             if (pfgBoard > 0.5)
             {
-               strcpy(tmpGradtype,"   ");
+               OSTRCPY( tmpGradtype, sizeof(tmpGradtype), "   ");
                P_getstring(GLOBAL,"gradtype",tmpGradtype,1,MAXSTR-1);
                if (tmpGradtype[2] == 'a')
                {

--- a/src/nvpsg/GradientController.cpp
+++ b/src/nvpsg/GradientController.cpp
@@ -13,6 +13,13 @@
 #include "FFKEYS.h"
 #include "ACode32.h"
 #include "cpsg.h"
+
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 //
 #define WriteWord( x ) pAcodeBuf->putCode( x )
 #define putPattern( x ) pWaveformBuf->putCode( x )
@@ -330,8 +337,8 @@ cPatternEntry *GradientController::resolveOblShpGrdPattern(char *nm, int flag, c
     scalef = GRADMAXPLUS;
     if (tmp != NULL)
       return(tmp);
-    strcpy(tname,nm);
-    strcat(tname,".GRD");
+    OSTRCPY( tname, sizeof(tname), nm);
+    OSTRCAT( tname, sizeof(tname), ".GRD");
     wcount = 0; eventcount = 0;
     grad_rms_value = 0.0;
 

--- a/src/nvpsg/InitAcqObject.cpp
+++ b/src/nvpsg/InitAcqObject.cpp
@@ -21,14 +21,18 @@
 
 
 extern "C" {
+
   int * init_acodes(Acqparams *);
   void initautostruct(void);
+
+#include "safestring.h"
+
 }
 
 
 InitAcqObject::InitAcqObject()
 {
-  strcpy(Name,"InitAcqObject");
+  OSTRCPY( Name, sizeof(Name), "InitAcqObject");
   UniqueID = 9;
   pAcodeMgr = NULL;
   pAcodeBuf = NULL;
@@ -36,7 +40,7 @@ InitAcqObject::InitAcqObject()
 
 InitAcqObject::InitAcqObject(const char *nm)
 {
-  strcpy(Name, nm);
+  OSTRCPY( Name, sizeof(Name), nm);
   UniqueID = 9;
   pAcodeMgr = AcodeManager::getInstance();
   setAcodeBuffer();

--- a/src/nvpsg/MasterController.cpp
+++ b/src/nvpsg/MasterController.cpp
@@ -24,6 +24,12 @@
 #include "cpsg.h"
 #include "spinner.h"
 
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 #ifndef MAXSTR
 #define MAXSTR	256
 #endif
@@ -1033,7 +1039,7 @@ int MasterController::initializeExpStates(int setupflag)
     exit(-1);
   }
   NSRModeFlag = 0;
-  strcpy(estring,"   ");
+  OSTRCPY( estring, sizeof(estring), "   ");
   // Do this first, avoid race condition
   if ( P_getstring(GLOBAL, "gradtype", estring, 1, MAXSTR) < 0)
      abort_message("PSG: Cannot find gradtype");
@@ -1453,7 +1459,7 @@ int MasterController::initializeExpStates(int setupflag)
       }
      if (blafMode > 0)
      { 
-        strcpy( estring, "" );
+        OSTRCPY( estring, sizeof(estring), "" );
         k = 0;
         if (P_getstring(GLOBAL, "hdwshimlist",estring, 1, MAXSTR) == 0) 
         {
@@ -1593,7 +1599,7 @@ void MasterController::RollCall(char *configString)
   i = strlen(configString);
   if (i > MAX_ROLLCALL_STRLEN )
     exit(-1);  // string too large 
-  strcpy((char *)&(buffer[1]),configString);
+  OSTRCPY( (char *)&(buffer[1]), sizeof(buffer) - sizeof(int), configString);
   j = (i/4 + 1);  //  integers..
 #ifdef LINUX
   for (i=0; i <= j; i++)
@@ -2091,7 +2097,7 @@ void MasterController::setConsoleMap(int kind, int obschannel, int decchannel, i
   trInterconnect.usageFlag = kind;
   trInterconnect.numRcvrs = nRcvrs;
   getStringSetDefault(CURRENT,"rcvrs",rcvrStr,"ynnnn");
-  strcpy(trInterconnect.rcvrS,rcvrStr);
+  OSTRCPY( trInterconnect.rcvrS, sizeof(trInterconnect.rcvrS), rcvrStr);
   getStringSetDefault(CURRENT,"presig",presigStr,"nnnn");
   if (strncmp(presigStr, "h",1) == 0)
      NSRModeFlag |= PRESIGBIT;

--- a/src/nvpsg/PFGController.cpp
+++ b/src/nvpsg/PFGController.cpp
@@ -13,6 +13,13 @@
 #include "FFKEYS.h"
 #include "ACode32.h"
 #include "cpsg.h"
+
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 //
 #define WriteWord( x )  pAcodeBuf->putCode( x )
 #define putPattern( x ) pWaveformBuf->putCode( x )
@@ -87,22 +94,25 @@ int PFGController::setEnable(char *key)
 {
   int buffer[4];
   char errorstring[128];
-  strcpy(errorstring,"");
+  OSTRCPY( errorstring, sizeof(errorstring), "");
   
   buffer[0] = 0;  /* everyone off */
   if (tolower(key[0]) == 'y') 
     {
-      if (!isPresent('x')) strcat(errorstring,"no X gradient ");
+      if (!isPresent('x'))
+        OSTRCAT( errorstring, sizeof(errorstring), "no X gradient ");
 	 buffer[0] |= XPFGPRESENT;
     }
   if (tolower(key[1]) == 'y') 
     {
-      if  (!isPresent('y')) strcat(errorstring,"no Y gradient ");
+      if  (!isPresent('y'))
+        OSTRCAT( errorstring, sizeof(errorstring), "no Y gradient ");
 	 buffer[0] |= YPFGPRESENT;
     }
   if (tolower(key[2]) == 'y') 
     {
-      if  (!isPresent('z')) strcat(errorstring,"no Z gradient ");
+      if  (!isPresent('z'))
+        OSTRCAT( errorstring, sizeof(errorstring), "no Z gradient ");
 	 buffer[0] |= ZPFGPRESENT;
     }
   if (strlen(errorstring) > 1) 
@@ -284,8 +294,8 @@ cPatternEntry *PFGController::resolveGrad1Pattern(char *nm, int flag, char *emsg
     scalef = PFGMAXPLUS;
     if (tmp != NULL)
       return(tmp);
-    strcpy(tname,nm);
-    strcat(tname,".GRD");
+    OSTRCPY( tname, sizeof(tname), nm);
+    OSTRCAT( tname, sizeof(tname), ".GRD");
     wcount = 0; eventcount = 0;
 
     i = findPatternFile(tname);
@@ -357,8 +367,8 @@ cPatternEntry *PFGController::resolveOblShpGrdPattern(char *nm, int flag, const 
     scalef = PFGMAXPLUS;
     if (tmp != NULL)
       return(tmp);
-    strcpy(tname,nm);
-    strcat(tname,".GRD");
+    OSTRCPY( tname, sizeof(tname), nm);
+    OSTRCAT( tname, sizeof(tname), ".GRD");
     wcount = 0; eventcount = 0;
     grad_rms_value = 0.0;
 

--- a/src/nvpsg/PFGController.h
+++ b/src/nvpsg/PFGController.h
@@ -10,12 +10,17 @@
 #ifndef INC_PFGCONTROLLER_H
 #define INC_PFGCONTROLLER_H
 
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 #include "GradientBase.h"
 
 #define XPFGPRESENT  1
 #define YPFGPRESENT  2
 #define ZPFGPRESENT  4
-
 
 #define PFGMAXPLUS (32767.0)
 #define PFGUNITYPLUS (0x4000)
@@ -43,15 +48,16 @@ class PFGController: public GradientBase
         usageFlag = 0; 
         if (tolower(gradtype[0] != 'n'))  usageFlag |= XPFGPRESENT;
         if (tolower(gradtype[1] != 'n'))  usageFlag |= YPFGPRESENT;
-	if (tolower(gradtype[2] != 'n'))  usageFlag |= ZPFGPRESENT;
+        if (tolower(gradtype[2] != 'n'))  usageFlag |= ZPFGPRESENT;
         kind = PFG_TAG;
-        strncpy(gradType,gradtype,10);  // why is strncpy() only using 10 of 16 chars?
-        // BDZ: gradType is size 16 and strncpy() might not have null terminated.
-        gradType[10] = 0;
+        // BDZ the following 11 was derived from original code. Ideally
+        // should use sizeof(gradType) instead. why is strcpy() only
+        // using 10 of 16 chars?
+        OSTRCPY(gradType, 11, gradtype);
         wait4meExpireTicker = 0L;
         if ( pAcodeBuf == NULL)
         {  cout << "PFGController constr(): pAcodeBuf is NULL \n" ; }
-     };  
+     };
   
      int isPresent(char x);
      int setEnable(char *cstring);
@@ -73,7 +79,6 @@ class PFGController: public GradientBase
      void showPowerIntegral();
      void showEventPowerIntegral(const char *);
      void getPowerIntegral(double *powerarray);
-
-
 };
+
 #endif

--- a/src/nvpsg/Pbox_bld.h
+++ b/src/nvpsg/Pbox_bld.h
@@ -44,6 +44,8 @@
                      for relatively latge J-couplings and relatively small sw. 
 */
 
+#include "safestring.h"
+
 static shape hidec, lodec;
 
 void make_bilev(double BLorder, double pwhi, double pwlo, double dbw, double rpw90, double rpwr)
@@ -55,16 +57,13 @@ void make_bilev(double BLorder, double pwhi, double pwlo, double dbw, double rpw
   {
     abort_message("Unsafe BLxpwr level. Aborting");
   }
-    
-  sprintf(cmd,"Pbox hilev.DEC -u %s -w \"wurst2i %.1f/%.7f\" -sucyc t5 -s 1.0 -p %.0f -l %.1f",
-               userdir, dbw, pwhi, rpwr, rpw90*1.0e6);
+
+  OSPRINTF( cmd, sizeof(cmd), "Pbox hilev.DEC -u %s -w \"wurst2i %.1f/%.7f\" -sucyc t5 -s 1.0 -p %.0f -l %.1f", userdir, dbw, pwhi, rpwr, rpw90*1.0e6);
   system(cmd);  
   if(BLorder == 16.0)             
-    sprintf(cmd,"Pbox lolev.DEC -u %s -w \"WURST2 %.1f/%.7f\" -sucyc m16 -s 1.0 -p %.0f -l %.1f",
-                 userdir, dbw, pwlo, rpwr, rpw90*1.0e6);
+    OSPRINTF( cmd, sizeof(cmd), "Pbox lolev.DEC -u %s -w \"WURST2 %.1f/%.7f\" -sucyc m16 -s 1.0 -p %.0f -l %.1f", userdir, dbw, pwlo, rpwr, rpw90*1.0e6);
   else
-    sprintf(cmd,"Pbox lolev.DEC -u %s -w \"WURST2 %.1f/%.7f\" -sucyc t5,m4 -s 1.0 -p %.0f -l %.1f",
-                 userdir, dbw, pwlo, rpwr, rpw90*1.0e6);
+    OSPRINTF( cmd, sizeof(cmd), "Pbox lolev.DEC -u %s -w \"WURST2 %.1f/%.7f\" -sucyc t5,m4 -s 1.0 -p %.0f -l %.1f", userdir, dbw, pwlo, rpwr, rpw90*1.0e6);
   system(cmd);               
   hidec = getDsh("hilev");
   lodec = getDsh("lolev");

--- a/src/nvpsg/RFController.cpp
+++ b/src/nvpsg/RFController.cpp
@@ -21,6 +21,12 @@
 
 #include <arpa/inet.h>
 
+extern "C" {
+
+#include "safestring.h"
+
+}
+
 #define WriteWord( x )  pAcodeBuf->putCode( x )
 #define putPattern( x ) pWaveformBuf->putCode( x )
 #define OFFSETPULSE_TIMESLICE (0.00000020L)
@@ -115,20 +121,20 @@ RFController::RFController(char *name,int flags)
           abort_message("psg internal unable to allocate memory for pattern alias list on %s. abort!\n",Name);
        patAliasListIndex= 0;
 
-       strcpy(logicalName,""); // this initialization was missing
-       strcpy(coarsePowerName,"NONE");
-       strcpy(finePowerName,"NONE");
-       strcpy(finePowerName2,"NONE");
-       strcpy(tunePwrName,""); // this initialization was missing
-       strcpy(freqName,"NONE");
-       strcpy(freqOffsetName,"NONE");
-       strcpy(dmName,"NONE");
-       strcpy(dmmName,"NONE");
-       strcpy(dmfName,"NONE");
-       strcpy(dseqName,"NONE");
-       strcpy(homoName,"NONE");
-       strcpy(dresName,"NONE");
-       strcpy(nucleusName,""); // this initialization was missing
+       logicalName[0] = 0; // this initialization was missing
+       OSTRCPY( coarsePowerName, sizeof(coarsePowerName), "NONE");
+       OSTRCPY( finePowerName, sizeof(finePowerName), "NONE");
+       OSTRCPY( finePowerName2, sizeof(finePowerName2), "NONE");
+       tunePwrName[0] = 0; // this initialization was missing
+       OSTRCPY( freqName, sizeof(freqName), "NONE");
+       OSTRCPY( freqOffsetName, sizeof(freqOffsetName), "NONE");
+       OSTRCPY( dmName, sizeof(dmName), "NONE");
+       OSTRCPY( dmmName, sizeof(dmmName), "NONE");
+       OSTRCPY( dmfName, sizeof(dmfName), "NONE");
+       OSTRCPY( dseqName, sizeof(dseqName), "NONE");
+       OSTRCPY( homoName, sizeof(homoName), "NONE");
+       OSTRCPY( dresName, sizeof(dresName), "NONE");
+       nucleusName[0]= 0; // this initialization was missing
        prevStatusDmIndex  = -1;
        prevStatusDmmIndex = -1;
        prevSyncType       = 1;
@@ -183,20 +189,20 @@ void RFController::setLogicalNames(int id, char rfNames[][8])
    //rfNames[][] = {"obs","tof","tpwr","tpwrf","xm","xmm","xmf","xseq","xhomo","sfrq","dres","xpwrt","tpwrm","tn"};
 
    logicalID = id;
-   strcpy(logicalName,     rfNames[0]);
-   strcpy(freqOffsetName,  rfNames[1]);
-   strcpy(coarsePowerName, rfNames[2]);
-   strcpy(finePowerName,   rfNames[3]);
-   strcpy(dmName,          rfNames[4]);
-   strcpy(dmmName,         rfNames[5]);
-   strcpy(dmfName,         rfNames[6]);
-   strcpy(dseqName,        rfNames[7]);
-   strcpy(homoName,        rfNames[8]);
-   strcpy(freqName,        rfNames[9]);
-   strcpy(dresName,        rfNames[10]);
-   strcpy(tunePwrName,     rfNames[11]);
-   strcpy(finePowerName2,  rfNames[12]);
-   strcpy(nucleusName,     rfNames[13]);
+   OSTRCPY( logicalName,     sizeof(logicalName),     rfNames[0]);
+   OSTRCPY( freqOffsetName,  sizeof(freqOffsetName),  rfNames[1]);
+   OSTRCPY( coarsePowerName, sizeof(coarsePowerName), rfNames[2]);
+   OSTRCPY( finePowerName,   sizeof(finePowerName),   rfNames[3]);
+   OSTRCPY( dmName,          sizeof(dmName),          rfNames[4]);
+   OSTRCPY( dmmName,         sizeof(dmmName),         rfNames[5]);
+   OSTRCPY( dmfName,         sizeof(dmfName),         rfNames[6]);
+   OSTRCPY( dseqName,        sizeof(dseqName),        rfNames[7]);
+   OSTRCPY( homoName,        sizeof(homoName),        rfNames[8]);
+   OSTRCPY( freqName,        sizeof(freqName),        rfNames[9]);
+   OSTRCPY( dresName,        sizeof(dresName),        rfNames[10]);
+   OSTRCPY( tunePwrName,     sizeof(tunePwrName),     rfNames[11]);
+   OSTRCPY( finePowerName2,  sizeof(finePowerName2),  rfNames[12]);
+   OSTRCPY( nucleusName,     sizeof(nucleusName),     rfNames[13]);
 
 // sfrq, dfrq, etc, need to be know early on ( before initializeExpStates() )
 // so let's look it up now.
@@ -895,7 +901,7 @@ void RFController::writePatternAlias(void)
           putPattern(patAliasList[i]);
        }
        char nm[32];
-       strcpy(nm,"pattern_alias_list");
+       OSTRCPY( nm, sizeof(nm), "pattern_alias_list");
 
        cPatternEntry *tmp = new cPatternEntry(nm,1,patAliasID,patAliasListIndex,patAliasListIndex);
        addPattern(tmp);
@@ -928,8 +934,8 @@ cPatternEntry *RFController::resolveRFPattern(char *nm, int flag, const char *em
     pwrf = 0.0;
     if (tmp != NULL)
       return(tmp);
-    strcpy(tname,nm);
-    strcat(tname,".RF");
+    OSTRCPY( tname, sizeof(tname), nm);
+    OSTRCAT( tname, sizeof(tname), ".RF");
     wcount = 0; eventcount = 0;
        i = findPatternFile(tname);
        if (i != 1)
@@ -1029,9 +1035,9 @@ cPatternEntry *RFController::resolveDecPattern(char *nm, int flag, double pw_90,
     int lastGateWord, lastAmpWord, lastPhaseWord;
     char tname[200],uname[200];
     double ampScale = 1023.0;
-    strcpy(tname,nm);
-    strcat(tname,".DEC");
-    sprintf(uname,"%s_%d",nm,mode);
+    OSTRCPY( tname, sizeof(tname), nm);
+    OSTRCAT( tname, sizeof(tname), ".DEC");
+    OSPRINTF( uname, sizeof(uname), "%s_%d", nm, mode);
     // do we already know the pattern??
     // disambiguate synchronous/async mode 
     cPatternEntry *tmp = find(uname, flag);
@@ -1199,13 +1205,13 @@ cPatternEntry *RFController::resolveDecOffsetPattern(char *nm, int flag, double 
     char tname[200],bname[200];
     double ampScale = 1023.0;
     //if (pw_90 > 0.002) text_error("driver needs an added memory");
-    sprintf(tname,"%s_%6.2f_%d",nm,offset,flag); //generate a unique name
+    OSPRINTF( tname, sizeof(tname), "%s_%6.2f_%d", nm, offset, flag); //generate a unique name
     // do we already know the pattern??
     cPatternEntry *tmp = find(tname, flag);
     if (tmp != NULL)
       return(tmp);
-    strcat(tname,".DEC");
-    sprintf(bname,"%s.DEC",nm);
+    OSTRCAT( tname, sizeof(tname), ".DEC");
+    OSPRINTF( bname, sizeof(bname), "%s.DEC", nm);
     scalef = 4095.0/1023.0;
     if (flag < 1)   // safety..
       flag = 1;
@@ -1328,7 +1334,7 @@ cPatternEntry *RFController::resolveFreqList(int lnum, double *offsetArray, int 
 	char nbuff[256];
 	int j,index,nsize,tstore[64];
         int wordcount,eventcount;
-	sprintf(nbuff,"__freqList_%d",lnum);
+	OSPRINTF( nbuff, sizeof(nbuff), "__freqList_%d", lnum);
 	cPatternEntry *tmp = find(nbuff, 8);
 	// already defined??
 	if (tmp != NULL)
@@ -1360,7 +1366,7 @@ int RFController::useRTFreq(int lnum,int vvar)
    char nbuff[256];
    int num, evntc, wordc;
    int abuff[4];
-   sprintf(nbuff,"__freqList_%d",lnum);
+   OSPRINTF( nbuff, sizeof(nbuff), "__freqList_%d", lnum);
    cPatternEntry *tmp = find(nbuff, 8);
    if (tmp == NULL)
      text_error("did not find frequency list");
@@ -1480,12 +1486,13 @@ cPatternEntry *RFController::resolveHomoDecPattern(char *nm, int flag, double pw
 
     ampScale = 1023.0;
     rawwfgsize = 262144;
-    strcpy(tname,nm);
-    strcat(tname,".DEC");
+    OSTRCPY( tname, sizeof(tname), nm);
+    OSTRCAT( tname, sizeof(tname), ".DEC");
     scalef = 4095.0/1023.0;
     if (flag < 1)   // safety..
       flag = 1;
-    sprintf(dbname,"%s_hd %g-%d",nm,pw_90,dwTicks); // construct a pattern id
+    // construct a pattern id
+    OSPRINTF( dbname, sizeof(dbname), "%s_hd %g-%d", nm, pw_90, dwTicks);
     // see if we can find dbname if so return it...
     // else construct,  and enter into database...
     tmp = find(dbname, flag);
@@ -1763,8 +1770,8 @@ cPatternEntry *RFController::resolveSWIFTpattern(char *nm, int dwTicks, int rfon
       abort_message("waveform shape name not defined for swift_acquire. abort!\n");
    }
 
-   strcpy(pname, nm);
-   strcat(pname,".RF");
+   OSTRCPY( pname, sizeof(pname), nm);
+   OSTRCAT( pname, sizeof(pname), ".RF");
    i = findPatternFile(pname);
    if (i != 1)
    {
@@ -2138,9 +2145,9 @@ int RFController::initializeExpStates(int setupflag)
 
   if ( P_getstring(CURRENT,"ampmode",ampModeStr,1,16) < 0)
   {
-     strcpy(ampModeStr,"dddddddddddddddddddddddd");
+     OSTRCPY( ampModeStr, sizeof(ampModeStr), "dddddddddddddddddddddddd");
   }
-  strcpy(nucStr,"none");
+  OSTRCPY( nucStr, sizeof(nucStr), "none");
   if (strcmp(logicalName,"obs")==0)  P_getstring(CURRENT,"tn",nucStr,1,256);
   if (strcmp(logicalName,"dec")==0)  P_getstring(CURRENT,"dn",nucStr,1,256);
   if (strcmp(logicalName,"dec2")==0)  P_getstring(CURRENT,"dn2",nucStr,1,256);
@@ -2426,31 +2433,31 @@ void RFController::initAmpLinearization(char *nucStr)
 
     index = 0;
 
-    strcpy(ampdir,nucStr);
+    OSTRCPY( ampdir, sizeof(ampdir), nucStr);
     if (P_getstring(GLOBAL, "hipwrampenable", strbuff, 1, 32) >= 0) {
        int i=Name[2]-'0'; // rf1=1 rf2=2 ..
        if(i>0 && strbuff[i-1]=='y')
-           strcat(ampdir,"-HP");
+           OSTRCAT( ampdir, sizeof(ampdir), "-HP");
     }
 
     // search user and system directories for tpwr map file
     if(use_tpwr>0){
-        sprintf(dirpath, "%s/amptables/%s/%s", userdir,Name,ampdir);
-        sprintf(path, "%s/tpwr.map",dirpath);
+        OSPRINTF( dirpath, sizeof(dirpath), "%s/amptables/%s/%s", userdir, Name, ampdir);
+        OSPRINTF( path, sizeof(path), "%s/tpwr.map",dirpath);
         FILE *fp = fopen(path, "r");
         if (fp == NULL){
-            sprintf(dirpath, "%s/amptables/%s/%s", systemdir,Name,ampdir);
-            sprintf(path, "%s/tpwr.map",dirpath);
+            OSPRINTF( dirpath, sizeof(dirpath), "%s/amptables/%s/%s", systemdir, Name, ampdir);
+            OSPRINTF( path, sizeof(path), "%s/tpwr.map", dirpath);
             fp = fopen(path, "r");
         }
         if (fp == NULL){
-            sprintf(dirpath, "%s/amptables/%s", userdir,Name);
-            sprintf(path, "%s/tpwr.map",dirpath);
+            OSPRINTF( dirpath, sizeof(dirpath), "%s/amptables/%s", userdir, Name);
+            OSPRINTF( path, sizeof(path), "%s/tpwr.map", dirpath);
             fp = fopen(path, "r");
         }
         if (fp == NULL){
-            sprintf(dirpath, "%s/amptables/%s", systemdir,Name);
-            sprintf(path, "%s/tpwr.map",dirpath);
+            OSPRINTF( dirpath, sizeof(dirpath), "%s/amptables/%s", systemdir, Name);
+            OSPRINTF( path, sizeof(path), "%s/tpwr.map", dirpath);
             fp = fopen(path, "r");
         }
         if (fp == NULL){
@@ -2495,12 +2502,12 @@ void RFController::initAmpLinearization(char *nucStr)
     }
 
     // search user and system directories for table info file
-    sprintf(dirpath, "%s/amptables/%s/%s", userdir,Name,ampdir);
-    sprintf(path, "%s/tables.map",dirpath);
+    OSPRINTF( dirpath, sizeof(dirpath), "%s/amptables/%s/%s", userdir, Name, ampdir);
+    OSPRINTF( path, sizeof(path), "%s/tables.map", dirpath);
     FILE *fp = fopen(path, "r");
     if (fp == NULL){
-        sprintf(dirpath, "%s/amptables/%s/%s", systemdir,Name,ampdir);
-        sprintf(path, "%s/tables.map",dirpath);
+        OSPRINTF( dirpath, sizeof(dirpath), "%s/amptables/%s/%s", systemdir, Name, ampdir);
+        OSPRINTF( path, sizeof(path), "%s/tables.map", dirpath);
         fp = fopen(path, "r");
     }
     if (fp == NULL){
@@ -2578,7 +2585,7 @@ void RFController::initAmpLinearization(char *nucStr)
         bool bintables=false;
         if(strcmp(tblfile,"inline")!=0){
             fclose(fp);
-            sprintf(path, "%s/%s", dirpath,tblfile);
+            OSPRINTF( path, sizeof(path), "%s/%s", dirpath, tblfile);
             fp = fopen(path, "rb");
             if(fp==NULL){
                 use_tbls=0;
@@ -3215,7 +3222,7 @@ cPatternEntry *RFController::makeOffsetPattern(char *nm, int nInc, double phss, 
   int wcount, eventcount, repeats,trepeats;
   char qname[200],tname[200];
   pInc = degrees2Binary(phss); //  --- rounding .....
-  sprintf(qname,"ols_%s:%d,%g_%5.3f_%s",nm,nInc,phss,pacc,tag);
+  OSPRINTF( qname, sizeof(qname), "ols_%s:%d,%g_%5.3f_%s", nm, nInc, phss, pacc, tag);
 
   cPatternEntry *tmp;
 
@@ -3238,8 +3245,8 @@ cPatternEntry *RFController::makeOffsetPattern(char *nm, int nInc, double phss, 
   pDinc = phss*((double) nInc);
   wcount = 0;
   eventcount = 0;
-  strcpy(tname,nm);
-  strcat(tname,".RF");
+  OSTRCPY( tname, sizeof(tname), nm);
+  OSTRCAT( tname, sizeof(tname), ".RF");
   //
   i = findPatternFile(tname);
   if (i != 1)
@@ -3325,8 +3332,8 @@ int RFController::analyzeRFPattern(char *nm, int flag, const char *emsg, int act
     {
       return tmp->getNumberStates();
     }
-    strcpy(tname,nm);
-    strcat(tname,".RF");
+    OSTRCPY( tname, sizeof(tname), nm);
+    OSTRCAT( tname, sizeof(tname), ".RF");
     wcount = 0; eventcount = 0;
 
        i = findPatternFile(tname);
@@ -3386,20 +3393,23 @@ int RFController::rRFOffsetShapeList(char *baseshape, double pw, double *offsetL
 
    int numEntries = (int)num;
 
-   if (strcmp(baseshape,"") == 0) strcpy(pname,"hard"); else strcpy(pname,baseshape);
+   if (strcmp(baseshape,"") == 0)
+       OSTRCPY( pname, sizeof(pname), "hard");
+   else
+       OSTRCPY( pname, sizeof(pname), baseshape);
 
    refPat = resolveRFPattern(pname,1,"RFoffset_shapelist",1);
    if (refPat == NULL)
        abort_message("unable to find %s shape file. abort!\n",pname);
    rmspower = refPat->getPowerFraction(); // everyone's got the same power.. 
-   strcpy(tagname,"");
+   OSTRCPY( tagname, sizeof(tagname), "");
    // generates a signature of the offset list ..
    if (numEntries > 1)
    {
 	   tsum = 0.0;
 	   for (i=1; i < numEntries; i++)
 		   tsum += *(offsetList+i);
-	   sprintf(tagname,"%7.1f",tsum);
+	   OSPRINTF( tagname, sizeof(tagname), "%7.1f", tsum);
    }
    numberStates = refPat->getNumberStates();
    listId = -1;
@@ -3597,7 +3607,7 @@ int RFController::registerUserDECShape(char *name, struct _DECpattern *pa, doubl
     int pcntrl;
     // do we already know the pattern??
     if (dps_flag) return(0);
-    sprintf(lname,"%s_%d",name,mode); 
+    OSPRINTF( lname, sizeof(lname), "%s_%d", name, mode);
     cPatternEntry *tmp = find(lname, 2);  /* flag?? */
     if (tmp != NULL)
       return(0);
@@ -3767,7 +3777,7 @@ RFSpecificPulse::RFSpecificPulse(int RFChanNum, int onOff, char cmode, char *nam
   rfChanID = RFChanNum;
   p2rfc = P2TheConsole->getRFControllerByLogicalIndex(rfChanID);
   onFlag = onOff;
-  strncpy(shapeName,name,256);
+  OSTRCPY( shapeName, sizeof(shapeName), name);
   pw = pwidth;
   mode[0] = cmode;
   tpwr = cpwr;

--- a/src/nvpsg/WaveformUtility.cpp
+++ b/src/nvpsg/WaveformUtility.cpp
@@ -16,6 +16,12 @@
 #include "cpsg.h"
 #include "FFKEYS.h"
 
+extern "C" {
+    
+#include "safestring.h"
+
+}
+
 #define OFFSETPULSE_TIMESLICE (0.00000020L)
 
 extern int bgflag;
@@ -41,7 +47,7 @@ cPatternEntry *WaveformUtility::readRFWaveform(char *name, RFController *rf1, un
   wcount = 0; eventcount = 0;
   scalef = 4095.0/1023.0;
 
-  strcpy(tname,name);
+  OSTRCPY( tname, sizeof(tname), name);
      i = rf1->findPatternFile(tname);
      if (i != 1)
        {

--- a/src/nvpsg/aptable.c
+++ b/src/nvpsg/aptable.c
@@ -24,6 +24,7 @@
 
 #include "lc.h"
 
+#include "safestring.h"
 
 /*************************
 *  Constant Definitions  *
@@ -445,7 +446,7 @@ int loadtable(char *infilename)
    else
    {
       parsetable = TRUE;
-      strcpy(tablelimits[loadtablecall].previnfilename, infilename);
+      OSTRCPY( tablelimits[loadtablecall].previnfilename, sizeof(tablelimits[loadtablecall].previnfilename), infilename);
    }
 
 /**********************************************************
@@ -1792,9 +1793,9 @@ static FILE *open_table(const char *basename, const char *concatname,
    char	tblfilename[MAXSTR];
    FILE	*tablefile;
 
-   strcpy(tblfilename, basename);
-   strcat(tblfilename, concatname);
-   strcat(tblfilename, inputname);
+   OSTRCPY( tblfilename, sizeof(tblfilename), basename);
+   OSTRCAT( tblfilename, sizeof(tblfilename), concatname);
+   OSTRCAT( tblfilename, sizeof(tblfilename), inputname);
    tablefile = fopen(tblfilename, permission);
 
    return(tablefile);

--- a/src/nvpsg/arrayfuncs.c
+++ b/src/nvpsg/arrayfuncs.c
@@ -25,6 +25,8 @@
 
 #include "PSGFileHeader.h"
 
+#include "safestring.h"
+
 #define DPRTLEVEL 1
 #define MAXGLOBALS 136
 #define MAXGVARLEN 40
@@ -1058,7 +1060,7 @@ static void initglblstruc(const char *name, double *glbladdr, int (*function)() 
       fprintf(stdout, "initglblstruc: index: %d beyond limit %d\n", index, MAXGLOBALS);
       psg_abort(1);
    }
-   strcpy(glblvars[index].gnam, name);
+   OSTRCPY( glblvars[index].gnam, sizeof(glblvars[index].gnam), name);
    glblvars[index].glblvalue = glbladdr;
    glblvars[index].funcptr = function;
    glblCount++;

--- a/src/nvpsg/chempack.c
+++ b/src/nvpsg/chempack.c
@@ -27,6 +27,8 @@
 #include "cps.h"
 
 
+#include "safestring.h"
+
 void shaped_satpulse(const char *shn, double saturation1, codeint sphse1) {
     FILE *inpf;
     double *ofq, reps=0.0, uspw90;
@@ -34,10 +36,10 @@ void shaped_satpulse(const char *shn, double saturation1, codeint sphse1) {
     extern char userdir[];
     int nlf, i;
     
-    sprintf(shname, "%s_%s",seqfil,shn);
+    OSPRINTF( shname, sizeof(shname), "%s_%s", seqfil, shn);
     if (FIRST_FID) {
         uspw90 = (getval("pw90"))*1e6*(getval("tpwr_cf"));
-        sprintf(str, "%s/shapelib/Pbox.inp" , userdir);
+        OSPRINTF( str, sizeof(str), "%s/shapelib/Pbox.inp" , userdir);
         inpf = fopen(str, "w");
         nlf = getArrayparval("pstof",&ofq);
         for (i=0; i<nlf; i++)
@@ -45,7 +47,7 @@ void shaped_satpulse(const char *shn, double saturation1, codeint sphse1) {
         fprintf(inpf, " attn = e \n");
         fclose(inpf);
         
-        sprintf(cmd, "Pbox %s.RF -%.0f -l %.2f -p %.0f \n", shname,reps,uspw90,tpwr);
+        OSPRINTF( cmd, sizeof(cmd), "Pbox %s.RF -%.0f -l %.2f -p %.0f \n", shname, reps, uspw90, tpwr);
         system(cmd);
     }
     
@@ -63,10 +65,10 @@ void shaped_saturate(const char *shn2, double saturation2, codeint sphse2) {
     extern char userdir[];
     int nlf, i;
     
-    sprintf(shname, "%s_%s",seqfil,shn2);
+    OSPRINTF( shname, sizeof(shname), "%s_%s", seqfil, shn2);
     if (FIRST_FID) {
         uspw90 = (getval("pw90"))*1e6*(getval("tpwr_cf"));
-        sprintf(str, "%s/shapelib/Pbox.inp" , userdir);
+        OSPRINTF( str, sizeof(str), "%s/shapelib/Pbox.inp" , userdir);
         inpf = fopen(str, "w");
         nlf = getArrayparval("pstof",&ofq);
         for (i=0; i<nlf; i++)
@@ -74,7 +76,7 @@ void shaped_saturate(const char *shn2, double saturation2, codeint sphse2) {
         fprintf(inpf, " attn = e \n");
         fclose(inpf);
         
-        sprintf(cmd, "Pbox %s.DEC -%.0f -l %.2f -p %.0f \n", shname,reps,uspw90,tpwr);
+        OSPRINTF( cmd, sizeof(cmd), "Pbox %s.DEC -%.0f -l %.2f -p %.0f \n", shname, reps, uspw90, tpwr);
         system(cmd);
     }
     

--- a/src/nvpsg/chempack.h
+++ b/src/nvpsg/chempack.h
@@ -14,6 +14,8 @@
 #include "Pbox_psg.h"
 #endif
 
+#include "safestring.h"
+
 /*
   Four functions:
   shaped_satpulse(shapename,satduration,frequencyparameter)
@@ -35,12 +37,12 @@ void shaped_satpulse(const char *shn, double saturation1, codeint sphse1)
   extern char userdir[];
   int nlf, i;
 
-  sprintf(shname, "%s_%s",seqfil,shn);
+  OSPRINTF( shname, sizeof(shname), "%s_%s", seqfil,shn);
   if (FIRST_FID)
   {
-        int ret __attribute__((unused));
+    int ret __attribute__((unused));
   	uspw90 = (getval("pw90"))*1e6*(getval("tpwr_cf"));
-  	sprintf(str, "%s/shapelib/Pbox.inp" , userdir);
+  	OSPRINTF( str, sizeof(str), "%s/shapelib/Pbox.inp" , userdir);
   	inpf = fopen(str, "w");
   	nlf = getArrayparval("pstof",&ofq);
   	for (i=0; i<nlf; i++)
@@ -48,7 +50,7 @@ void shaped_satpulse(const char *shn, double saturation1, codeint sphse1)
   	fprintf(inpf, " attn = e \n");
   	fclose(inpf);
 
-  	sprintf(cmd, "Pbox %s.RF -u %s -%.0f -l %.2f -p %.0f \n", shname,userdir,reps,uspw90,tpwr);
+  	OSPRINTF( cmd, sizeof(cmd), "Pbox %s.RF -u %s -%.0f -l %.2f -p %.0f \n", shname, userdir, reps, uspw90, tpwr);
   	ret = system(cmd);
   }
   obspower(satpwr);
@@ -65,12 +67,12 @@ void shaped_saturate(const char *shn2, double saturation2, codeint sphse2)
   extern char userdir[];
   int nlf, i;
 
-  sprintf(shname, "%s_%s",seqfil,shn2);
+  OSPRINTF( shname, sizeof(shname), "%s_%s", seqfil, shn2);
   if (FIRST_FID)
   {
-        int ret __attribute__((unused));
+    int ret __attribute__((unused));
   	uspw90 = (getval("pw90"))*1e6*(getval("tpwr_cf"));
-  	sprintf(str, "%s/shapelib/Pbox.inp" , userdir);
+  	OSPRINTF( str, sizeof(str), "%s/shapelib/Pbox.inp", userdir);
   	inpf = fopen(str, "w");
   	nlf = getArrayparval("pstof",&ofq);
   	for (i=0; i<nlf; i++)
@@ -78,7 +80,7 @@ void shaped_saturate(const char *shn2, double saturation2, codeint sphse2)
   	fprintf(inpf, " attn = e \n");
   	fclose(inpf);
 
-  	sprintf(cmd, "Pbox %s.DEC -u %s -%.0f -l %.2f -p %.0f \n", shname,userdir,reps,uspw90,tpwr);
+  	OSPRINTF( cmd, sizeof(cmd), "Pbox %s.DEC -u %s -%.0f -l %.2f -p %.0f \n", shname, userdir, reps, uspw90, tpwr);
   	ret = system(cmd);
   }
 

--- a/src/nvpsg/initacqparms.c
+++ b/src/nvpsg/initacqparms.c
@@ -28,6 +28,7 @@
 #include "ACode32.h"
 #include "acqparms.h"
 #include "cps.h"
+#include "safestring.h"
 
 /*  PSG_LC  conditional compiles lc.h properly for PSG */
 #ifndef  PSG_LC
@@ -741,23 +742,23 @@ int setup_parfile(int suflag)
     {   text_error("initacqqueue(): cannot get userdir");
 	psg_abort(1);
     }
-    strcpy(ExpInfo.UsrDirFile,tmpstr);
+    OSTRCPY( ExpInfo.UsrDirFile, sizeof(ExpInfo.UsrDirFile), tmpstr);
 
     if (P_getstring(GLOBAL,"systemdir",tmpstr,1,255) < 0)
     {   text_error("initacqqueue(): cannot get systemdir");
 	psg_abort(1);
     }
-    strcpy(ExpInfo.SysDirFile,tmpstr);
+    OSTRCPY( ExpInfo.SysDirFile, sizeof(ExpInfo.SysDirFile), tmpstr);
 
     if (P_getstring(GLOBAL,"curexp",tmpstr,1,255) < 0)
     {   text_error("initacqqueue(): cannot get curexp");
 	psg_abort(1);
     }
-    strcpy(ExpInfo.CurExpFile,tmpstr);
+    OSTRCPY( ExpInfo.CurExpFile, sizeof(ExpInfo.CurExpFile), tmpstr);
 
     /* multiple reciever mapping for recvproc */
     ExpInfo.RvcrMapping[0] = (char) 0;
-    RcvrMapStr("rcvrs",ExpInfo.RvcrMapping);
+    RcvrMapStr("rcvrs", ExpInfo.RvcrMapping);
     if (bgflag) fprintf(stdout," [[[[[[[[[-->>  RcvrMapStr: '%s'\n",ExpInfo.RvcrMapping);
 
     /* --- suflag					*/
@@ -775,28 +776,28 @@ int setup_parfile(int suflag)
     {   text_error("initacqqueue(): cannot get goid");
 	psg_abort(1);
     }
-    strcpy(ExpInfo.InitCodefile,infopath);
-    strcat(ExpInfo.InitCodefile,".init");
-    strcpy(ExpInfo.PreCodefile,infopath);
-    strcat(ExpInfo.PreCodefile,".pre");
-    strcpy(ExpInfo.PSCodefile,infopath);
-    strcat(ExpInfo.PSCodefile,".ps");
-    strcpy(ExpInfo.PostCodefile,infopath);
-    strcat(ExpInfo.PostCodefile,".post");
+    OSTRCPY( ExpInfo.InitCodefile, sizeof(ExpInfo.InitCodefile), infopath);
+    OSTRCAT( ExpInfo.InitCodefile, sizeof(ExpInfo.InitCodefile), ".init");
+    OSTRCPY( ExpInfo.PreCodefile, sizeof(ExpInfo.PreCodefile), infopath);
+    OSTRCAT( ExpInfo.PreCodefile, sizeof(ExpInfo.PreCodefile), ".pre");
+    OSTRCPY( ExpInfo.PSCodefile, sizeof(ExpInfo.PSCodefile), infopath);
+    OSTRCAT( ExpInfo.PSCodefile, sizeof(ExpInfo.PSCodefile), ".ps");
+    OSTRCPY( ExpInfo.PostCodefile, sizeof(ExpInfo.PostCodefile), infopath);
+    OSTRCAT( ExpInfo.PostCodefile, sizeof(ExpInfo.PostCodefile), ".post");
 
-    strcpy(ExpInfo.RTParmFile,infopath);
-    strcat(ExpInfo.RTParmFile,".RTpars");
-    strcpy(ExpInfo.AcqRTTablefile,infopath);
-    strcat(ExpInfo.AcqRTTablefile,".init.InitAcqObject");
-    strcpy(ExpInfo.WaveFormFile,infopath);
-    strcat(ExpInfo.WaveFormFile,".pat");
+    OSTRCPY( ExpInfo.RTParmFile, sizeof(ExpInfo.RTParmFile), infopath);
+    OSTRCAT( ExpInfo.RTParmFile, sizeof(ExpInfo.RTParmFile), ".RTpars");
+    OSTRCPY( ExpInfo.AcqRTTablefile, sizeof(ExpInfo.AcqRTTablefile), infopath);
+    OSTRCAT( ExpInfo.AcqRTTablefile, sizeof(ExpInfo.AcqRTTablefile), ".init.InitAcqObject");
+    OSTRCPY( ExpInfo.WaveFormFile, sizeof(ExpInfo.WaveFormFile), infopath);
+    OSTRCAT( ExpInfo.WaveFormFile, sizeof(ExpInfo.WaveFormFile), ".pat");
 
     /* Beware that infopath gets accessed again
        if acqiflag is set, for the data file path */
 
     /* --- file path to named acqfile or exp# acqfile  'file' --- */
 
-    strcpy(ExpInfo.VpMsgID,"");
+    OSTRCPY( ExpInfo.VpMsgID, sizeof(ExpInfo.VpMsgID), "");
     if (!acqiflag)
     {
       int autoflag;
@@ -806,7 +807,7 @@ int setup_parfile(int suflag)
       {   text_error("initacqqueue(): cannot get exppath");
 	  psg_abort(1);
       }
-      strcpy(ExpInfo.DataFile,tmpstr);
+      OSTRCPY( ExpInfo.DataFile, sizeof(ExpInfo.DataFile), tmpstr);
       ExpInfo.InteractiveFlag = 0;
       if (getparm("auto","string",GLOBAL,autopar,12))
           autoflag = 0;
@@ -815,14 +816,14 @@ int setup_parfile(int suflag)
       ExpInfo.ExpFlags = 0;
       if (autoflag)
       {
-         strcat(ExpInfo.DataFile,".fid");
+         OSTRCAT( ExpInfo.DataFile, sizeof(ExpInfo.DataFile), ".fid");
 	 ExpInfo.ExpFlags |= AUTOMODE_BIT;  /* set automode bit */
       }
       if ( ! P_getstring(CURRENT,"vpmode",autopar,1,12) && (autopar[0] == 'y') )
       {
          ExpInfo.ExpFlags |= VPMODE_BIT;  /* set vpmode bit */
          if (P_getstring(CURRENT,"VPaddr",tmpstr,1,255) >= 0)
-           strcpy(ExpInfo.VpMsgID,tmpstr);
+           OSTRCPY( ExpInfo.VpMsgID, sizeof(ExpInfo.VpMsgID), tmpstr);
       }
       if (ra_flag)
          ExpInfo.ExpFlags |=  RESUME_ACQ_BIT;  /* set RA bit */
@@ -831,8 +832,8 @@ int setup_parfile(int suflag)
     }
     else
     {
-      strcpy(ExpInfo.DataFile,infopath);
-      strcat(ExpInfo.DataFile,".Data");
+      OSTRCPY( ExpInfo.DataFile, sizeof(ExpInfo.DataFile), infopath);
+      OSTRCAT( ExpInfo.DataFile, sizeof(ExpInfo.DataFile), ".Data");
       ExpInfo.InteractiveFlag = 1;
       ExpInfo.ExpFlags = 0;
     }
@@ -841,7 +842,7 @@ int setup_parfile(int suflag)
     {   text_error("initacqqueue(): cannot get goid: user");
 	psg_abort(1);
     }
-    strcpy(ExpInfo.UserName,tmpstr);
+    OSTRCPY( ExpInfo.UserName, sizeof(ExpInfo.UserName), tmpstr);
 
     if (P_getstring(CURRENT,"goid",tmpstr,3,255) < 0)
     {   text_error("initacqqueue(): cannot get goid: exp number");
@@ -853,13 +854,13 @@ int setup_parfile(int suflag)
     {   text_error("initacqqueue(): cannot get goid: exp");
 	psg_abort(1);
     }
-    strcpy(ExpInfo.AcqBaseBufName,tmpstr);
+    OSTRCPY( ExpInfo.AcqBaseBufName, sizeof(ExpInfo.AcqBaseBufName), tmpstr);
 
     if (P_getstring(GLOBAL,"vnmraddr",tmpstr,1,255) < 0)
     {   text_error("initacqqueue(): cannot get vnmraddr");
 	psg_abort(1);
     }
-    strcpy(ExpInfo.MachineID,tmpstr);
+    OSTRCPY( ExpInfo.MachineID, sizeof(ExpInfo.MachineID), tmpstr);
 
     /* --- interleave parameter 'il' --- */
 
@@ -939,8 +940,8 @@ int setup_parfile(int suflag)
     umask( ExpInfo.UserUmask );		/* make sure the process umask does not change */
 
     /* fill in the account info */
-    strcpy(tmpstr,ExpInfo.SysDirFile);
-    strcat(tmpstr,"/adm/accounting/acctLog.xml");
+    OSTRCPY( tmpstr, sizeof(tmpstr), ExpInfo.SysDirFile);
+    OSTRCAT( tmpstr, sizeof(tmpstr), "/adm/accounting/acctLog.xml");
     if ( access(tmpstr,F_OK) != 0)
     {
        ExpInfo.Billing.enabled = 0;
@@ -956,20 +957,24 @@ int setup_parfile(int suflag)
         if (P_getstring(GLOBAL, "operator", tmpstr, 1, 255) < 0)
            ExpInfo.Billing.Operator[0]='\000';
         else
-           strncpy(ExpInfo.Billing.Operator,tmpstr,200);
+           // BDZ: 200 should be sizeof(ExpInfo.Billing.Operator)
+           OSTRCPY(ExpInfo.Billing.Operator, 200, tmpstr);
         if (P_getstring(CURRENT, "account", tmpstr, 1, 255) < 0)
            ExpInfo.Billing.account[0]='\000';
         else
-           strncpy(ExpInfo.Billing.account,tmpstr,200);
+           // BDZ 200 should be sizeof(ExpInfo.Billing.account)
+           OSTRCPY(ExpInfo.Billing.account, 200, tmpstr);
         if (P_getstring(CURRENT, "pslabel", tmpstr, 1, 255) < 0)
            ExpInfo.Billing.seqfil[0]='\000';
         else
-           strncpy(ExpInfo.Billing.seqfil,tmpstr,200);
+           // BDZ 200 should be sizeof(ExpInfo.Billing.seqfil)
+           OSTRCPY(ExpInfo.Billing.seqfil, 200, tmpstr);
         ptr = strrchr(infopath,'/');
         if ( ptr )
         {
            ptr++;
-           strncpy(ExpInfo.Billing.goID, ptr ,200);
+           // BDZ 200 should be sizeof(ExpInfo.Billing.goID)
+           OSTRCPY(ExpInfo.Billing.goID, 200, ptr);
         }
         else
         {
@@ -983,7 +988,7 @@ void set_rcvrs_info()
 {
     /* multiple reciever mapping for recvproc */
     ExpInfo.RvcrMapping[0] = (char) 0;
-    RcvrMapStr("rcvrs",ExpInfo.RvcrMapping);
+    RcvrMapStr("rcvrs", ExpInfo.RvcrMapping);
     if (bgflag) fprintf(stdout," [[[[[[[[[-->>  RcvrMapStr: '%s'\n",ExpInfo.RvcrMapping);
 }
 
@@ -1030,16 +1035,21 @@ void write_shr_info(double exp_time)
        ExpInfo.NumTables = num_tables;
     */
 
-    if ( ! AcodeManager_getAcodeStageWriteFlag(0) ) strcpy(ExpInfo.InitCodefile,"\0");
-    if ( ! AcodeManager_getAcodeStageWriteFlag(1) ) strcpy(ExpInfo.PreCodefile,"\0");
-    if ( ! AcodeManager_getAcodeStageWriteFlag(2) ) strcpy(ExpInfo.PSCodefile,"\0");
-    if ( ! AcodeManager_getAcodeStageWriteFlag(3) ) strcpy(ExpInfo.PostCodefile,"\0");
-    if ( ! AcodeManager_getAcodeStageWriteFlag(4) ) strcpy(ExpInfo.WaveFormFile,"\0");
+    if ( ! AcodeManager_getAcodeStageWriteFlag(0) )
+      OSTRCPY( ExpInfo.InitCodefile, sizeof(ExpInfo.InitCodefile), "\0");
+    if ( ! AcodeManager_getAcodeStageWriteFlag(1) )
+      OSTRCPY( ExpInfo.PreCodefile,  sizeof(ExpInfo.PreCodefile), "\0");
+    if ( ! AcodeManager_getAcodeStageWriteFlag(2) )
+      OSTRCPY( ExpInfo.PSCodefile,   sizeof(ExpInfo.PSCodefile), "\0");
+    if ( ! AcodeManager_getAcodeStageWriteFlag(3) )
+      OSTRCPY( ExpInfo.PostCodefile, sizeof(ExpInfo.PostCodefile), "\0");
+    if ( ! AcodeManager_getAcodeStageWriteFlag(4) )
+      OSTRCPY( ExpInfo.WaveFormFile, sizeof(ExpInfo.WaveFormFile), "\0");
 
     if (ExpInfo.InteractiveFlag)
     {
        char tmppath[256];
-       sprintf(tmppath,"%s.new",infopath);
+       OSPRINTF( tmppath, sizeof(tmppath), "%s.new", infopath);
        unlink(tmppath);
        Infofd = open(tmppath,O_EXCL | O_WRONLY | O_CREAT,0666);
     }
@@ -1066,14 +1076,14 @@ void ra_inovaacqparms(unsigned int fidn)
    char fidpath[512];
    int curct;
 
-   sprintf(fidpath,"%s/fid",ExpInfo.DataFile);
+   OSPRINTF( fidpath, sizeof(fidpath), "%s/fid", ExpInfo.DataFile);
    if (fidn == 1)
    {
      ifile = mOpen(fidpath,ExpInfo.DataSize,O_RDONLY );
      if (ifile == NULL)
      {
-	text_error("Cannot open data file: '%s', RA aborted.\n",
-		ExpInfo.DataFile);
+       text_error("Cannot open data file: '%s', RA aborted.\n",
+               ExpInfo.DataFile);
        psg_abort(1);
      }
      /* read in file header */
@@ -1081,20 +1091,20 @@ void ra_inovaacqparms(unsigned int fidn)
 					sizeof(acqfileheader));
      if (acqfileheader.np != ExpInfo.NumDataPts)
      {
-	text_error("FidFile np: %d not equal NumDataPts: %d, RA aborted.\n",
-		acqfileheader.np,ExpInfo.NumDataPts);
+       text_error("FidFile np: %d not equal NumDataPts: %d, RA aborted.\n",
+               acqfileheader.np,ExpInfo.NumDataPts);
        psg_abort(1);
      }
      if (acqfileheader.ebytes != ExpInfo.DataPtSize)
      {
-	text_error("FidFile dp: %d not equal DataPtSize: %d, RA aborted.\n",
-		acqfileheader.ebytes,ExpInfo.DataPtSize);
+       text_error("FidFile dp: %d not equal DataPtSize: %d, RA aborted.\n",
+               acqfileheader.ebytes,ExpInfo.DataPtSize);
        psg_abort(1);
      }
      if (acqfileheader.ntraces != ExpInfo.NumFids)
      {
-	text_error("FidFile nf: %d not equal NumFids: %d, RA aborted.\n",
-		acqfileheader.ntraces,ExpInfo.NumFids);
+       text_error("FidFile nf: %d not equal NumFids: %d, RA aborted.\n",
+               acqfileheader.ntraces,ExpInfo.NumFids);
        psg_abort(1);
      }
      ifile->offsetAddr += sizeof(acqfileheader);  /* move my file pointers */
@@ -1115,14 +1125,14 @@ void ra_inovaacqparms(unsigned int fidn)
 	   {
 	      if (curct != (((ExpInfo.CurrentTran/ExpInfo.NumInBS)+1) *
 							ExpInfo.NumInBS))
-	    text_error("Warning: File_ct(%d): %d not equal ct+bs: %d\n",
-		fidn,curct,ExpInfo.CurrentTran+ExpInfo.NumInBS);
+             text_error("Warning: File_ct(%d): %d not equal ct+bs: %d\n",
+                        fidn, curct, ExpInfo.CurrentTran + ExpInfo.NumInBS);
 	   }
 	   else
 	   {
 	      if (curct != ExpInfo.CurrentTran)
-	    text_error("Warning: File_ct(%d): %d not equal ct: %d\n",
-		fidn,curct,ExpInfo.CurrentTran);
+             text_error("Warning: File_ct(%d): %d not equal ct: %d\n",
+                        fidn, curct, ExpInfo.CurrentTran);
 	   }
 	}
 	else
@@ -1130,14 +1140,14 @@ void ra_inovaacqparms(unsigned int fidn)
 	   if (fidn < getStartFidNum())
 	   {
 	      if (curct != ExpInfo.NumTrans)
-	    text_error("Warning: File_ct(%d): %d not equal nt: %d\n",
-		fidn,curct,ExpInfo.NumTrans);
+             text_error("Warning: File_ct(%d): %d not equal nt: %d\n",
+                        fidn, curct, ExpInfo.NumTrans);
 	   }
 	   else
 	   {
 	      if (curct != ExpInfo.CurrentTran)
-	    text_error("Warning: File_ct(%d): %d not equal ct: %d\n",
-		fidn,curct,ExpInfo.CurrentTran);
+             text_error("Warning: File_ct(%d): %d not equal ct: %d\n",
+                        fidn, curct, ExpInfo.CurrentTran);
 	   }
 	}
 
@@ -1153,8 +1163,8 @@ void ra_inovaacqparms(unsigned int fidn)
 					sizeof(acqblockheader));
 	curct = acqblockheader.ctcount;
 	if (curct != ExpInfo.CurrentTran)
-	  text_error("Warning: File_ct(%d): %d not equal CurrentTran: %d\n",
-		fidn,curct,ExpInfo.CurrentTran);
+       text_error("Warning: File_ct(%d): %d not equal CurrentTran: %d\n",
+                  fidn, curct, ExpInfo.CurrentTran);
    }
    else curct = 0;
 

--- a/src/nvpsg/math.c
+++ b/src/nvpsg/math.c
@@ -11,6 +11,10 @@
 
 extern void broadcastCodes(int, int, int*);
 
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
 /*--------------------------------------------------------------
 |	incr(a)
 |	 a++;, where a is a real time variables

--- a/src/nvpsg/pboxpulse.h
+++ b/src/nvpsg/pboxpulse.h
@@ -28,8 +28,11 @@
 // Structure for PBOXPULSE
 // =============================
 #define PB_NSUFFIX 13
+
 typedef struct {
+   
    char seqName[PB_NSUFFIX]; // Xc7,Yspc5 etc...
+   
    char ch[5];       // channel on which to execute the pulse
    char wv[64];      // type of softpulse, names in wavelib
    double db;        // scaler value - 16 to 63
@@ -123,16 +126,15 @@ PBOXPULSE update_PBOXPULSE(PBOXPULSE shp, int iRec)
 
    char lpattern[NPATTERN];
    var = getname0("",shp.seqName,"");
-   sprintf(lpattern,"%s%d",var,shp.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, shp.nRec);
    shp.hasArray = hasarry(shp.array, lpattern);
    int lix = arryindex(shp.array);
    if (shp.calc > 0) {
       var = getname0("",shp.seqName,"");
-      sprintf(shp.pattern,"%s%d_%d",var,shp.nRec,lix);
+      OSPRINTF( shp.pattern, sizeof(shp.pattern), "%s%d_%d", var, shp.nRec, lix);
       if (shp.hasArray == 1) {
          int ret __attribute__((unused));
-	 sprintf(cmd,"Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f %.2f\" -stepsize 0.2\n",
-                shp.pattern,shp.wv,shp.pw,shp.of,shp.st,shp.ph,shp.fla);
+         OSPRINTF( cmd, sizeof(cmd), "Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f %.2f\" -stepsize 0.2\n", shp.pattern, shp.wv, shp.pw, shp.of, shp.st, shp.ph, shp.fla);
          ret = system(cmd);
          pboxshp = getRsh(shp.pattern); 
          shp.B1max = pboxshp.B1max; 
@@ -161,7 +163,7 @@ PBOXPULSE combine_PBOXPULSE(PBOXPULSE shp1, PBOXPULSE shp2, int iRec, int calc)
 // The two Shapes must be on the same channel
 
    if (strcmp(shp1.ch,shp2.ch) == 0) { 
-      strcpy(shp.ch,shp1.ch); 
+      OSTRCPY( shp.ch, sizeof(shp.ch), shp1.ch); 
 
 // Set the larger power for shp
 
@@ -204,13 +206,13 @@ PBOXPULSE combine_PBOXPULSE(PBOXPULSE shp1, PBOXPULSE shp2, int iRec, int calc)
 
 // Concatenate the wave names for shp (not used)
 
-      strcpy(shp.wv, shp1.wv);           
-      strcat(shp.wv,shp2.wv);
+      OSTRCPY( shp.wv, sizeof(shp.wv), shp1.wv);
+      OSTRCAT( shp.wv, sizeof(shp.wv), shp2.wv);
 
 // Concatenate the seqName's for shp (not used)
 
-      strcpy(shp.seqName, shp1.seqName);
-      strcat(shp.seqName,shp2.seqName);
+      OSTRCPY( shp.seqName, sizeof(shp.seqName), shp1.seqName);
+      OSTRCAT( shp.seqName, sizeof(shp.seqName), shp2.seqName);
 
 // Set other defaults for shp
 
@@ -223,23 +225,21 @@ PBOXPULSE combine_PBOXPULSE(PBOXPULSE shp1, PBOXPULSE shp2, int iRec, int calc)
 
       char lpattern[10*NPATTERN];
       var1 = getname0("",shp1.seqName,"");
-      strcpy(bar1,var1); 
+      OSTRCPY( bar1, sizeof(bar1), var1); 
       var2 = getname0("",shp2.seqName,"");
-      strcpy(bar2,var2);
-      sprintf(lpattern,"%s%d_%s%d",bar1,shp1.nRec,bar2,shp2.nRec);
+      OSTRCPY( bar2, sizeof(bar2), var2);
+      OSPRINTF( lpattern, sizeof(lpattern), "%s%d_%s%d", bar1, shp1.nRec, bar2, shp2.nRec);
       shp.hasArray = hasarry(shp.array, lpattern);
       int lix = arryindex(shp.array);
       if (shp.calc > 0) {
          var1 = getname0("",shp1.seqName,"");
-         strcpy(bar1,var1); 
+         OSTRCPY( bar1, sizeof(bar1), var1);
          var2 = getname0("",shp2.seqName,"");
-         strcpy(bar2,var2);  
-         sprintf(shp.pattern,"%s%d_%s%d_%d",bar1,shp1.nRec,bar2,shp2.nRec,lix);
+         OSTRCPY( bar2, sizeof(bar2), var2);
+         OSPRINTF( shp.pattern, sizeof(shp.pattern), "%s%d_%s%d_%d", bar1, shp1.nRec, bar2, shp2.nRec, lix);
          if (shp.hasArray == 1) {
             int ret __attribute__((unused));
-            sprintf(cmd,"Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f %.2f\" \"%s /%.7f %.2f %.2f %.2f %.2f\" -stepsize 0.2" ,
-               shp.pattern,shp1.wv,shp1.pw,shp1.of,shp1.st,shp1.ph,shp1.fla, 
-                           shp2.wv,shp2.pw,shp2.of,shp2.st,shp2.ph,shp2.fla);
+            OSPRINTF( cmd, sizeof(cmd), "Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f %.2f\" \"%s /%.7f %.2f %.2f %.2f %.2f\" -stepsize 0.2" , shp.pattern, shp1.wv, shp1.pw, shp1.of, shp1.st, shp1.ph, shp1.fla, shp2.wv, shp2.pw, shp2.of, shp2.st, shp2.ph, shp2.fla);
             ret = system(cmd);
             pboxshp = getRsh(shp.pattern); 
             shp.B1max = pboxshp.B1max; 
@@ -267,7 +267,7 @@ PBOXPULSE getpboxpulse(char *seqName, int iRec, int calc)
       printf("Error in getpboxpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(shp.seqName,"%s",seqName);
+   OSTRCPY( shp.seqName, sizeof(shp.seqName), seqName);
    shp.calc = calc;
    shp.array = parsearry(shp.array);
    shp.nRec = iRec;
@@ -343,16 +343,15 @@ PBOXPULSE getpboxpulse(char *seqName, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",shp.seqName,"");
-   sprintf(lpattern,"%s%d",var,shp.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, shp.nRec);
    shp.hasArray = hasarry(shp.array, lpattern);
    int lix = arryindex(shp.array);
    if (shp.calc > 0) {
       var = getname0("",shp.seqName,"");
-      sprintf(shp.pattern,"%s%d_%d",var,shp.nRec,lix);
+      OSPRINTF( shp.pattern, sizeof(shp.pattern), "%s%d_%d", var, shp.nRec, lix);
       if (shp.hasArray == 1) {
          int ret __attribute__((unused));
-	 sprintf(cmd,"Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f %.2f\" -stepsize 0.2\n",
-                shp.pattern,shp.wv,shp.pw,shp.of,shp.st,shp.ph,shp.fla);
+         OSPRINTF( cmd, sizeof(cmd), "Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f %.2f\" -stepsize 0.2\n", shp.pattern, shp.wv, shp.pw, shp.of, shp.st, shp.ph, shp.fla);
          ret = system(cmd);
          pboxshp = getRsh(shp.pattern); 
          shp.B1max = pboxshp.B1max; 
@@ -375,7 +374,7 @@ PBOXPULSE getrefpboxpulse(char *seqName, int iRec, int calc)
       printf("Error in getpsoftpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(shp.seqName,"%s",seqName);
+   OSTRCPY( shp.seqName, sizeof(shp.seqName), seqName);
    shp.calc = calc;
    shp.array = parsearry(shp.array);
    shp.nRec = iRec;
@@ -448,16 +447,15 @@ PBOXPULSE getrefpboxpulse(char *seqName, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",shp.seqName,"");
-   sprintf(lpattern,"%s%d",var,shp.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, shp.nRec);
    shp.hasArray = hasarry(shp.array, lpattern);
    int lix = arryindex(shp.array);
    if (shp.calc > 0) {
       var = getname0("",shp.seqName,"");
-      sprintf(shp.pattern,"%s%d_%d",var,shp.nRec,lix);
+      OSPRINTF( shp.pattern, sizeof(shp.pattern), "%s%d_%d", var, shp.nRec, lix);
       if (shp.hasArray == 1) {
          int ret __attribute__((unused));
-         sprintf(cmd,"Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f\" -stepsize 0.2 -p %2.0f -l %f -attn e\n",
-                shp.pattern,shp.wv,shp.pw,shp.of,shp.st,shp.ph,ref_db,ref_pw);
+         OSPRINTF( cmd, sizeof(cmd), "Pbox %s.RF -w \"%s /%.7f %.2f %.2f %.2f\" -stepsize 0.2 -p %2.0f -l %f -attn e\n", shp.pattern, shp.wv, shp.pw, shp.of, shp.st, shp.ph, ref_db, ref_pw);
          ret = system(cmd);
       }
    }

--- a/src/nvpsg/safestring.c
+++ b/src/nvpsg/safestring.c
@@ -1,0 +1,214 @@
+
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+//extern void text_error(const char *format, ...);
+extern void psg_abort(int error);
+    
+// NOTE don't call this: use ourstrcpy() instead. See below.
+
+int _safestrcpy(const char* fileName, const int lineNum, char* dest, size_t destSize, const char* source) {
+
+    size_t sourceLen;
+    size_t destCharIndex;
+    
+    if (dest == NULL) {
+
+        printf("Error: Line %d in file %s provided NULL destination!!\n", lineNum, fileName);
+        psg_abort(4201);
+        return 0;  // dummy return value: aids testing
+    }
+
+    if (destSize <= 0) {
+
+        printf("Error: Line %d in file %s provided destination string size <= 0!!\n", lineNum, fileName);
+        psg_abort(4202);
+        return 0;  // dummy return value: aids testing
+    }
+
+    if (source == NULL) {
+
+        printf("Error: Line %d in file %s provided NULL source!!\n", lineNum, fileName);
+        psg_abort(4203);
+        return 0;  // dummy return value: aids testing
+    }
+
+    sourceLen = strlen(source);
+
+    for (destCharIndex = 0; destCharIndex < destSize; destCharIndex++) {
+
+        if (destCharIndex < sourceLen) {
+
+            dest[destCharIndex] = source[destCharIndex];
+        }
+        else {
+
+            dest[destCharIndex] = (char) 0;
+            
+            return 0;  // truncation didn't happen
+        }
+    }
+
+    if (sourceLen >= destSize) {
+
+        printf("WARNING: STRING TRUNCATION: Line %d in file %s tried to assign %ud chars to %ud size destination\n", lineNum, fileName, (sourceLen+1) , destSize);
+
+        dest[destSize-1] = 0;
+        
+        return 1;  // truncation happened
+    }
+
+    return 0;  // truncation didn't happen
+}
+
+// NOTE don't call this: use ourstrcat() instead. See below.
+
+int _safestrcat(const char* fileName, const int lineNum, char* dest, size_t destSize, const char* source) {
+
+    size_t origLen;
+    size_t sourceLen;
+    size_t destCharIndex;
+    size_t srcCharIndex;
+    
+    if (dest == NULL) {
+
+        printf("Error: Line %d in file %s provided NULL destination!!\n", lineNum, fileName);
+        psg_abort(4204);
+        return 0;  // dummy return value: aids testing
+    }
+
+    if (destSize <= 0) {
+
+        printf("Error: Line %d in file %s provided destination string size <= 0!!\n", lineNum, fileName);
+        psg_abort(4205);
+        return 0;  // dummy return value: aids testing
+    }
+
+    if (source == NULL) {
+
+        printf("Error: Line %d in file %s provided NULL source!!\n", lineNum, fileName);
+        psg_abort(4206);
+        return 0;  // dummy return value: aids testing
+    }
+
+    origLen = strlen(dest);
+  
+    if (origLen >= destSize) {
+
+        printf("Error: Line %d in file %s provided malformed destination string!!\n", lineNum, fileName);
+        psg_abort(4207);
+        return 0;  // dummy return value: aids testing
+    }
+    
+    sourceLen = strlen(source);
+    
+    for (destCharIndex = origLen; destCharIndex < destSize; destCharIndex++) {
+
+        srcCharIndex = destCharIndex - origLen;
+        
+        if (srcCharIndex < sourceLen) {
+
+            dest[destCharIndex] = source[srcCharIndex];
+        }
+        else {
+
+            dest[destCharIndex] = (char) 0;
+            
+            return 0;  // truncation did not happen
+        }
+    }
+
+    if (origLen + sourceLen >= destSize) {
+
+        dest[destSize-1] = 0;
+        
+        printf("WARNING: STRING TRUNCATION: Line %d in file %s tried to assign %ud chars to %ud size destination\n", lineNum, fileName, (sourceLen+1) , (destSize - origLen));
+
+        return 1;  // truncation happened
+    }
+
+    return 0;  // truncation did not happen
+}
+
+// NOTE don't call this: use oursprintf() instead. See below.
+
+int _safesprintf(const char* fileName, const int lineNum, int* retCode, char* dest, size_t destSize, const char* fmt, va_list args) {
+
+    // how big is big enough? how big is too big?
+    
+    #define MAX_BUFF_SZ_HERE 1280
+    
+    char buffer[MAX_BUFF_SZ_HERE];
+    
+    int buffContentsLen;
+    
+    if (dest == NULL) {
+
+        printf("Error: Line %d in file %s provided NULL destination!!\n", lineNum, fileName);
+        psg_abort(4208);
+        return 0;  // dummy return value: aids testing
+    }
+
+    if (destSize <= 0) {
+
+        printf("Error: Line %d in file %s provided destination string size <= 0!!\n", lineNum, fileName);
+        psg_abort(4209);
+        return 0;  // dummy return value: aids testing
+    }
+
+    if (fmt == NULL) {
+
+        printf("Error: Line %d in file %s provided NULL format string!!\n", lineNum, fileName);
+        psg_abort(4210);
+        return 0;  // dummy return value: aids testing
+    }
+
+    *retCode = vsprintf(buffer, fmt, args);
+
+    buffContentsLen = strlen(buffer);    
+
+    if (buffContentsLen >= MAX_BUFF_SZ_HERE) {
+
+        printf("Error: internal buffer was overwritten on line %d in file %s!!\n", lineNum, fileName);
+        psg_abort(4211);
+        return 0;  // dummy return value: aids testing
+    }
+
+    return _safestrcpy(fileName, lineNum, dest, destSize, buffer);
+}
+
+char* ourstrcpy(const char* fileName, const int lineNum, char* dest, size_t destSize, const char* source) {
+
+    _safestrcpy(fileName, lineNum, dest, destSize, source);
+
+    return dest;
+}
+
+char* ourstrcat(const char* fileName, const int lineNum, char* dest, size_t destSize, const char* source) {
+
+    _safestrcat(fileName, lineNum, dest, destSize, source);
+
+    return dest;
+}
+
+int oursprintf(const char* fileName, const int lineNum, char* dest, size_t destSize, const char* fmt, ...) {
+
+    int retCode = 0;
+    
+    va_list args;
+
+    va_start(args, fmt);
+
+    _safesprintf(fileName, lineNum, &retCode, dest, destSize, fmt, args);
+
+    va_end(args);
+
+	if (retCode >= destSize) {  // truncation happened: fix sprintf() return value.
+	
+		retCode = destSize - 1;
+	}
+    
+    return retCode;
+}
+

--- a/src/nvpsg/safestring.h
+++ b/src/nvpsg/safestring.h
@@ -1,0 +1,23 @@
+#ifndef SAFESTRING_H
+
+#define SAFESTRING_H
+
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+extern char* ourstrcpy(const char* fileName, const int lineNum, char* dest, size_t destSize, const char* source);
+
+extern char* ourstrcat(const char* fileName, const int lineNum, char* dest, size_t destSize, const char* source);
+
+extern int oursprintf(const char* fileName, const int lineNum, char* dest, size_t destSize, const char* fmt, ...);
+
+
+#define OUR_OPEN_PAREN (
+#define OUR_CLOSE_PAREN )
+
+#define OSTRCPY(...)  ourstrcpy  OUR_OPEN_PAREN __FILE__, __LINE__, __VA_ARGS__ OUR_CLOSE_PAREN
+#define OSTRCAT(...)  ourstrcat  OUR_OPEN_PAREN __FILE__, __LINE__, __VA_ARGS__ OUR_CLOSE_PAREN
+#define OSPRINTF(...) oursprintf OUR_OPEN_PAREN __FILE__, __LINE__, __VA_ARGS__ OUR_CLOSE_PAREN
+
+#endif

--- a/src/nvpsg/sglEPI.c
+++ b/src/nvpsg/sglEPI.c
@@ -50,6 +50,8 @@
 #include "sglCommon.h"
 #include "sglEPI.h"
 
+#include "safestring.h"
+
 /**************************************************************************/
 /*** EPI WRAPPERS *********************************************************/
 /**************************************************************************/
@@ -654,20 +656,20 @@ void calc_epi(EPI_GRADIENT_T          *epi_grad,
 
   /* Print table t1 to file in tablib */
   switch(ky_order[0]) {
-    case 'l': sprintf(order_str,"lin"); break;
-    case 'c': sprintf(order_str,"cen"); break;
+    case 'l': OSPRINTF( order_str, sizeof(order_str), "lin");
+      break;
+    case 'c': OSPRINTF( order_str, sizeof(order_str), "cen");
+      break;
     default:  
       abort_message("%s: ky_order %s not recognized, use 'l' (linear) or 'c' (centric)\n",
                      seqfil,ky_order);
   } 
 
   if (ky_order[1] == 'r')  /* not reversed */
-    sprintf(gpe_tab,"%s_nv%d_f%d_%s%d_rev",seqfil,
-       (int)pe_grad->steps,(int)fract_ky,order_str,(int)nseg);
+    OSPRINTF( gpe_tab, sizeof(gpe_tab), "%s_nv%d_f%d_%s%d_rev", seqfil, int)pe_grad->steps, (int)fract_ky, r, (int)nseg);
   else
-    sprintf(gpe_tab,"%s_nv%d_f%d_%s%d",seqfil,
-       (int)pe_grad->steps,(int)fract_ky,order_str,(int)nseg);
-  sprintf(tab_file,"%s/tablib/%s",userdir,gpe_tab);
+    OSPRINTF( gpe_tab, sizeof(gpe_tab), "%s_nv%d_f%d_%s%d", seqfil, (int)pe_grad->steps, (int)fract_ky, order_str, (int)nseg);
+  OSPRINTF( tab_file, sizeof(tab_file), "%s/tablib/%s", userdir, gpe_tab);
 
   if ((fp = fopen(tab_file,"w")) == NULL) {
     abort_message("Error opening file %s\n",gpe_tab);
@@ -682,7 +684,7 @@ void calc_epi(EPI_GRADIENT_T          *epi_grad,
   }
   fprintf(fp,"\n"); 
   fclose(fp);
-  strcpy(petable,gpe_tab);
+  strcpy(petable,gpe_tab);  // BDZ: can't easily be made safe
   putstring("petable",gpe_tab);
 
   /* Return values in VnmrJ parameter pe_table */

--- a/src/nvpsg/sglHelper.c
+++ b/src/nvpsg/sglHelper.c
@@ -794,6 +794,7 @@ void write_bvalues(DIFFUSION_T *diffusion,char *basepar,char *tracepar,char *max
   /* write the values */
   if (strlen(basepar)>0) {
     if ((par=(char *)malloc((strlen(basepar)+3)*sizeof(char))) == NULL) nomem();
+    // BDZ note that all these strcpy/strcat calls are safe
     strcpy(par,basepar); strcat(par,"rr");
     putarray(par,diffusion->bro,diffusion->nbval); 
     strcpy(par,basepar); strcat(par,"pp");

--- a/src/nvpsg/sglPrepulses.c
+++ b/src/nvpsg/sglPrepulses.c
@@ -45,6 +45,7 @@
 #include "sglCommon.h"
 #include "sglPrepulses.h"
 
+#include "safestring.h"
 
 /***********************************************************************
 *  Function Name: create_fatsat
@@ -701,11 +702,11 @@ fpwrscale=1.0;
           /* The sine modulated control may not be required for a dedicated tag coil */
           if (asltagcoil[0] == 'y') {
             if (!strcmp(caslctrl,"")) {
-              strcpy(caslctrl,"sinemod");
+              OSTRCPY( caslctrl, sizeof(caslctrl), "sinemod");
               putCmd("caslctrl = '%s'",caslctrl);
             }
           } else {
-            strcpy(caslctrl,"sinemod");
+            OSTRCPY( caslctrl, sizeof(caslctrl), "sinemod");
             putCmd("caslctrl = '%s'",caslctrl);
           }
         }
@@ -713,7 +714,7 @@ fpwrscale=1.0;
         break;
       case STAR:
         if (seqcon[1]=='c' && ns>1) {
-          strcpy(starctrl,"doubletag");
+          OSTRCPY( starctrl, sizeof(starctrl), "doubletag");
           putCmd("starctrl = '%s'",starctrl);
         }
         if (!strcmp(starctrl,"doubletag")) stardoubletag=TRUE;
@@ -958,7 +959,7 @@ fpwrscale=1.0;
     trise=trisesave;
 
     /* Initialize asl test string and parameter */
-    strcpy(aslteststring,"");
+    OSTRCPY( aslteststring, sizeof(alsteststring), "");
     putCmd("asltestpars = ''");
     putCmd("asltesttag = 0");
 
@@ -1010,7 +1011,7 @@ fpwrscale=1.0;
       psTime = nps*ps_grad.duration+GRADIENT_RES;
       if (tspoilps > 0.0) psTime +=nps*psspoil_grad.duration;
       putvalue("pstime",psTime);
-      strcat(aslteststring,"PS");
+      OSTRCAT( aslteststring, sizeof(aslteststring), "PS");
       putCmd("asltestpars[%d] = 'PS'",asltestval);
       putCmd("asltesttag[%d] = 1",asltestval++);
       /* Hijack IR's virblock (vnps=virblock) for number of PS pulses */
@@ -1018,8 +1019,9 @@ fpwrscale=1.0;
     }
 
     /* Update asl test string and parameter (tag and control are always in test string) */
-    if (strlen(aslteststring)>1) strcat(aslteststring,"/");
-    strcat(aslteststring,"Tag/Ctrl");
+    if (strlen(aslteststring)>1)
+      OSTRCAT( aslteststring, sizeof(aslteststring), "/");
+    OSTRCAT( aslteststring, sizeof(alsteststring), "Tag/Ctrl");
     putCmd("asltestpars[%d] = 'Tag'",asltestval);
     putCmd("asltesttag[%d] = 1",asltestval++);
     putCmd("asltestpars[%d] = 'Ctrl'",asltestval);
@@ -1096,7 +1098,7 @@ fpwrscale=1.0;
       ipsTime = nips*ips_grad.duration+GRADIENT_RES;
       if (tspoilips > 0.0) ipsTime +=nips*ipsspoil_grad.duration;
       putvalue("ipstime",ipsTime);
-      strcat(aslteststring,"/IPS");
+      OSTRCAT( aslteststring, sizeof(aslteststring), "/IPS");
       putCmd("asltestpars[%d] = 'IPS'",asltestval);
       putCmd("asltesttag[%d] = 1",asltestval++);
       /* Hijack IR's vnirpulses (vnips=vnirpulses) for number of IPS pulses */
@@ -1154,7 +1156,7 @@ fpwrscale=1.0;
       q2Time = nq2*q2_grad.duration+GRADIENT_RES;
       if (tspoilq2 > 0.0) q2Time += nq2*q2spoil_grad.duration;
       putvalue("q2time",q2Time);
-      strcat(aslteststring,"/TagQ/CtrlQ");
+      OSTRCAT( aslteststring, sizeof(aslteststring), "/TagQ/CtrlQ");
       putCmd("asltestpars[%d] = 'TagQ'",asltestval);
       putCmd("asltesttag[%d] = 1",asltestval++);
       putCmd("asltestpars[%d] = 'CtrlQ'",asltestval);
@@ -1320,8 +1322,8 @@ double calc_aslTime(double asladd,double trepmin,int *treptype)
         if (FP_EQ(mirt1[i],0.0))
           abort_message("calc_aslTime MIR error: mirt1[%d] is 0.0. Reset T1 values and add appropriate T1 values\n",i+1);
       /* Check that the aslmirtime binary is present */
-      sprintf(timefile,"/tmp/aslmirtimestatus_%s",getenv("USER"));
-      sprintf(timecmd,"which aslmirtime > %s",timefile);
+      OSPRINTF( timefile, sizeof(timefile), "/tmp/aslmirtimestatus_%s", getenv("USER"));
+      OSPRINTF( timecmd, sizeof(timecmd), "which aslmirtime > %s", timefile);
       ret = system(timecmd);
       if (stat(timefile,&buf) == -1)
         abort_message("calc_aslTime MIR error: Unable to access file /tmp/aslmirtimestatus\n");
@@ -1329,17 +1331,17 @@ double calc_aslTime(double asladd,double trepmin,int *treptype)
         abort_message("calc_aslTime MIR error: aslmirtime binary appears to be missing\n");
       /* If there's no abort_message the aslmirtime binary is present */
       /* Set system call to calculate MIR times */
-      sprintf(timecmd,"aslmirtime -n %d -d %f -t %d",nmir,mirTime,(int)dvarinfo.size);
+      OSPRINTF( timecmd, sizeof(timecmd), "aslmirtime -n %d -d %f -t %d", nmir, mirTime, (int)dvarinfo.size);
       for (i=0;i<(int)dvarinfo.size;i++)
       {
          char tmp[32];
 
-         sprintf(tmp," %f",mirt1[i]);
-         strcat(timecmd,tmp);
+         OSPRINTF( tmp, sizeof(tmp), " %f", mirt1[i]);
+         OSTRCAT( timecmd, sizeof(timecmd), tmp);
       }
       /* Execute the system call */
       ret = system(timecmd);
-      sprintf(timefile,"/tmp/aslmirtime_%s.txt",getenv("USER"));
+      OSPRINTF( timefile, sizeof(timefile), "/tmp/aslmirtime_%s.txt", getenv("USER"));
       /* Open timefile for reading */
       if ((fp=fopen(timefile,"r")) == NULL)
         abort_message("calc_aslTime MIR error: Unable to open %s\n",timefile);
@@ -1921,7 +1923,7 @@ void create_tag()
 		/* Calculate Taggign RF power ************************/
 		tag_rf.flip = fliptag;                 /* assign flip angle for RF tagging pulse */
 		tag_rf.rfDuration = pw;                /* assign duration for RF tagging pulse */
-		strcpy(tag_rf.pulseName,tagpat);       /* assign RF pulse name for RF tagging pulse */
+		OSTRCPY( tag_rf.pulseName, sizeof(tag_rf.pulseName), tagpat); /* assign RF pulse name for RF tagging pulse */
 		calcPower(&tag_rf,rfcoil);             /* calculate MTC RF power */
 		if (sgldisplay) 
 		{

--- a/src/nvpsg/sglRF.c
+++ b/src/nvpsg/sglRF.c
@@ -20,6 +20,7 @@
 
 #include "sglRF.h"
 
+#include "safestring.h"
 
 /*----------------------------------------------------------*/
 /*---- cosine and sine coefficients for Mao pulses      ----*/
@@ -165,13 +166,13 @@ void sincRf(RF_PULSE_T *rf)
   }
 
   /* Set modulation type */
-  strcpy(rf->header.modulation,"amplitude");
+  OSTRCPY( rf->header.modulation, sizeof(rf->header.modulation), "amplitude");
 
   /* Set rf fraction */
   rf->header.rfFraction = 0.5;
 
   /* Set pulse type */
-  strcpy(rf->header.type,"selective");
+  OSTRCPY( rf->header.type, sizeof(rf->header.type), "selective");
 
   /* Set actual bandwidth of pulse */
   if ((FP_LT(rf->flip,FLIPLIMIT_LOW)) || (FP_GT(rf->flip,FLIPLIMIT_HIGH)))
@@ -214,7 +215,7 @@ void sincRf(RF_PULSE_T *rf)
   putparsRf(rf);  
 
   /* Update pulseName with new shape name */
-  strcpy(rf->pulseName,rf->shapeName);
+  OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rf->shapeName);
 
   /* Free memory */
   free(rf->amp);
@@ -278,13 +279,13 @@ void gaussRf(RF_PULSE_T *rf)
   }
 
   /* Set modulation type */
-  strcpy(rf->header.modulation,"amplitude");
+  OSTRCPY( rf->header.modulation, sizeof(rf->header.modulation), "amplitude");
 
   /* Set rf fraction */
   rf->header.rfFraction = 0.5;
 
   /* Set pulse type */
-  strcpy(rf->header.type,"selective");
+  OSTRCPY( rf->header.type, sizeof(rf->header.type), "selective");
 
   /* Set actual bandwidth of pulse */
   if ((FP_LT(rf->flip,FLIPLIMIT_LOW)) || (FP_GT(rf->flip,FLIPLIMIT_HIGH)))
@@ -323,7 +324,7 @@ void gaussRf(RF_PULSE_T *rf)
   putparsRf(rf);  
 
   /* Update pulseName with new shape name */
-  strcpy(rf->pulseName,rf->shapeName);
+  OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rf->shapeName);
 
   /* Free memory */
   free(rf->amp);
@@ -381,13 +382,13 @@ void maoRf(RF_PULSE_T *rf)
   }
 
   /* Set modulation type */
-  strcpy(rf->header.modulation,"amplitude");
+  OSTRCPY( rf->header.modulation, sizeof(rf->header.modulation), "amplitude");
 
   /* Set rf fraction */
   rf->header.rfFraction = 0.5;
 
   /* Set pulse type */
-  strcpy(rf->header.type,"selective");
+  OSTRCPY( rf->header.type, sizeof(rf->header.type), "selective");
 
   /* Set actual bandwidth of pulse */
   rf->bandwidth = rf->header.inversionBw/rf->rfDuration;
@@ -458,7 +459,7 @@ void maoRf(RF_PULSE_T *rf)
   putparsRf(rf);  
 
   /* Update pulseName with new shape name */
-  strcpy(rf->pulseName,rf->shapeName);
+  OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rf->shapeName);
 
   /* Free memory */
   free(rf->amp);
@@ -503,13 +504,13 @@ void hsafpRf(RF_PULSE_T *rf)
   rf->header.inversionBw = rf->rfDuration*rf->bandwidth;
 
   /* Set modulation type */
-  strcpy(rf->header.modulation,"adiabatic");
+  OSTRCPY( rf->header.modulation, sizeof(rf->header.modulation), "adiabatic");
 
   /* Set rf fraction */
   rf->header.rfFraction = 0.5;
 
   /* Set pulse type */
-  strcpy(rf->header.type,"selective");
+  OSTRCPY( rf->header.type, sizeof(rf->header.type), "selective");
 
   /* Set SPL version */
   rf->header.version = SPLVERSION;
@@ -570,7 +571,7 @@ void hsafpRf(RF_PULSE_T *rf)
   putparsRf(rf);  
 
   /* Update pulseName with new shape name */
-  strcpy(rf->pulseName,rf->shapeName);
+  OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rf->shapeName);
 
   /* Free memory */
   free(rf->amp);
@@ -617,13 +618,13 @@ void hsRf(RF_PULSE_T *rf)
   rf->header.inversionBw = rf->rfDuration*rf->bandwidth;
 
   /* Set modulation type */
-  strcpy(rf->header.modulation,"amplitude");
+  OSTRCPY( rf->header.modulation, sizeof(rf->header.modulation), "amplitude");
 
   /* Set rf fraction */
   rf->header.rfFraction = 0.5;
 
   /* Set pulse type */
-  strcpy(rf->header.type,"selective");
+  OSTRCPY( rf->header.type, sizeof(rf->header.type), "selective");
 
   /* Set SPL version */
   rf->header.version = SPLVERSION;
@@ -686,7 +687,7 @@ void hsRf(RF_PULSE_T *rf)
   putparsRf(rf);  
 
   /* Update pulseName with new shape name */
-  strcpy(rf->pulseName,rf->shapeName);
+  OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rf->shapeName);
 
   /* Free memory */
   free(rf->amp);
@@ -731,13 +732,13 @@ void htahpRf(RF_PULSE_T *rf)
   rf->header.inversionBw = -1.0;
 
   /* Set modulation type */
-  strcpy(rf->header.modulation,"adiabatic");
+  OSTRCPY( rf->header.modulation, sizeof(rf->header.modulation), "adiabatic");
 
   /* Set rf fraction */
   rf->header.rfFraction = 0.0;
 
   /* Set pulse type */
-  strcpy(rf->header.type,"nonselective");
+  OSTRCPY( rf->header.type, sizeof(rf->header.type), "nonselective");
 
   /* Set SPL version */
   rf->header.version = SPLVERSION;
@@ -772,7 +773,7 @@ void htahpRf(RF_PULSE_T *rf)
   putparsRf(rf);  
 
   /* Update pulseName with new shape name */
-  strcpy(rf->pulseName,rf->shapeName);
+  OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rf->shapeName);
 
   /* Free memory */
   free(rf->amp);
@@ -817,13 +818,13 @@ void htbir4Rf(RF_PULSE_T *rf)
   rf->header.inversionBw = -1.0;
 
   /* Set modulation type */
-  strcpy(rf->header.modulation,"adiabatic");
+  OSTRCPY( rf->header.modulation, sizeof(rf->header.modulation), "adiabatic");
 
   /* Set rf fraction */
   rf->header.rfFraction = 0.0;
 
   /* Set pulse type */
-  strcpy(rf->header.type,"nonselective");
+  OSTRCPY( rf->header.type, sizeof(rf->header.type), "nonselective");
 
   /* Set SPL version */
   rf->header.version = SPLVERSION;
@@ -885,7 +886,7 @@ void htbir4Rf(RF_PULSE_T *rf)
   putparsRf(rf);  
 
   /* Update pulseName with new shape name */
-  strcpy(rf->pulseName,rf->shapeName);
+  OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rf->shapeName);
 
   /* Free memory */
   free(rf->amp);
@@ -925,13 +926,13 @@ void sineRf(RF_PULSE_T *rf)
   rf->header.inversionBw = -1.0;
 
   /* Set modulation type */
-  strcpy(rf->header.modulation,"amplitude");
+  OSTRCPY( rf->header.modulation, sizeof(rf->header.modulation), "amplitude");
 
   /* Set rf fraction */
   rf->header.rfFraction = 0.5;
 
   /* Set pulse type */
-  strcpy(rf->header.type,"selective");
+  OSTRCPY( rf->header.type, sizeof(rf->header.type), "selective");
 
   /* Set SPL version */
   rf->header.version = SPLVERSION;
@@ -964,7 +965,7 @@ void sineRf(RF_PULSE_T *rf)
   putparsRf(rf);  
 
   /* Update pulseName with new shape name */
-  strcpy(rf->pulseName,rf->shapeName);
+  OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rf->shapeName);
 
   /* Free memory */
   free(rf->amp);
@@ -1087,10 +1088,10 @@ void simAFPintRf(RF_PULSE_T *rf)
   step=rf->pts/1000;
 
   /* Generate filename */
-  strcpy(simfile,userdir);
-  strcat(simfile,"/shapelib/");
-  strcat(simfile,rf->shapeName);
-  strcat(simfile,".sim");
+  OSTRCPY( simfile, sizeof(simfile), userdir);
+  OSTRCAT( simfile, sizeof(simfile), "/shapelib/");
+  OSTRCAT( simfile, sizeof(simfile), rf->shapeName);
+  OSTRCAT( simfile, sizeof(simfile), ".sim");
 
   /* Open simfile */
   if ((fp=fopen(simfile,"w")) == NULL) 
@@ -1164,10 +1165,10 @@ void simintRf(RF_PULSE_T *rf,double targetmz)
   step=rf->pts/1000;
 
   /* Generate filename */
-  strcpy(simfile,userdir);
-  strcat(simfile,"/shapelib/");
-  strcat(simfile,rf->shapeName);
-  strcat(simfile,".sim");
+  OSTRCPY( simfile, sizeof(simfile), userdir);
+  OSTRCAT( simfile, sizeof(simfile), "/shapelib/");
+  OSTRCAT( simfile, sizeof(simfile), rf->shapeName);
+  OSTRCAT( simfile, sizeof(simfile), ".sim");
 
   /* Open simfile */
   if ((fp=fopen(simfile,"w")) == NULL) 
@@ -1241,10 +1242,10 @@ void writeRf(RF_PULSE_T *rf)
   int i;
 
   /* Generate filename */
-  strcpy(shapefile,userdir);
-  strcat(shapefile,"/shapelib/");
-  strcat(shapefile,rf->shapeName);
-  strcat(shapefile,".RF");
+  OSTRCPY( simfile, sizeof(simfile), userdir);
+  OSTRCAT( simfile, sizeof(simfile), "/shapelib/");
+  OSTRCAT( simfile, sizeof(simfile), rf->shapeName);
+  OSTRCAT( simfile, sizeof(simfile), ".RF");
   
   /* Open shapefile */
   if ((fp=fopen(shapefile,"w")) == NULL) 
@@ -1366,9 +1367,9 @@ void writeRf(RF_PULSE_T *rf)
 void setshapeRf(RF_PULSE_T *rf)
 {
   /* Generate new shape name */
-  strcpy(rf->shapeName,rf->pulseName);
-  strcat(rf->shapeName,"_");
-  strcat(rf->shapeName,rf->pulseBase);
+  OSTRCPY( rf->shapeName, sizeof(rf->shapeName), rf->pulseName);
+  OSTRCAT( rf->shapeName, sizeof(rf->shapeName), "_");
+  OSTRCAT( rf->shapeName, sizeof(rf->shapeName), rf->pulseBase);
 }
 
 
@@ -1384,8 +1385,8 @@ void getparsRf(RF_PULSE_T *rf)
   for (i=0;i<MAXRFPARS;i++) rf->pars[i]=0.0;
 
   /* Generate "*pars" name from the base name */  
-  strcpy(parname,rf->pulseBase);
-  strcat(parname,"pars");
+  OSTRCPY( parname, sizeof(parname), rf->pulseBase);
+  OSTRCAT( parname, sizeof(parname), "pars");
 
   /* This will report a suitable error if the "*pars" parameter does not exist */
   rf->npars=(int)getarray(parname,rf->pars);
@@ -1448,8 +1449,8 @@ void putparsRf(RF_PULSE_T *rf)
   char str[MAX_STR];
    
   /* Generate "*pars" name from the base name */  
-  strcpy(str,rf->pulseBase);
-  strcat(str,"pars");
+  OSTRCPY( str, rf->pulseBase);
+  OSTRCAT( str, "pars");
 
   /* Write the shape parameters back to "*pars" */
   putCmd("%s[1] = %f\n",str,rf->res*1.0e6);

--- a/src/nvpsg/sglWrappers.c
+++ b/src/nvpsg/sglWrappers.c
@@ -10,8 +10,12 @@
 *   HISTORY:
 *
 ***************************************************************************/
+
 #include "sglCommon.h"
 #include "sglWrappers.h"
+
+#include "safestring.h"
+
 extern int checkflag;
 extern int option_check(const char *);
 
@@ -87,7 +91,7 @@ void init_slice(SLICE_SELECT_GRADIENT_T *grad, char name[],double thk)
    initSliceSelect(grad);                     /* initialize slice select gradient with defaults*/
    grad->thickness  = thk;		      /* assign slice thickness */
    grad->maxGrad    = gmax;                   /* assign maximum allowed gradient */
-   strcpy(grad->name,name);                   /* assign waveform name */
+   OSTRCPY( grad->name, sizeof(grad->name), name); /* assign waveform name */
    }
 
 void init_slice_butterfly(SLICE_SELECT_GRADIENT_T *grad, char name[], 
@@ -97,7 +101,7 @@ void init_slice_butterfly(SLICE_SELECT_GRADIENT_T *grad, char name[],
    initSliceSelect(grad);                        /* initialize slice select gradient with defaults*/
    grad->thickness  = thk;                       /* assign slice thickness */
    grad->maxGrad    = gmax;                      /* assign maximum allowed gradient */     
-   strcpy(grad->name,name);                      /* assign waveform name */
+   OSTRCPY( grad->name, sizeof(grad->name), name); /* assign waveform name */
    grad->enableButterfly   = TRUE;               /* enable butterfly gradients */
    grad->cr1amp            = grad->cr2amp            = gcrush;       /* assign crusher amplitude */
    grad->crusher1Duration  = grad->crusher2Duration  = tcrush;       /* assign crusher duration */
@@ -138,7 +142,7 @@ void init_slice_refocus(REFOCUS_GRADIENT_T *refgrad, char name[])
    if ((ix > 1) && !sglarray) return;
    initRefocus(refgrad);                          /* initialize refocus gradient with defaults */
    refgrad->maxGrad = glim*gmax;                  /* assign maximum allowed gradient */     
-   strcpy(refgrad->name,name);                    /* assign waveform name */
+   OSTRCPY( refgrad->name, sizeof(refgrad->name), name); /* assign waveform name */
    }
 
 
@@ -148,7 +152,7 @@ void calc_slice_refocus(REFOCUS_GRADIENT_T *refgrad, SLICE_SELECT_GRADIENT_T *gr
    
    if ((ix > 1) && !sglarray) return;
    refgrad->balancingMoment0 = grad->m0ref * refgrad->gmult;  /* assign refocusing moment */
-   strcpy(refgrad->param1,VJparam_g);                         /* assign VNMRJ parameter 1 */
+   OSTRCPY( refgrad->param1, sizeof(refgrad->param1), VJparam_g); /* assign VNMRJ parameter 1 */
    refgrad->writeToDisk      = write_flag;                    /* set writeToDisk flag */
    calcRefocus(refgrad);                                      /* calculate slice refocusign gradient */
 
@@ -167,7 +171,7 @@ void calc_slice_dephase(REFOCUS_GRADIENT_T *refgrad, SLICE_SELECT_GRADIENT_T *gr
    
    if ((ix > 1) && !sglarray) return;
    refgrad->balancingMoment0 = grad->m0def * refgrad->gmult;  /* assign dephasing moment */
-   strcpy(refgrad->param1,VJparam_g);                         /* assign VNMRJ parameter 1 */
+   OSTRCPY( refgrad->param1, sizeof(refgrad->param1), VJparam_g); /* assign VNMRJ parameter 1 */
    refgrad->writeToDisk      = write_flag;                    /* set writeToDisk flag */
    calcRefocus(refgrad);                                      /* calculate slice refocusign gradient */
 
@@ -192,7 +196,7 @@ void init_readout(READOUT_GRADIENT_T *grad, char name[],
    grad->acqTime       = np/(2*sw);   	            /* set acquisition time */
    grad->maxGrad       = gmax;                      /* assign maximum allowed gradient */
    grad->fov           = lro*10;                    /* set field of view [cm] */
-   strcpy(grad->name,name);                         /* assign waveform name */
+   OSTRCPY( grad->name, sizeof(grad->name), name); /* assign waveform name */
    }
 
 void init_readout_butterfly(READOUT_GRADIENT_T *grad, char name[], 
@@ -205,7 +209,7 @@ void init_readout_butterfly(READOUT_GRADIENT_T *grad, char name[],
    grad->acqTime       = np/2/sw;   	            /* set acquisition time */
    grad->maxGrad       = gmax;                      /* assign maximum allowed gradient */
    grad->fov           = lro*10;                    /* set field of view [cm] */
-   strcpy(grad->name,name);                         /* assign waveform name */
+   OSTRCPY( grad->name, sizeof(grad->name), name); /* assign waveform name */
 
    grad->enableButterfly   = TRUE;                   /* enable butterfly gradients */
    grad->cr1amp            = grad->cr2amp            = gcrush;           /* assign crusher amplitude */
@@ -248,7 +252,7 @@ void init_readout_refocus(REFOCUS_GRADIENT_T *refgrad, char name[])
    if ((ix > 1) && !sglarray) return;
    initDephase(refgrad);                          /* initialize dephase gradient with defaults */
    refgrad->maxGrad = glim*gmax;                  /* assign maximum allowed gradient */     
-   strcpy(refgrad->name,name);                    /* assign waveform name */
+   OSTRCPY( refgrad->name, sizeof(refgrad->name), name); /* assign waveform name */
    }
 
 void calc_readout_refocus(REFOCUS_GRADIENT_T *refgrad, READOUT_GRADIENT_T *grad,
@@ -257,7 +261,7 @@ void calc_readout_refocus(REFOCUS_GRADIENT_T *refgrad, READOUT_GRADIENT_T *grad,
    if ((ix > 1) && !sglarray) return;
    refgrad->balancingMoment0 = grad->m0ref * refgrad->gmult;                    /* Assign dephase moment */
    refgrad->writeToDisk      = write_flag;                     /* Set writeToDisk flag */
-   strcpy(refgrad->param1,VJparam_g);                          /* assign VNMRJ parameter 1 */
+   OSTRCPY( refgrad->param1, sizeof(refgrad->param1), VJparam_g); /* assign VNMRJ parameter 1 */
    calcRefocus(refgrad);                                       /* calculate dephase gradient */
    
    /* return dephase gradient parameter to VnmrJ space */   
@@ -271,7 +275,7 @@ void calc_readout_rephase(REFOCUS_GRADIENT_T *refgrad, READOUT_GRADIENT_T *grad,
    if ((ix > 1) && !sglarray) return;
    refgrad->balancingMoment0 = grad->m0def * refgrad->gmult;   /* Assign dephase moment */
    refgrad->writeToDisk      = write_flag;                     /* Set writeToDisk flag */
-   strcpy(refgrad->param1,VJparam_g);                          /* assign VNMRJ parameter 1 */
+   OSTRCPY( refgrad->param1, sizeof(refgrad->param1), VJparam_g); /* assign VNMRJ parameter 1 */
    calcRefocus(refgrad);                                       /* calculate dephase gradient */
    
    /* return dephase gradient parameter to VnmrJ space */   
@@ -291,15 +295,15 @@ void init_phase(PHASE_ENCODE_GRADIENT_T *grad, char name[], double lpe, double n
    grad->steps    = nv;                         /* number of phase encode steps */
    grad->maxGrad  = gmax*glimpe;                /* maximum allowed gradient */   
    grad->calcFlag = SHORTEST_DURATION_FROM_MOMENT;  
-   strcpy(grad->name,name);                     /* assign waveform name */
+   OSTRCPY( grad->name, sizeof(grad->name), name); /* assign waveform name */
    }
 
 void calc_phase(PHASE_ENCODE_GRADIENT_T *grad, int write_flag, char VJparam_g[], char VJparam_t[]) 
    {
    if ((ix > 1) && !sglarray) return;
    grad->writeToDisk = write_flag;          /* set writeToDiskFlag */
-   strcpy(grad->param1,VJparam_g);          /* assign VNMRJ parameter 1 */
-   strcpy(grad->param2,VJparam_t);          /* assign VNMRJ parameter 2 */
+   OSTRCPY( grad->param1, sizeof(grad->param1), VJparam_g); /* assign VNMRJ parameter 1 */
+   OSTRCPY( grad->param2, sizeof(grad->param2), VJparam_t); /* assign VNMRJ parameter 2 */
    calcPhase(grad);                         /* calculate and create phase encode grdient */
    /* return phase encode gradient parameters to VnmrJ space */   
    if (strcmp(VJparam_g, ""))
@@ -318,7 +322,7 @@ void init_dephase( GENERIC_GRADIENT_T *grad, char name[] )
 	if( (ix > 1) && !sglarray ) return;
 	initDephase( grad );
 	grad->maxGrad = glim*gmax;
-	strcpy(grad->name, name);	
+    OSTRCPY( grad->name, sizeof(grad->name), name);
 }
 
 void calc_dephase( GENERIC_GRADIENT_T *grad, int write_flag, double moment0,
@@ -327,8 +331,8 @@ void calc_dephase( GENERIC_GRADIENT_T *grad, int write_flag, double moment0,
 	if( (ix > 1) && !sglarray ) return;
 	grad->balancingMoment0 = moment0 * grad->gmult;
 	grad->writeToDisk = write_flag;
-	strcpy( grad->param1, VJparam_g );
-	strcpy( grad->param2, VJparam_t );
+    OSTRCPY( grad->param1, sizeof(grad->param1), VJparam_g);
+    OSTRCPY( grad->param2, sizeof(grad->param2), VJparam_t);
 	calcRefocus( grad );
 	if( strcmp( VJparam_g, "" ) )
 		putvalue( VJparam_g, grad->amp );
@@ -347,7 +351,7 @@ void init_generic(GENERIC_GRADIENT_T *grad, char name[], double amp, double time
    grad->amp = amp;                              /* assign gradient amplitude */
    grad->duration  = time;                       /* assign gradient duration */
    grad->maxGrad   = gmax;                       /* assign maximum allowed gradient */               
-   strcpy(grad->name,name);                      /* assign waveform name */
+   OSTRCPY( grad->name, sizeof(grad->name), name); /* assign waveform name */
    }
 
 
@@ -357,8 +361,8 @@ void calc_generic(GENERIC_GRADIENT_T *grad, int write_flag, char VJparam_g[], ch
 
    if ((ix > 1) && !sglarray) return;
    grad->writeToDisk = write_flag;        /* assign writeToDisk flag */
-   strcpy(grad->param1,VJparam_g);        /* Assign VNMRJ paramter 1 */
-   strcpy(grad->param2,VJparam_t);        /* Assign VNMRJ paramter 2 */
+   OSTRCPY( grad->param1, sizeof(grad->param1), VJparam_g); /* Assign VNMRJ paramter 1 */
+   OSTRCPY( grad->param2, sizeof(grad->param2), VJparam_t);/* Assign VNMRJ paramter w */
 
    if (grad->amp > grad->maxGrad) {
      sgl_abort_message("ERROR gradient %s: Crusher amplitude (%.2f) exceeds maximum (%.2f)",
@@ -412,7 +416,7 @@ void trapezoid(GENERIC_GRADIENT_T *grad, char name[], double amp, double time, d
    grad->m0        = moment;                     /* assign moment0 */
    grad->maxGrad   = gmax;                       /* assign maximum allowed gradient */               
    grad->writeToDisk = write_flag;               /* set writeToDisk flag */
-   strcpy(grad->name,name);                      /* assign waveform name */
+   OSTRCPY( grad->name, sizeof(grad->name), name); /* assign waveform name */
 
    /* check amplitude */
    if (amp > glim*gmax) {
@@ -612,7 +616,7 @@ double calc_zfill_gradient(FLOWCOMP_T *grad0, GENERIC_GRADIENT_T  *grad1,
 
     initZeroFillGradient(&zf_grad0); /* initialize zerofill structure for pe grad */
    // strcpy(zf_grad0.name,"zfgrad0");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
-     strcpy(zf_grad0.name,"zfgrad0");  //Don't explode!!!
+    OSTRCPY( zf_grad0.name, sizeof(zf_grad0.name), "zfgrad0");
     text_message("grad0 name is %s", grad0->name);
 
     zf_grad0.numPoints= grad0->numPoints ;/* assign number of waveform points */
@@ -628,9 +632,8 @@ double calc_zfill_gradient(FLOWCOMP_T *grad0, GENERIC_GRADIENT_T  *grad1,
     writeToDisk(grad0->dataPoints, grad0->numPoints, 0, grad0->resolution,
 				     TRUE /*rolout*/, grad0->name); 
     initZeroFillGradient(&zf_grad1); /* initialize zerofill structure for pe grad */
-    strcpy(zf_grad1.name,"zfgrad1");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
+    OSTRCPY( zf_grad1.name, sizeof(zf_grad1.name), "zfgrad1");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
     
-
     zf_grad1.numPoints= grad1->numPoints ;/* assign number of waveform points */
     zf_grad1.dataPoints = grad1->dataPoints; /* assign waveform to be zero-filled */
     zf_grad1.newDuration= time; /* duration of the fc grad for readout */
@@ -645,9 +648,8 @@ double calc_zfill_gradient(FLOWCOMP_T *grad0, GENERIC_GRADIENT_T  *grad1,
 				     grad1->rollOut, grad1->name); 
 
     initZeroFillGradient(&zf_grad2); /* initialize zerofill structure for pe grad */
-    strcpy(zf_grad2.name,"zfgrad2");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
+    OSTRCPY( zf_grad2.name, sizeof(zf_grad2.name), "zfgrad2");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
     
-
     zf_grad2.numPoints= grad2->numPoints ;/* assign number of waveform points */
     zf_grad2.dataPoints = grad2->dataPoints; /* assign waveform to be zero-filled */
     zf_grad2.newDuration= time; /* duration of the fc grad for readout */
@@ -692,9 +694,8 @@ double calc_zfill_gradient2(FLOWCOMP_T *grad0, FLOWCOMP_T  *grad1,
 
     initZeroFillGradient(&zf_grad0); /* initialize zerofill structure for pe grad */
    // strcpy(zf_grad0.name,"zfgrad0");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
-     strcpy(zf_grad0.name,"zfgrad0");  
+    OSTRCPY(zf_grad0.name, sizeof(zf_grad0.name), "zfgrad0");  
    
-
     zf_grad0.numPoints= grad0->numPoints ;/* assign number of waveform points */
     zf_grad0.dataPoints = grad0->dataPoints; /* assign waveform to be zero-filled */
     zf_grad0.newDuration= time; /* duration of the fc grad for readout */
@@ -708,9 +709,8 @@ double calc_zfill_gradient2(FLOWCOMP_T *grad0, FLOWCOMP_T  *grad1,
     writeToDisk(grad0->dataPoints, grad0->numPoints, 0, grad0->resolution,
 				     TRUE /*rolout*/, grad0->name); 
     initZeroFillGradient(&zf_grad1); /* initialize zerofill structure for pe grad */
-    strcpy(zf_grad1.name,"zfgrad1");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
+    OSTRCPY( zf_grad1.name, sizeof(zf_grad1.name), "zfgrad1");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
    
-
     zf_grad1.numPoints= grad1->numPoints ;/* assign number of waveform points */
     zf_grad1.dataPoints = grad1->dataPoints; /* assign waveform to be zero-filled */
     zf_grad1.newDuration= time; /* duration of the fc grad for readout */
@@ -725,9 +725,8 @@ double calc_zfill_gradient2(FLOWCOMP_T *grad0, FLOWCOMP_T  *grad1,
 				     grad1->rollOut, grad1->name); 
 
     initZeroFillGradient(&zf_grad2); /* initialize zerofill structure for pe grad */
-    strcpy(zf_grad2.name,"zfgrad2");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
+    OSTRCPY( zf_grad2.name, sizeof(zf_grad2.name), "zfgrad2");   /*fill in the unique name, otherwise the name will be repeated for each zerofill pattern*/
     
-
     zf_grad2.numPoints= grad2->numPoints ;/* assign number of waveform points */
     zf_grad2.dataPoints = grad2->dataPoints; /* assign waveform to be zero-filled */
     zf_grad2.newDuration= time; /* duration of the fc grad for readout */
@@ -751,7 +750,7 @@ double calc_zfill_gradient2(FLOWCOMP_T *grad0, FLOWCOMP_T  *grad1,
 /**************************************************************************/
 /*** RF pulse *************************************************************/
 /**************************************************************************/
-void init_rf (RF_PULSE_T *rf, char rfName[], double pw, double flip,
+void init_rf (RF_PULSE_T *rf, char rfName[MAX_STR], double pw, double flip,
               double rof1, double rof2)
    {
    if ((ix > 1) && !sglarray) {
@@ -759,8 +758,8 @@ void init_rf (RF_PULSE_T *rf, char rfName[], double pw, double flip,
      return;
    }
    initRf(rf);
-   strcpy(rf->pulseName,rfName);
-   strcpy(rf->rfcoil,rfcoil);
+   OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rfName);
+   OSTRCPY( rf->rfcoil, sizeof(rf->rfcoil), rfcoil);
    rf->rfDuration = shapelistpw(rfName,pw);  /* Round to 200ns resolution*/
    rf->flip = flip;
    rf->flipmult = 1.0;   /* default to 1, programmer can reassign in sequence */
@@ -782,7 +781,7 @@ void init_rf (RF_PULSE_T *rf, char rfName[], double pw, double flip,
      sgl_abort_message("ERROR rf shape '%s': RF Fraction must be between 0 and 1",rfName);
    }
 
-void shape_rf (RF_PULSE_T *rf, char rfBase[], char rfName[], double pw, double flip,
+void shape_rf (RF_PULSE_T *rf, char rfBase[MAX_STR], char rfName[MAX_STR], double pw, double flip,
               double rof1, double rof2)
    {
    if ((ix > 1) && !sglarray) {
@@ -790,9 +789,9 @@ void shape_rf (RF_PULSE_T *rf, char rfBase[], char rfName[], double pw, double f
      return;
    }
    initRf(rf);
-   strcpy(rf->pulseBase,rfBase);
-   strcpy(rf->pulseName,rfName);
-   strcpy(rf->rfcoil,rfcoil);
+   OSTRCPY( rf->pulseBase, sizeof(rf->pulseBase), rfBase);
+   OSTRCPY( rf->pulseName, sizeof(rf->pulseName), rfName);
+   OSTRCPY( rf->rfcoil, sizeof(rf->rfcoil), rfcoil);
    rf->rfDuration = pw;
    rf->flip = flip;
    rf->flipmult = 1.0;
@@ -843,8 +842,8 @@ void calc_rf (RF_PULSE_T *rf, char VJparam_tpwr[], char VJparam_tpwrf[])
    {
    
    //if ((ix > 1) && !sglarray) return;
-   strcpy(rf->param1,VJparam_tpwr);
-   strcpy(rf->param2,VJparam_tpwrf);
+   OSTRCPY( rf->param1, sizeof(rf->param1), VJparam_tpwr);
+   OSTRCPY( rf->param2, sizeof(rf->param2), VJparam_tpwrf);
    calcPower(rf, rf->rfcoil);
    switch (rf->error) {
      case ERR_RF_CALIBRATION_FILE_MISSING:

--- a/src/nvpsg/solidchoppers.h
+++ b/src/nvpsg/solidchoppers.h
@@ -53,8 +53,8 @@ SHAPE make_shape(SHAPE s)
 
 // Open the output file for print.
 
-   sprintf(str,"%s/shapelib/",userdir);
-   sprintf(shapepath,"%s%s.DEC",str,s.pars.pattern);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/", userdir);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s%s.DEC", str, s.pars.pattern);
    if ((fp = fopen(shapepath,"w")) == NULL) {
       printf("Error in open of %s \n",shapepath);
       psg_abort(1);
@@ -75,7 +75,7 @@ SHAPE make_shape(SHAPE s)
 
    char lpattern[NPATTERN];
    int lix = arryindex(s.pars.array);
-   sprintf(lpattern,"%s%d",getname0("",s.pars.seqName,""),s.pars.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", getname0("",s.pars.seqName,""), s.pars.nRec);
    savet(s.pars.t, lix, lpattern);
 
 // Initialize the time, phase and steps
@@ -298,8 +298,8 @@ SHAPE make_shape1(SHAPE s)
 
 // Open the output file for print.
 
-   sprintf(str,"%s/shapelib/",userdir);
-   sprintf(shapepath,"%s%s.DEC",str,s.pars.pattern);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/", userdir);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s%s.DEC", str, s.pars.pattern);
    if ((fp = fopen(shapepath,"w")) == NULL) {
       printf("Error in open of %s \n",shapepath);
       psg_abort(1);
@@ -320,7 +320,7 @@ SHAPE make_shape1(SHAPE s)
 
    char lpattern[NPATTERN];
    int lix = arryindex(s.pars.array);
-   sprintf(lpattern,"%s%d",getname0("",s.pars.seqName,""),s.pars.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", getname0("",s.pars.seqName,""), s.pars.nRec);
    savet(s.pars.t, lix, lpattern);
 
 // Initialize the time, phase and steps
@@ -526,7 +526,7 @@ SHAPE genericInitShape(SHAPE s, char *name, double p, double phint, int iRec)
       printf("Error in genericInitShape()! The  name %s is invalid !\n",name);
       psg_abort(-1);
    }
-   sprintf(s.pars.seqName,"%s",name);
+   OSPRINTF( s.pars.seqName, sizeof(s.pars.seqName), "%s", name);
 
 // Obtain Phase Arguments
 
@@ -563,16 +563,16 @@ SHAPE genericInitShape(SHAPE s, char *name, double p, double phint, int iRec)
 
    char lpattern[NPATTERN];
    var = getname0("",s.pars.seqName,"");
-   sprintf(lpattern,"%s%d",var,s.pars.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, s.pars.nRec);
    s.pars.hasArray = hasarry(s.pars.array, lpattern);
    int lix = arryindex(s.pars.array);
    var = getname0("",s.pars.seqName,"");
    if (s.pars.calc > 0) {
-      sprintf(s.pars.pattern,"%s%d_%d",var,s.pars.nRec,lix);
+      OSPRINTF( s.pars.pattern, sizeof(s.pars.pattern), "%s%d_%d", var, s.pars.nRec, lix);
       if (s.pars.hasArray == 1) {
          s = make_shape(s);
       }
-       s.pars.t = gett(lix, lpattern);
+      s.pars.t = gett(lix, lpattern);
    }
    return s;
 }
@@ -588,7 +588,7 @@ SHAPE genericInitShape1(SHAPE s, char *name, double p, double phint, int iRec)
       printf("Error in genericInitShape()! The  name %s is invalid !\n",name);
       psg_abort(-1);
    }
-   sprintf(s.pars.seqName,"%s",name);
+   OSPRINTF( s.pars.seqName, sizeof(s.pars.seqName), "%s", name);
 
 // Obtain Phase Arguments
 
@@ -625,16 +625,16 @@ SHAPE genericInitShape1(SHAPE s, char *name, double p, double phint, int iRec)
 
    char lpattern[NPATTERN];
    var = getname0("",s.pars.seqName,"");
-   sprintf(lpattern,"%s%d",var,s.pars.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, s.pars.nRec);
    s.pars.hasArray = hasarry(s.pars.array, lpattern);
    int lix = arryindex(s.pars.array);
    var = getname0("",s.pars.seqName,"");
    if (s.pars.calc > 0) {
-      sprintf(s.pars.pattern,"%s%d_%d",var,s.pars.nRec,lix);
+      OSPRINTF( s.pars.pattern, sizeof(s.pars.pattern), "%s%d_%d", var, s.pars.nRec, lix);
       if (s.pars.hasArray == 1) {
          s = make_shape1(s);
       }
-       s.pars.t = gett(lix, lpattern);
+      s.pars.t = gett(lix, lpattern);
    }
    return s;
 }
@@ -678,8 +678,8 @@ MPSEQ MPchopper(MPSEQ seq)
 
 // Open the output file
 
-   sprintf(str,"%s/shapelib/",userdir);
-   sprintf(shapepath,"%s%s.DEC",str,seq.pattern);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/", userdir);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s%s.DEC", str, seq.pattern);
    if ( (fp = fopen(shapepath,"w")) == NULL) {
       printf("Error in open of %s \n",shapepath);
       psg_abort(1);
@@ -712,7 +712,7 @@ MPSEQ MPchopper(MPSEQ seq)
 //Save the total duration to the MODULE structure.
 
    char lpattern[NPATTERN];
-   sprintf(lpattern,"%s%d",getname0("",seq.seqName,""),seq.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", getname0("",seq.seqName,""), seq.nRec);
    int lix = arryindex(seq.array);
    savet(seq.t, lix, lpattern);
 
@@ -967,8 +967,8 @@ CP make_cp(CP cp)
 
 // Open the output file for print.
 
-   sprintf(str,"%s/shapelib/",userdir);
-   sprintf(shapepath,"%s%s.DEC",str,cp.pattern);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/", userdir);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s%s.DEC", str, cp.pattern);
    if ((fp = fopen(shapepath,"w")) == NULL) {
       printf("Error in open of %s \n",shapepath);
       psg_abort(1);
@@ -988,7 +988,7 @@ CP make_cp(CP cp)
 
    char lpattern[NPATTERN];
    int lix = arryindex(cp.array);
-   sprintf(lpattern,"%s%d",getname0("",cp.seqName,""),cp.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", getname0("",cp.seqName,""), cp.nRec);
    savet(cp.t, lix, lpattern);
 
 // Initialize the time, phase and steps

--- a/src/nvpsg/soliddecshapes.h
+++ b/src/nvpsg/soliddecshapes.h
@@ -225,11 +225,11 @@ TPPM gettppm(char *name)
    int nRec = 0;
    char lpattern[NPATTERN];
    var = getname0("","TPPM",name);
-   sprintf(lpattern,"%s%d",var,nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, nRec);
    dec.hasArray = hasarry(dec.array, lpattern);
    int lix = arryindex(dec.array);
    var = getname0("","TPPM",name);
-   sprintf(dec.pattern,"%s%d_%d",var,nRec,lix);
+   OSPRINTF( dec.pattern, sizeof(dec.pattern), "%s%d_%d", var, nRec, lix);
    if (dec.hasArray == 1) {
       make_tppm(dec);
    }
@@ -282,11 +282,11 @@ SPINAL getspinal(char *name)
    int nRec = 0;  
    char lpattern[NPATTERN];
    var = getname0("","SPINAL",name);
-   sprintf(lpattern,"%s%d",var,nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, nRec);
    dec.hasArray = hasarry(dec.array, lpattern);
    int lix = arryindex(dec.array);
    var = getname0("","SPINAL",name);
-   sprintf(dec.pattern,"%s%d_%d",var,nRec,lix);
+   OSPRINTF( dec.pattern, sizeof(dec.pattern), "%s%d_%d", var, nRec, lix);
    if (dec.hasArray == 1) {
       make_spinal(dec);
    }
@@ -345,11 +345,11 @@ SPINAL2 getspinal2(char *name)
    int nRec = 0;  
    char lpattern[NPATTERN];
    var = getname0("","SPINAL2",name);
-   sprintf(lpattern,"%s%d",var,nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, nRec);
    dec.hasArray = hasarry(dec.array, lpattern);
    int lix = arryindex(dec.array);
    var = getname0("","SPINAL2",name);
-   sprintf(dec.pattern,"%s%d_%d",var,nRec,lix);
+   OSPRINTF( dec.pattern, sizeof(dec.pattern), "%s%d_%d", var, nRec, lix);
    if (dec.hasArray == 1) {
       make_spinal2(dec);
    }
@@ -408,11 +408,11 @@ SPINAL2 getspinal2s(char *name)
    int nRec = 0;  
    char lpattern[NPATTERN];
    var = getname0("","SPINAL",name);
-   sprintf(lpattern,"%s%d",var,nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, nRec);
    dec.hasArray = hasarry(dec.array, lpattern);
    int lix = arryindex(dec.array);
    var = getname0("","SPINAL",name);
-   sprintf(dec.pattern,"%s%d_%d",var,nRec,lix);
+   OSPRINTF( dec.pattern, sizeof(dec.pattern), "%s%d_%d", var, nRec, lix);
    if (dec.hasArray == 1) {
       make_spinal2(dec);
    }
@@ -459,11 +459,11 @@ WALTZ getwaltz(char *name)
    int nRec = 0;  
    char lpattern[NPATTERN];
    var = getname0("","WALTZ",name);
-   sprintf(lpattern,"%s%d",var,nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, nRec);
    dec.hasArray = hasarry(dec.array, lpattern);
    int lix = arryindex(dec.array);
    var = getname0("","WALTZ",name);
-   sprintf(dec.pattern,"%s%d_%d",var,nRec,lix);
+   OSPRINTF( dec.pattern, sizeof(dec.pattern), "%s%d_%d", var, nRec, lix);
    if (dec.hasArray == 1) {
       make_waltz(dec);
    }
@@ -512,11 +512,11 @@ PARIS getparis(char *name)
    int nRec = 0;
    char lpattern[NPATTERN];
    var = getname0("","PARIS",name);
-   sprintf(lpattern,"%s%d",var,nRec);   
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, nRec);   
    dec.hasArray = hasarry(dec.array, lpattern);
    int lix = arryindex(dec.array);
    var = getname0("","PARIS",name);
-   sprintf(dec.pattern,"%s%d_%d",var,nRec,lix);
+   OSPRINTF( dec.pattern, sizeof(dec.pattern), "%s%d_%d", var, nRec, lix);
    if (dec.hasArray == 1) {
       make_paris(dec);
    }
@@ -533,8 +533,8 @@ void make_tppm(TPPM dec)
    FILE *fp;
    int i;
    extern char userdir[];
-   sprintf(shapepath,"%s/shapelib/",userdir);
-   sprintf(str,"%s%s.DEC",shapepath,dec.pattern);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s/shapelib/", userdir);
+   OSPRINTF( str, sizeof(str), "%s%s.DEC", shapepath, dec.pattern);
 
    if((fp = fopen(str,"w"))==NULL) {
       abort_message("Error in make_tppm(): can not create file %s!\n", str);
@@ -632,8 +632,8 @@ void make_spinal(SPINAL dec)
    extern char userdir[];
    int n,i;
    int sign[8] = {1,-1,-1,1,-1,1,1,-1};
-   sprintf(shapepath,"%s/shapelib/",userdir);
-   sprintf(str,"%s%s.DEC",shapepath,dec.pattern);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s/shapelib/", userdir);
+   OSPRINTF( str, sizeof(str), "%s%s.DEC", shapepath, dec.pattern);
 
    if((fp = fopen(str,"w"))==NULL) {
       abort_message("Error in make_spinal(): can not create file %s!\n", str);
@@ -731,8 +731,8 @@ void make_spinal2(SPINAL2 dec)
    extern char userdir[];
    int n,i;
    int sign[8] = {1,-1,-1,1,-1,1,1,-1};
-   sprintf(shapepath,"%s/shapelib/",userdir);
-   sprintf(str,"%s%s.DEC",shapepath,dec.pattern);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s/shapelib/", userdir);
+   OSPRINTF( str, sizeof(str), "%s%s.DEC", shapepath, dec.pattern);
 
    if((fp = fopen(str,"w"))==NULL) {
       abort_message("Error in make_spinal2(): can not create file %s!\n", str);
@@ -829,8 +829,8 @@ void make_waltz(WALTZ dec)
    FILE *fp;
    extern char userdir[];
    int i;
-   sprintf(shapepath,"%s/shapelib/",userdir);
-   sprintf(str,"%s%s.DEC",shapepath,dec.pattern);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s/shapelib/", userdir);
+   OSPRINTF( str, sizeof(str), "%s%s.DEC", shapepath, dec.pattern);
 
    if((fp = fopen(str,"w"))==NULL) {
       abort_message("Error in make_waltz(): can not create file %s!\n", str);
@@ -928,8 +928,8 @@ void make_paris(PARIS p)
    FILE *fp;
    extern char userdir[];
    int i;
-   sprintf(shapepath,"%s/shapelib/",userdir);
-   sprintf(str,"%s%s.DEC",shapepath,p.pattern);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s/shapelib/", userdir);
+   OSPRINTF( str, sizeof(str), "%s%s.DEC", shapepath, p.pattern);
 
    if((fp = fopen(str,"w"))==NULL) {
       abort_message("Error in make_paris(): can not create file %s!\n", str);
@@ -1025,8 +1025,8 @@ DSEQ getdseq(char *name)
 {
    DSEQ d;
    char var[13];
-   sprintf(var,"%s",name);
-   strcat(var,"seq");
+   OSPRINTF( var, sizeof(var), "%s", name);
+   OSTRCAT( var, sizeof(var), "seq");
    Getstr(var,d.seq,sizeof(d.seq));
 
    if (!strcmp(d.seq,"tppm")) {
@@ -1070,7 +1070,7 @@ DSEQ getdseq2(char *name)
 DSEQ setdseq(char *name, char *seq)
 {
    DSEQ d;
-   sprintf(d.seq,"%s",seq);
+   OSPRINTF( d.seq, sizeof(d.seq), "%s", seq);
 
    if (!strcmp(d.seq,"tppm")) {
       d.t = gettppm(name);

--- a/src/nvpsg/solidelements.h
+++ b/src/nvpsg/solidelements.h
@@ -162,9 +162,8 @@ double roundamp(double par, double res)
 void Getstr(char *parname, char *parval, int arrsize)
 {
    char str[MAXSTR];  //getstr() always returns an char array of size MAXSTR
-   getstr(parname,str);
-   strncpy(parval,str,arrsize);
-   if (strlen(str) >= arrsize) *(parval+arrsize-1) = '\0';
+   getstr(parname, str);
+   OSTRCPY( parval, arrsize, str);
 }
 
 //=======================================
@@ -306,10 +305,10 @@ char* getname0(char *varType, char *varSuffix, char *chXtra)
    chLOW[capCount] = '\0';
 
    if (strlen(chXtra) == 0) {
-      sprintf(varName,"%s%s%s%s",varType,chUP,chSeqType,chDescr);
+      OSPRINTF(varName,sizeof(varName),"%s%s%s%s",varType,chUP,chSeqType,chDescr);
       return varName;
    }
-   sprintf(varName,"%s%s%s%s%s",varType,chXtra,chSeqType,chLOW,chDescr);
+   OSPRINTF(varName,sizeof(varName),"%s%s%s%s%s",varType,chXtra,chSeqType,chLOW,chDescr);
    return varName;
 }
 
@@ -358,10 +357,10 @@ char* getname1(char *varType, char *varSuffix, int chnl)
    }
 
    if (chnl > 0) {
-      sprintf(varName,"%s%s%s%s%s",varType,chID,chLOW,chSeqType,chDescr);
+      OSPRINTF(varName,sizeof(varName),"%s%s%s%s%s",varType,chID,chLOW,chSeqType,chDescr);
    }
    else {
-      sprintf(varName,"%s%s%s%s",varType,chUP,chSeqType,chDescr);
+      OSPRINTF(varName,sizeof(varName),"%s%s%s%s",varType,chUP,chSeqType,chDescr);
    }
    return varName;
 }
@@ -395,7 +394,7 @@ AR parsearry(AR params)
    while(i < j) {
       while((i < j) && (array[i] >= '0')) {
          params.a[q] = array[i];
-	 name[p] = array[i];
+         name[p] = array[i];
          k = 0;
          i++; q++; p++;
       }
@@ -500,8 +499,11 @@ int hasarry(AR params, char *pattern)
    int arrindex = 0;
    int arrindexm = 0;
    int prod = 1;
-   int i = 0; int test; int k; int currentmod;
-   
+   int i = 0;
+   int test;
+   int k;
+   int currentmod;
+
    if (ix == 1) {
       k = 0;
       test = 1;
@@ -510,7 +512,7 @@ int hasarry(AR params, char *pattern)
          k++;
       }
       currentmod = k - 1;
-      strcpy(mod[currentmod].pattern,pattern);
+      OSTRCPY( mod[currentmod].pattern, sizeof(mod[currentmod].pattern), pattern);
       mod[currentmod].arrayindex = -1;
       mod[currentmod].filled = 1;
    }
@@ -584,6 +586,7 @@ double gett(int lix, char *pattern)
 {
    double time = 0.0;
    int k = 0; int test;
+
    test = 1;
    while ((k < 64) && (test > 0)) {
       if ((mod[k].filled < 1) || ((strcmp(mod[k].pattern,pattern) == 0))) test = 0;
@@ -604,7 +607,7 @@ AR combine_array(AR a, AR b)
    AR c;
    int i;  
    if (strcmp(a.a,b.a) == 0) {
-      strcpy(c.a,a.a);
+      OSTRCPY( c.a, sizeof(c.a), a.a);
       c.c = a.c;
       c.d = a.d;
       for (i = 0; i < a.c; i++) c.b[i] = a.b[i];
@@ -625,5 +628,3 @@ AR combine_array(AR a, AR b)
    }
 }
 #endif
-
-

--- a/src/nvpsg/solidhhdec.h
+++ b/src/nvpsg/solidhhdec.h
@@ -62,7 +62,9 @@ MPDEC getmpdec(char *name, int iph , double p, double phint, int iRec, int calc)
 {
    MPDEC d;
    char *var;
-   strcpy(d.seqName,name);
+   char n[2];
+   
+   OSTRCPY( d.seqName, sizeof(d.seqName), name);
    var = getname0("seq",d.seqName,"");
    Getstr(var,d.seq,sizeof(d.seq));
 
@@ -74,9 +76,11 @@ MPDEC getmpdec(char *name, int iph , double p, double phint, int iRec, int calc)
 // mpsName - seqName for mpseq
 
    var = getname0(d.seq,d.seqName,"");
-   strcpy(d.mpsName,d.seq);
+   OSTRCPY( d.mpsName, sizeof(d.mpsName), d.seq);
    var = getname0("",d.seqName,"");
-   strncat(d.mpsName,var,1);
+   n[0] = *var;
+   n[1] = (char) 0;
+   OSTRCAT( d.mpsName, sizeof(d.mpsName), n);
 
    if (!strcmp(d.seq,"tppm") || !strcmp(d.seq,"spinal")) {
       d.mps = getspnl(name,iph,p,phint,iRec,calc);
@@ -110,7 +114,8 @@ MPDEC setmpdec(char *name, int iph, double p, double phint, int iRec, int calc)
 {
    MPDEC d;
    char *var;
-   strcpy(d.seqName,name);
+
+   OSTRCPY( d.seqName, sizeof(d.seqName), name);
    var = getname0("seq",d.seqName,"");
    Getstr(var,d.seq,sizeof(d.seq));
 
@@ -837,7 +842,7 @@ MPSEQ getpmlgsuper(char *seqName, int iph ,double p, double phint, int iRec, int
       printf("Error in getpmlgsuper(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   strcpy(pm.seqName,seqName);
+   OSTRCPY( pm.seqName, sizeof(pm.seqName), seqName);
    pm.calc = calc;
    pm.array = parsearry(pm.array);
 
@@ -978,12 +983,12 @@ MPSEQ getpmlgsuper(char *seqName, int iph ,double p, double phint, int iRec, int
 
    char lpattern[NPATTERN];
    var = getname0("",pm.seqName,"");
-   sprintf(lpattern,"%s%d",var,pm.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pm.nRec);
    pm.hasArray = hasarry(pm.array, lpattern);
    int lix = arryindex(pm.array);
    if (pm.calc > 0) {
       var = getname0("",pm.seqName,"");
-      sprintf(pm.pattern,"%s%d_%d",var,pm.nRec,lix);
+      OSPRINTF( pm.pattern, sizeof(pm.pattern), "%s%d_%d", var, pm.nRec, lix);
       if (pm.hasArray == 1) {
          pm = MPchopper(pm); 
          pm.iSuper = iph + pm.nelem%pm.nphSuper;
@@ -992,8 +997,3 @@ MPSEQ getpmlgsuper(char *seqName, int iph ,double p, double phint, int iRec, int
    }
    return pm;
 }
-
-
-
-
-

--- a/src/nvpsg/solidmpseqs.h
+++ b/src/nvpsg/solidmpseqs.h
@@ -57,6 +57,7 @@
 //Implement MPSEQ and Misc Waveforms with "get" Functions
 //===========================================================
 
+
 //===============
 // Build a RAMP
 //===============
@@ -84,7 +85,7 @@ RAMP getramp(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getramp(). The sequence name %s is invalid!\n",seqName);
       psg_abort(-1);
    }
-   sprintf(r.seqName,"%s",seqName);
+   OSPRINTF( r.seqName, sizeof(r.seqName), "%s", seqName);
    r.calc = calc;
    r.array = parsearry(r.array);
 
@@ -151,12 +152,12 @@ RAMP getramp(char *seqName, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",r.seqName,"");
-   sprintf(lpattern,"%s%d",var,r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, r.nRec);
    r.hasArray = hasarry(r.array,lpattern);
    int lix = arryindex(r.array);
    if (r.calc > 0) {
       var = getname0("",r.seqName,"");
-      sprintf(r.pattern,"%s%d_%d",var,r.nRec,lix);
+      OSPRINTF( r.pattern, sizeof(r.pattern), "%s%d_%d", var, r.nRec, lix);
       if (r.hasArray == 1) {
          r = make_ramp(r); 
       }
@@ -179,7 +180,7 @@ MPSEQ getms(char *seqName, int iph, double p, double phint, int iRec, int calc)
       printf("Error in getms(). The sequence name %s is invalid!\n",seqName);
       psg_abort(-1);
    }
-   sprintf(m.seqName,"%s",seqName);
+   OSPRINTF( m.seqName, sizeof(m.seqName), "%s", seqName);
    m.calc = calc;
    m.array = parsearry(m.array);
 
@@ -275,12 +276,12 @@ MPSEQ getms(char *seqName, int iph, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",m.seqName,"");
-   sprintf(lpattern,"%s%d",var,m.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, m.nRec);
    m.hasArray = hasarry(m.array, lpattern);
    int lix = arryindex(m.array);
    if (m.calc > 0) {
       var = getname0("",m.seqName,"");
-      sprintf(m.pattern,"%s%d_%d",var,m.nRec,lix);
+      OSPRINTF( m.pattern, sizeof(m.pattern), "%s%d_%d", var, m.nRec, lix);
       if (m.hasArray == 1) {
          m = MPchopper(m);
          m.iSuper = iph + m.nelem%m.nphSuper;
@@ -304,7 +305,7 @@ MPSEQ getpul(char *seqName, int iph, double p, double phint, int iRec, int calc)
       printf("Error in getpuls(). The sequence name %s is invalid!\n",seqName);
       psg_abort(-1);
    }
-   sprintf(pul.seqName,"%s",seqName);
+   OSPRINTF( pul.seqName, sizeof(pul.seqName), "%s", seqName);
    pul.calc = calc;
    pul.array = parsearry(pul.array);
 
@@ -387,12 +388,12 @@ MPSEQ getpul(char *seqName, int iph, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",pul.seqName,"");
-   sprintf(lpattern,"%s%d",var,pul.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pul.nRec);
    pul.hasArray = hasarry(pul.array, lpattern);
    int lix = arryindex(pul.array);
    if (pul.calc > 0) {
       var = getname0("",pul.seqName,"");
-      sprintf(pul.pattern,"%s%d_%d",var,pul.nRec,lix);
+      OSPRINTF( pul.pattern, sizeof(pul.pattern), "%s%d_%d", var, pul.nRec, lix);
       if (pul.hasArray == 1) {
          pul = MPchopper(pul); 
          pul.iSuper = iph + pul.nelem%pul.nphSuper;
@@ -419,7 +420,7 @@ MPSEQ getpasl(char *seqName,int iph,double p, double phint, int iRec, int calc)
       printf("Error in getpuls(). The sequence name %s is invalid!\n",seqName);
       psg_abort(-1);
    }
-   sprintf(f.seqName,"%s",seqName);
+   OSPRINTF( f.seqName, sizeof(f.seqName), "%s", seqName);
    f.calc = calc;
    f.array = parsearry(f.array);
 
@@ -517,12 +518,12 @@ MPSEQ getpasl(char *seqName,int iph,double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",f.seqName,"");
-   sprintf(lpattern,"%s%d",var,f.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, f.nRec);
    f.hasArray = hasarry(f.array, lpattern);
    int lix = arryindex(f.array);
    if (f.calc > 0) {
       var = getname0("",f.seqName,"");
-      sprintf(f.pattern,"%s%d_%d",var,f.nRec,lix);
+      OSPRINTF( f.pattern, sizeof(f.pattern), "%s%d_%d", var, f.nRec, lix);
       if (f.hasArray == 1) {
          f = MPchopper(f); 
          f.iSuper = iph + f.nelem%f.nphSuper;
@@ -549,7 +550,7 @@ MPSEQ getr1235(char *seqName, int iph, double p, double phint, int iRec, int cal
         printf("Error in getr1235(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    } 
-   sprintf(r.seqName,"%s",seqName);
+   OSPRINTF( r.seqName, sizeof(r.seqName), "%s", seqName);
    r.calc = calc;
    r.array = parsearry(r.array); 
 
@@ -661,12 +662,12 @@ MPSEQ getr1235(char *seqName, int iph, double p, double phint, int iRec, int cal
 
    char lpattern[NPATTERN];
    var = getname0("",r.seqName,"");
-   sprintf(lpattern,"%s%d",var,r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, r.nRec);
    r.hasArray = hasarry(r.array, lpattern);
    int lix = arryindex(r.array);
    if (r.calc > 0) {
       var = getname0("",r.seqName,"");
-      sprintf(r.pattern,"%s%d_%d",var,r.nRec,lix);
+      OSPRINTF( r.pattern, sizeof(r.pattern), "%s%d_%d", var, r.nRec, lix);
       if (r.hasArray == 1) {
          r = MPchopper(r); 
          r.iSuper = iph + r.nelem%72;
@@ -689,7 +690,7 @@ MPSEQ getr1426(char *seqName, int iph, double p, double phint, int iRec, int cal
         printf("Error in getr1426(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(r.seqName,"%s",seqName);
+   OSPRINTF( r.seqName, sizeof(r.seqName), "%s", seqName);
    r.calc = calc;
    r.array = parsearry(r.array); 
 
@@ -778,12 +779,12 @@ MPSEQ getr1426(char *seqName, int iph, double p, double phint, int iRec, int cal
 
    char lpattern[NPATTERN];
    var = getname0("",r.seqName,"");
-   sprintf(lpattern,"%s%d",var,r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, r.nRec);
    r.hasArray = hasarry(r.array, lpattern);
    int lix = arryindex(r.array);
    if (r.calc > 0) {
       var = getname0("",r.seqName,"");
-      sprintf(r.pattern,"%s%d_%d",var,r.nRec,lix);
+      OSPRINTF( r.pattern, sizeof(r.pattern), "%s%d_%d", var, r.nRec, lix);
       if (r.hasArray == 1) {
          r = MPchopper(r); 
          r.iSuper = iph + r.nelem%r.nphSuper;
@@ -806,7 +807,7 @@ MPSEQ getr1825(char *seqName, int iph, double p, double phint, int iRec, int cal
         printf("Error in getr1825(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(r.seqName,"%s",seqName);
+   OSPRINTF( r.seqName, sizeof(r.seqName), "%s", seqName);
    r.calc = calc;
    r.array = parsearry(r.array); 
 
@@ -892,12 +893,12 @@ MPSEQ getr1825(char *seqName, int iph, double p, double phint, int iRec, int cal
 
    char lpattern[NPATTERN];
    var = getname0("",r.seqName,"");
-   sprintf(lpattern,"%s%d",var,r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, r.nRec);
    r.hasArray = hasarry(r.array, r.pattern);
    int lix = arryindex(r.array);
    if (r.calc > 0) {
       var = getname0("",r.seqName,""); 
-      sprintf(r.pattern,"%s%d_%d",var,r.nRec,lix);
+      OSPRINTF( r.pattern, sizeof(r.pattern), "%s%d_%d", var, r.nRec, lix);
       if (r.hasArray == 1) {
          r = MPchopper(r); 
          r.iSuper = iph + r.nelem%r.nphSuper;
@@ -921,7 +922,7 @@ MPSEQ getspc5(char *seqName, int iph, double p, double phint, int iRec, int calc
         printf("Error in getspc5(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(spc5.seqName,"%s",seqName);
+   OSPRINTF( spc5.seqName, sizeof(spc5.seqName), "%s", seqName);
    spc5.calc = calc;
    spc5.array = parsearry(spc5.array);
 
@@ -1018,12 +1019,12 @@ MPSEQ getspc5(char *seqName, int iph, double p, double phint, int iRec, int calc
 
    char lpattern[NPATTERN];
    var = getname0("",spc5.seqName,"");
-   sprintf(lpattern,"%s%d",var,spc5.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, spc5.nRec);
    spc5.hasArray = hasarry(spc5.array, lpattern);
    int lix = arryindex(spc5.array);
    if (spc5.calc > 0) {
       var = getname0("",spc5.seqName,"");
-      sprintf(spc5.pattern,"%s%d_%d",var,spc5.nRec,lix);  
+      OSPRINTF( spc5.pattern, sizeof(spc5.pattern), "%s%d_%d", var, spc5.nRec, lix);  
       if (spc5.hasArray == 1) {
          spc5 = MPchopper(spc5); 
          spc5.iSuper = iph + spc5.nelem%spc5.nphSuper;
@@ -1048,7 +1049,7 @@ MPSEQ getpostc7(char *seqName, int iph, double p, double phint, int iRec, int ca
         printf("Error in getpostc7(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(c7.seqName,"%s",seqName);
+   OSPRINTF( c7.seqName, sizeof(c7.seqName), "%s", seqName);
    c7.calc = calc;
    c7.array = parsearry(c7.array);
 
@@ -1139,12 +1140,12 @@ MPSEQ getpostc7(char *seqName, int iph, double p, double phint, int iRec, int ca
 
    char lpattern[NPATTERN];
    var = getname0("",c7.seqName,"");
-   sprintf(lpattern,"%s%d",var,c7.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, c7.nRec);
    c7.hasArray = hasarry(c7.array, lpattern);
    int lix = arryindex(c7.array);
    if (c7.calc > 0) {
       var = getname0("",c7.seqName,"");
-      sprintf(c7.pattern,"%s%d_%d",var,c7.nRec,lix);
+      OSPRINTF( c7.pattern, sizeof(c7.pattern), "%s%d_%d", var, c7.nRec, lix);
       if (c7.hasArray == 1) {
          c7 = MPchopper(c7); 
          c7.iSuper = iph + c7.nelem%c7.nphSuper;
@@ -1168,7 +1169,7 @@ MPSEQ getfslg(char *seqName, int iph, double p, double phint, int iRec, int calc
         printf("Error in getfslg1(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(f.seqName,"%s",seqName);
+   OSPRINTF( f.seqName, sizeof(f.seqName), "%s", seqName);
    f.calc = calc;
    f.array = parsearry(f.array);
 
@@ -1262,12 +1263,12 @@ MPSEQ getfslg(char *seqName, int iph, double p, double phint, int iRec, int calc
 
    char lpattern[NPATTERN];
    var = getname0("",f.seqName,""); 
-   sprintf(lpattern,"%s%d",var,f.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, f.nRec);
    f.hasArray = hasarry(f.array, lpattern);
    int lix = arryindex(f.array);
    if (f.calc > 0) {
       var = getname0("",f.seqName,""); 
-      sprintf(f.pattern,"%s%d_%d",var,f.nRec,lix);
+      OSPRINTF( f.pattern, sizeof(f.pattern), "%s%d_%d", var, f.nRec, lix);
       if (f.hasArray == 1) {
          f = MPchopper(f);
          f.iSuper = iph + f.nelem%f.nphSuper;
@@ -1292,7 +1293,7 @@ MPSEQ getpmlg(char *seqName, int iph ,double p, double phint, int iRec, int calc
       printf("Error in getpmlg(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(pm.seqName,"%s",seqName);
+   OSPRINTF( pm.seqName, sizeof(pm.seqName), "%s", seqName);
    pm.calc = calc;
    pm.array = parsearry(pm.array);
 
@@ -1409,12 +1410,12 @@ MPSEQ getpmlg(char *seqName, int iph ,double p, double phint, int iRec, int calc
 
    char lpattern[NPATTERN];
    var = getname0("",pm.seqName,"");
-   sprintf(lpattern,"%s%d",var,pm.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pm.nRec);
    pm.hasArray = hasarry(pm.array, lpattern);
    int lix = arryindex(pm.array);
    if (pm.calc > 0) {
       var = getname0("",pm.seqName,"");
-      sprintf(pm.pattern,"%s%d_%d",var,pm.nRec,lix);
+      OSPRINTF( pm.pattern, sizeof(pm.pattern), "%s%d_%d", var, pm.nRec, lix);
       if (pm.hasArray == 1) {
          pm = MPchopper(pm); 
          pm.iSuper = iph + pm.nelem%pm.nphSuper;
@@ -1439,7 +1440,7 @@ MPSEQ getblew(char *seqName, int iph, double p, double phint, int iRec, int calc
       printf("Error in getblew(). The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(pm.seqName,"%s",seqName);
+   OSPRINTF( pm.seqName, sizeof(pm.seqName), "%s", seqName);
    pm.calc = calc;
    pm.array = parsearry(pm.array);
 
@@ -1539,12 +1540,12 @@ MPSEQ getblew(char *seqName, int iph, double p, double phint, int iRec, int calc
 
    char lpattern[NPATTERN];
    var = getname0("",pm.seqName,"");
-   sprintf(lpattern,"%s%d",var,pm.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pm.nRec);
    pm.hasArray = hasarry(pm.array, lpattern);
    int lix = arryindex(pm.array);
    if (pm.calc > 0) {
       var = getname0("",pm.seqName,"");
-      sprintf(pm.pattern,"%s%d_%d",var,pm.nRec,lix);
+      OSPRINTF( pm.pattern, sizeof(pm.pattern), "%s%d_%d", var, pm.nRec, lix);
       if (pm.hasArray == 1) {
          pm = MPchopper(pm);
          pm.iSuper = iph + pm.nelem%pm.nphSuper;
@@ -1568,7 +1569,7 @@ MPSEQ getdumbo(char *seqName, int iph, double p, double phint, int iRec, int cal
       printf("Error in getdumbo(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(pm.seqName,"%s",seqName);
+   OSPRINTF( pm.seqName, sizeof(pm.seqName), "%s", seqName);
    pm.calc = calc;
    pm.array = parsearry(pm.array);
 
@@ -1680,12 +1681,12 @@ MPSEQ getdumbo(char *seqName, int iph, double p, double phint, int iRec, int cal
 
    char lpattern[NPATTERN];
    var = getname0("",pm.seqName,"");
-   sprintf(lpattern,"%s%d",var,pm.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pm.nRec);
    pm.hasArray = hasarry(pm.array, lpattern);
    int lix = arryindex(pm.array);
    if (pm.calc > 0) {
       var = getname0("",pm.seqName,"");
-      sprintf(pm.pattern,"%s%d_%d",var,pm.nRec,lix);
+      OSPRINTF( pm.pattern, sizeof(pm.pattern), "%s%d_%d", var, pm.nRec, lix);
       if (pm.hasArray == 1) {
          pm = MPchopper(pm);
          pm.iSuper = iph + pm.nelem%pm.nphSuper;
@@ -1709,7 +1710,7 @@ MPSEQ getbaba(char *seqName, int iph, double p, double phint, int iRec, int calc
         printf("Error in getbaba(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(baba.seqName,"%s",seqName);
+   OSPRINTF( baba.seqName, sizeof(baba.seqName), "%s", seqName);
    baba.calc = calc;
    baba.array = parsearry(baba.array);
 
@@ -1837,12 +1838,12 @@ MPSEQ getbaba(char *seqName, int iph, double p, double phint, int iRec, int calc
 
    char lpattern[NPATTERN];
    var = getname0("",baba.seqName,"");
-   sprintf(lpattern,"%s%d",var,baba.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, baba.nRec);
    baba.hasArray = hasarry(baba.array, lpattern);
    int lix = arryindex(baba.array);
    if (baba.calc > 0) {
       var = getname0("",baba.seqName,"");
-      sprintf(baba.pattern,"%s%d_%d",var,baba.nRec,lix);
+      OSPRINTF( baba.pattern, sizeof(baba.pattern), "%s%d_%d", var, baba.nRec, lix);
       if (baba.hasArray == 1) {
          baba = MPchopper(baba); 
          baba.iSuper = iph + baba.nelem%baba.nphSuper;
@@ -1866,7 +1867,7 @@ MPSEQ getxy8(char *seqName, int iph, double p, double phint, int iRec, int calc)
         printf("Error in getxy8(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(xy8.seqName,"%s",seqName);
+   OSPRINTF( xy8.seqName, sizeof(xy8.seqName), "%s", seqName);
    xy8.calc = calc;
    xy8.array = parsearry(xy8.array);
 
@@ -1973,12 +1974,12 @@ MPSEQ getxy8(char *seqName, int iph, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",xy8.seqName,"");
-   sprintf(lpattern,"%s%d",var,xy8.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, xy8.nRec);
    xy8.hasArray = hasarry(xy8.array, lpattern);
    int lix = arryindex(xy8.array);
    if (xy8.calc > 0) {
       var = getname0("",xy8.seqName,"");
-      sprintf(xy8.pattern,"%s%d_%d",var,xy8.nRec,lix);
+      OSPRINTF( xy8.pattern, sizeof(xy8.pattern), "%s%d_%d", var, xy8.nRec, lix);
       if (xy8.hasArray == 1) {
          xy8 = MPchopper(xy8); 
          xy8.iSuper = iph + xy8.nelem%xy8.nphSuper;
@@ -2002,7 +2003,7 @@ CP getcp(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getcp(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(cp.seqName,"%s",seqName);
+   OSPRINTF( cp.seqName, sizeof(cp.seqName), "%s", seqName);
    cp.calc = calc;
    cp.array = parsearry(cp.array);
 
@@ -2042,14 +2043,14 @@ CP getcp(char *seqName, double p, double phint, int iRec, int calc)
    var = getname1("a",cp.seqName,1);
    cp.a1 = getval(var);
    if ((strcmp(cp.ch,"fr") == 0)) 
-   cp.array = disarry(var, cp.array);
+      cp.array = disarry(var, cp.array);
 
 // aXhxsuffix
 
    var = getname1("a",cp.seqName,2);
    cp.a2 = getval(var);
    if ((strcmp(cp.ch,"to") == 0)) 
-   cp.array = disarry(var, cp.array);
+      cp.array = disarry(var, cp.array);
 
 // dHXsuffix
 
@@ -2105,12 +2106,12 @@ CP getcp(char *seqName, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",cp.seqName,"");
-   sprintf(lpattern,"%s%d",var,cp.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, cp.nRec);
    cp.hasArray = hasarry(cp.array, lpattern);
    int lix = arryindex(cp.array);
    if (cp.calc > 0) {
       var = getname0("",cp.seqName,"");
-      sprintf(cp.pattern,"%s%d_%d",var,cp.nRec,lix);
+      OSPRINTF( cp.pattern, sizeof(cp.pattern), "%s%d_%d", var, cp.nRec, lix);
       if (cp.hasArray == 1) {
          cp = make_cp(cp);
       }
@@ -2133,14 +2134,14 @@ DREAM getdream(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getdream! The sequence name %s is invalid !\n",seqName);
       psg_abort(-1);
    }
-   sprintf(d.seqName,"%s",seqName);
+   OSPRINTF( d.seqName, sizeof(d.seqName), "%s", seqName);
    d.calc = calc;
    d.array = parsearry(d.array);
 
-   sprintf(d.Ruu.seqName,"%s",d.seqName);
-   sprintf(d.Rud.seqName,"%s",d.seqName);
-   sprintf(d.Rdu.seqName,"%s",d.seqName);
-   sprintf(d.Rdd.seqName,"%s",d.seqName);
+   OSPRINTF( d.Ruu.seqName, sizeof(d.Ruu.seqName), "%s", d.seqName);
+   OSPRINTF( d.Rud.seqName, sizeof(d.Rud.seqName), "%s", d.seqName);
+   OSPRINTF( d.Rdu.seqName, sizeof(d.Rdu.seqName), "%s", d.seqName);
+   OSPRINTF( d.Rdd.seqName, sizeof(d.Rdd.seqName), "%s", d.seqName);
 
 // Obtain Phase Arguments
 
@@ -2186,11 +2187,10 @@ DREAM getdream(char *seqName, double p, double phint, int iRec, int calc)
   
    var = getname0("ch",d.seqName,"");
    Getstr(var,d.ch,sizeof(d.ch));
-
-   sprintf(d.Ruu.ch,"%s",d.ch);
-   sprintf(d.Rud.ch,"%s",d.ch);
-   sprintf(d.Rdu.ch,"%s",d.ch);
-   sprintf(d.Rdd.ch,"%s",d.ch);
+   OSPRINTF( d.Ruu.ch, sizeof(d.Ruu.ch), "%s", d.ch);
+   OSPRINTF( d.Rud.ch, sizeof(d.Rud.ch), "%s", d.ch);
+   OSPRINTF( d.Rdu.ch, sizeof(d.Rdu.ch), "%s", d.ch);
+   OSPRINTF( d.Rdd.ch, sizeof(d.Rdd.ch), "%s", d.ch);
 
 //aXdream
 
@@ -2234,34 +2234,34 @@ DREAM getdream(char *seqName, double p, double phint, int iRec, int calc)
 
 //Set a Tangent Shape Only
 
-   sprintf(d.Ruu.sh,"t");
-   sprintf(d.Rud.sh,"t");
-   sprintf(d.Rdu.sh,"t");
-   sprintf(d.Rdd.sh,"t");
+   OSPRINTF( d.Ruu.sh, sizeof(d.Ruu.sh), "t");
+   OSPRINTF( d.Rud.sh, sizeof(d.Rud.sh), "t");
+   OSPRINTF( d.Rdu.sh, sizeof(d.Rdu.sh), "t");
+   OSPRINTF( d.Rdd.sh, sizeof(d.Rdd.sh), "t");
 
 //Set the Polarity of Each Waveform
 
-   sprintf(d.Ruu.pol,"uu");
-   sprintf(d.Rud.pol,"ud");
-   sprintf(d.Rdu.pol,"du");
-   sprintf(d.Rdd.pol,"dd");
+   OSPRINTF( d.Ruu.pol, sizeof(d.Ruu.pol), "uu");
+   OSPRINTF( d.Rud.pol, sizeof(d.Rud.pol), "ud");
+   OSPRINTF( d.Rdu.pol, sizeof(d.Rdu.pol), "du");
+   OSPRINTF( d.Rdd.pol, sizeof(d.Rdd.pol), "dd");
 
 //Set the Pattern Name for Each Waveform
 
    char lpattern[NPATTERN];
    var = getname0("",d.seqName,"");
-   sprintf(lpattern,"%s%d",var,d.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, d.nRec);
    d.hasArray = hasarry(d.array, d.Ruu.pattern);
    int lix = arryindex(d.array);
    if (d.calc > 0) {
       var = getname0("uu",d.seqName,"");
-      sprintf(d.Ruu.pattern,"%s%d_%d",var,d.Ruu.nRec,lix);
+      OSPRINTF( d.Ruu.pattern, sizeof(d.Ruu.pattern), "%s%d_%d", var, d.Ruu.nRec, lix);
       var = getname0("ud",d.seqName,"");
-      sprintf(d.Rud.pattern,"%s%d_%d",var,d.Rud.nRec,lix);
+      OSPRINTF( d.Rud.pattern, sizeof(d.Rud.pattern), "%s%d_%d", var, d.Rud.nRec, lix);
       var = getname0("du",d.seqName,"");
-      sprintf(d.Rdu.pattern,"%s%d_%d",var,d.Rdu.nRec,lix);
+      OSPRINTF( d.Rdu.pattern, sizeof(d.Rdu.pattern), "%s%d_%d", var, d.Rdu.nRec, lix);
       var = getname0("dd",d.seqName,"");
-      sprintf(d.Rdd.pattern,"%s%d_%d",var,d.Rdd.nRec,lix);
+      OSPRINTF( d.Rdd.pattern, sizeof(d.Rdd.pattern), "%s%d_%d", var, d.Rdd.nRec, lix);
       if (d.hasArray == 1) {
          d = make_dream(d);
       }
@@ -2287,7 +2287,7 @@ MPSEQ getdraws(char *seqName, int iph, double p, double phint, int iRec, int cal
         printf("Error in getdraws(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(r.seqName,"%s",seqName);
+   OSPRINTF( r.seqName, sizeof(r.seqName), "%s", seqName);
    r.calc = calc;
    r.array = parsearry(r.array); 
 
@@ -2401,12 +2401,12 @@ MPSEQ getdraws(char *seqName, int iph, double p, double phint, int iRec, int cal
 
    char lpattern[NPATTERN];
    var = getname0("",r.seqName,"");
-   sprintf(lpattern,"%s%d",var,r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, r.nRec);
    r.hasArray = hasarry(r.array,lpattern);
    int lix = arryindex(r.array);
    if (r.calc > 0) {
       var = getname0("",r.seqName,"");
-      sprintf(r.pattern,"%s%d_%d",var,r.nRec,lix);
+      OSPRINTF( r.pattern, sizeof(r.pattern), "%s%d_%d", var, r.nRec, lix);
       if (r.hasArray == 1) {
          r = MPchopper(r); 
          r.iSuper = iph + r.nelem%r.nphSuper;
@@ -2430,7 +2430,7 @@ MPSEQ getrapt(char *seqName, double p, double phint, int iRec, int calc)
         printf("Error in getrapt(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(r.seqName,"%s",seqName);
+   OSPRINTF( r.seqName, sizeof(r.seqName), "%s", seqName);
    r.calc = calc;
    r.array = parsearry(r.array);
 
@@ -2525,12 +2525,12 @@ MPSEQ getrapt(char *seqName, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",r.seqName,"");
-   sprintf(lpattern,"%s%d",var,r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, r.nRec);
    r.hasArray = hasarry(r.array, lpattern);
    int lix = arryindex(r.array);
    if (r.calc > 0) {
       var = getname0("",r.seqName,"");
-      sprintf(r.pattern,"%s%d_%d",var,r.nRec,lix);
+      OSPRINTF( r.pattern, sizeof(r.pattern), "%s%d_%d", var, r.nRec, lix);
       if (r.hasArray == 1) {
          r = MPchopper(r);
       }
@@ -2558,7 +2558,7 @@ MPSEQ getgrapt(char *seqName, double p, double phint, int iRec, int calc)
         printf("Error in getgrapt(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(r.seqName,"%s",seqName);
+   OSPRINTF( r.seqName, sizeof(r.seqName), "%s", seqName);
    r.calc = calc;
    r.array = parsearry(r.array);
 
@@ -2694,12 +2694,12 @@ MPSEQ getgrapt(char *seqName, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",r.seqName,"");
-   sprintf(lpattern,"%s%d",var,r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, r.nRec);
    r.hasArray = hasarry(r.array, lpattern);
    int lix = arryindex(r.array);
    if (r.calc > 0) {
       var = getname0("",r.seqName,"");
-      sprintf(r.pattern,"%s%d_%d",var,r.nRec,lix);
+      OSPRINTF( r.pattern, sizeof(r.pattern), "%s%d_%d", var, r.nRec, lix);
       if (r.hasArray == 1) {
          r = MPchopper(r);
       }
@@ -2725,7 +2725,7 @@ MPSEQ getpipsxy(char *seqName, int iph, double p, double phint, int iRec, int ca
         printf("Error in getpips(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(pips.seqName,"%s",seqName);
+   OSPRINTF( pips.seqName, sizeof(pips.seqName), "%s", seqName);
    pips.calc = calc;
    pips.array = parsearry(pips.array);
 
@@ -2835,12 +2835,12 @@ MPSEQ getpipsxy(char *seqName, int iph, double p, double phint, int iRec, int ca
 
    char lpattern[NPATTERN];
    var = getname0("",pips.seqName,"");
-   sprintf(lpattern,"%s%d",var,pips.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pips.nRec);
    pips.hasArray = hasarry(pips.array, lpattern);
    int lix = arryindex(pips.array);
    if (pips.calc > 0) {
       var = getname0("",pips.seqName,"");
-      sprintf(pips.pattern,"%s%d_%d",var,pips.nRec,lix);
+      OSPRINTF( pips.pattern, sizeof(pips.pattern), "%s%d_%d", var, pips.nRec, lix);
       if (pips.hasArray == 1) {
          pips = MPchopper(pips); 
          pips.iSuper = iph + pips.nelem%pips.nphSuper;
@@ -2863,7 +2863,7 @@ MPSEQ getsr4(char *seqName, int iph, double p, double phint, int iRec, int calc)
         printf("Error in getsr4(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(r.seqName,"%s",seqName);
+   OSPRINTF( r.seqName, sizeof(r.seqName), "%s", seqName);
    r.calc = calc;
    r.array = parsearry(r.array);
 
@@ -2970,12 +2970,12 @@ MPSEQ getsr4(char *seqName, int iph, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",r.seqName,"");
-   sprintf(lpattern,"%s%d",var,r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, r.nRec);
    r.hasArray = hasarry(r.array, lpattern);
    int lix = arryindex(r.array);
    if (r.calc > 0) {
       var = getname0("",r.seqName,"");
-      sprintf(r.pattern,"%s%d_%d",var,r.nRec,lix);
+      OSPRINTF( r.pattern, sizeof(r.pattern), "%s%d_%d", var, r.nRec, lix);
       if (r.hasArray == 1) {
          r = MPchopper(r); 
          r.iSuper = iph + r.nelem/24;
@@ -2998,7 +2998,7 @@ MPSEQ getsammyd(char *seqName, int iph, double p, double phint, int iRec, int ca
         printf("Error in getsammyd(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(sd.seqName,"%s",seqName);
+   OSPRINTF( sd.seqName, sizeof(sd.seqName), "%s", seqName);
    sd.calc = calc;
    sd.array = parsearry(sd.array);
 
@@ -3127,13 +3127,13 @@ MPSEQ getsammyd(char *seqName, int iph, double p, double phint, int iRec, int ca
 
    char lpattern[NPATTERN];
    var = getname0("",sd.seqName,"");
-   sprintf(lpattern,"%s%d",var,sd.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, sd.nRec);
 
    sd.hasArray = hasarry(sd.array, lpattern);
    int lix = arryindex(sd.array);
    if (sd.calc > 0) {
       var = getname0("",sd.seqName,"");
-      sprintf(sd.pattern,"%s%d_%d",var,sd.nRec,lix);
+      OSPRINTF( sd.pattern, sizeof(sd.pattern), "%s%d_%d", var, sd.nRec, lix);
       if (sd.hasArray == 1) {
          sd = MPchopper(sd); 
          sd.iSuper = iph + sd.nelem%sd.nphSuper;
@@ -3156,7 +3156,7 @@ MPSEQ getsammyo(char *seqName, int iph, double p, double phint, int iRec, int ca
         printf("Error in getsammyo(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(so.seqName,"%s",seqName);
+   OSPRINTF( so.seqName, sizeof(so.seqName), "%s", seqName);
    so.calc = calc;
    so.array = parsearry(so.array);
 
@@ -3262,12 +3262,12 @@ MPSEQ getsammyo(char *seqName, int iph, double p, double phint, int iRec, int ca
 
    char lpattern[NPATTERN];
    var = getname0("",so.seqName,"");
-   sprintf(lpattern,"%s%d",var,so.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, so.nRec);
    so.hasArray = hasarry(so.array, lpattern);
    int lix = arryindex(so.array);
    if (so.calc > 0) {
       var = getname0("",so.seqName,"");
-      sprintf(so.pattern,"%s%d_%d",var,so.nRec,lix);
+      OSPRINTF( so.pattern, sizeof(so.pattern), "%s%d_%d", var, so.nRec, lix);
       if (so.hasArray == 1) {
          so = MPchopper(so); 
          so.iSuper = iph + so.nelem%so.nphSuper;
@@ -3290,7 +3290,7 @@ MPSEQ getlg(char *seqName, int iph, double p, double phint, int iRec, int calc)
         printf("Error in getlg(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(f.seqName,"%s",seqName);
+   OSPRINTF( f.seqName, sizeof(f.seqName), "%s", seqName);
    f.calc = calc;
    f.iSuper = iph;
    f.array = parsearry(f.array);
@@ -3379,12 +3379,12 @@ MPSEQ getlg(char *seqName, int iph, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",f.seqName,"");
-   sprintf(lpattern,"%s%d",var,f.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, f.nRec);
    f.hasArray = hasarry(f.array, lpattern);
    int lix = arryindex(f.array);
    if (f.calc > 0) {
       var = getname0("",f.seqName,"");
-      sprintf(f.pattern,"%s%d_%d",var,f.nRec,lix);
+      OSPRINTF( f.pattern, sizeof(f.pattern), "%s%d_%d", var, f.nRec, lix);
       if (f.hasArray == 1) {
          f = MPchopper(f);
          f.iSuper = iph + f.nelem%f.nphSuper;
@@ -3407,7 +3407,7 @@ MPSEQ getrfdrxy8(char *seqName, int iph, double p, double phint, int iRec, int c
         printf("Error in getrfdrxy8(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(xy8.seqName,"%s",seqName);
+   OSPRINTF( xy8.seqName, sizeof(xy8.seqName), "%s", seqName);
    xy8.calc = calc;
    xy8.array = parsearry(xy8.array);
 
@@ -3521,12 +3521,12 @@ MPSEQ getrfdrxy8(char *seqName, int iph, double p, double phint, int iRec, int c
 
    char lpattern[NPATTERN];
    var = getname0("",xy8.seqName,"");
-   sprintf(lpattern,"%s%d",var,xy8.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, xy8.nRec);
    xy8.hasArray = hasarry(xy8.array, lpattern);
    int lix = arryindex(xy8.array);
    if (xy8.calc > 0) {
       var = getname0("",xy8.seqName,"");
-      sprintf(xy8.pattern,"%s%d_%d",var,xy8.nRec,lix);
+      OSPRINTF( xy8.pattern, sizeof(xy8.pattern), "%s%d_%d", var, xy8.nRec, lix);
       if (xy8.hasArray == 1) {
          xy8 = MPchopper(xy8); 
          xy8.iSuper = iph + xy8.nelem%xy8.nphSuper;
@@ -3551,7 +3551,7 @@ MPSEQ getseac7(char *seqName, int iph, double p, double phint, int iRec, int cal
         printf("Error in getseac7(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(seac7.seqName,"%s",seqName);
+   OSPRINTF( seac7.seqName, sizeof(seac7.seqName), "%s", seqName);
    seac7.calc = calc;
    seac7.array = parsearry(seac7.array);
 
@@ -3688,12 +3688,12 @@ MPSEQ getseac7(char *seqName, int iph, double p, double phint, int iRec, int cal
 
    char lpattern[NPATTERN];
    var = getname0("",seac7.seqName,"");
-   sprintf(lpattern,"%s%d",var,seac7.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, seac7.nRec);
    seac7.hasArray = hasarry(seac7.array, lpattern);
    int lix = arryindex(seac7.array);
    if (seac7.calc > 0) {
       var = getname0("",seac7.seqName,"");
-      sprintf(seac7.pattern,"%s%d_%d",var,seac7.nRec,lix);
+      OSPRINTF( seac7.pattern, sizeof(seac7.pattern), "%s%d_%d", var, seac7.nRec, lix);
       if (seac7.hasArray == 1) {
          seac7 = MPchopper(seac7); 
          seac7.iSuper = iph + seac7.nelem%seac7.nphSuper;
@@ -3718,7 +3718,7 @@ MPSEQ getsc14(char *seqName, int iph, double p, double phint, int iRec, int calc
         printf("Error in getsc14(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
     }
-   sprintf(sc14.seqName,"%s",seqName);
+   OSPRINTF( sc14.seqName, sizeof(sc14.seqName), "%s", seqName);
    sc14.calc = calc;
    sc14.array = parsearry(sc14.array);
 
@@ -3802,12 +3802,12 @@ MPSEQ getsc14(char *seqName, int iph, double p, double phint, int iRec, int calc
 
    char lpattern[NPATTERN];
    var = getname0("",sc14.seqName,"");
-   sprintf(lpattern,"%s%d",var,sc14.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, sc14.nRec);
    sc14.hasArray = hasarry(sc14.array, sc14.pattern);
    int lix = arryindex(sc14.array);
    if (sc14.calc > 0) {
       var = getname0("",sc14.seqName,"");
-      sprintf(sc14.pattern,"%s%d_%d",var,sc14.nRec,lix);
+      OSPRINTF( sc14.pattern, sizeof(sc14.pattern), "%s%d_%d", var, sc14.nRec, lix);
       if (sc14.hasArray == 1) {
          sc14 = MPchopper(sc14); 
          sc14.iSuper = iph + sc14.nelem%sc14.nphSuper;
@@ -3831,7 +3831,7 @@ MPSEQ getptrfdr(char *seqName, int iph, double p, double phint, int iRec, int ca
         printf("Error in getptrfdr(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(pt.seqName,"%s",seqName);
+   OSPRINTF( pt.seqName, sizeof(pt.seqName), "%s", seqName);
    pt.calc = calc;
    pt.array = parsearry(pt.array);
    
@@ -3937,12 +3937,12 @@ MPSEQ getptrfdr(char *seqName, int iph, double p, double phint, int iRec, int ca
 
    char lpattern[NPATTERN];
    var = getname0("",pt.seqName,"");
-   sprintf(lpattern,"%s%d",var,pt.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pt.nRec);
    pt.hasArray = hasarry(pt.array, lpattern);
    int lix = arryindex(pt.array);
    if (pt.calc > 0) {
       var = getname0("",pt.seqName,"");
-      sprintf(pt.pattern,"%s%d_%d",var,pt.nRec,lix);
+      OSPRINTF( pt.pattern, sizeof(pt.pattern), "%s%d_%d", var, pt.nRec, lix);
       if (pt.hasArray == 1) {
          pt = MPchopper(pt); 
          pt.iSuper = iph + pt.nelem%pt.nphSuper;
@@ -3966,7 +3966,7 @@ MPSEQ getfprfdr(char *seqName, int iph, double p, double phint, int iRec, int ca
         printf("Error in getfprfdr(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(fp.seqName,"%s",seqName);
+   OSPRINTF( fp.seqName, sizeof(fp.seqName), "%s", seqName);
    fp.calc = calc;
    fp.array = parsearry(fp.array);
 
@@ -4069,12 +4069,12 @@ MPSEQ getfprfdr(char *seqName, int iph, double p, double phint, int iRec, int ca
 
    char lpattern[NPATTERN];
    var = getname0("",fp.seqName,"");
-   sprintf(lpattern,"%s%d",var,fp.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, fp.nRec);
    fp.hasArray = hasarry(fp.array, lpattern);
    int lix = arryindex(fp.array);
    if (fp.calc > 0) {
       var = getname0("",fp.seqName,"");
-      sprintf(fp.pattern,"%s%d_%d",var,fp.nRec,lix);
+      OSPRINTF( fp.pattern, sizeof(fp.pattern), "%s%d_%d", var, fp.nRec, lix);
       if (fp.hasArray == 1) {
          fp = MPchopper(fp);
          fp.iSuper = iph + fp.nelem%fp.nphSuper;
@@ -4099,7 +4099,7 @@ MPSEQ getspnl(char *seqName, int iph, double p, double phint, int iRec, int calc
         printf("Error in getspnl(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(spnl.seqName,"%s",seqName);
+   OSPRINTF( spnl.seqName, sizeof(spnl.seqName), "%s", seqName);
    spnl.calc = calc;
    spnl.array = parsearry(spnl.array); 
 
@@ -4216,12 +4216,12 @@ MPSEQ getspnl(char *seqName, int iph, double p, double phint, int iRec, int calc
 
    char lpattern[NPATTERN];
    var = getname0("",spnl.seqName,"");
-   sprintf(lpattern,"%s%d",var,spnl.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, spnl.nRec);
    spnl.hasArray = hasarry(spnl.array, lpattern);
    int lix = arryindex(spnl.array);
    if (spnl.calc > 0) {
       var = getname0("",spnl.seqName,"");
-      sprintf(spnl.pattern,"%s%d_%d",var,spnl.nRec,lix);
+      OSPRINTF( spnl.pattern, sizeof(spnl.pattern), "%s%d_%d", var, spnl.nRec, lix);
       if (spnl.hasArray == 1) {
          spnl = MPchopper(spnl); 
          spnl.iSuper = iph + spnl.nelem%spnl.nphSuper;
@@ -4244,7 +4244,7 @@ MPSEQ getr1817(char *seqName, int iph, double p, double phint, int iRec, int cal
         printf("Error in getr1817(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(r.seqName,"%s",seqName);
+   OSPRINTF( r.seqName, sizeof(r.seqName), "%s", seqName);
    r.calc = calc;
    r.array = parsearry(r.array); 
 
@@ -4321,12 +4321,12 @@ MPSEQ getr1817(char *seqName, int iph, double p, double phint, int iRec, int cal
 
    char lpattern[NPATTERN];
    var = getname0("",r.seqName,"");
-   sprintf(lpattern,"%s%d",var,r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, r.nRec);
    r.hasArray = hasarry(r.array, lpattern);
    int lix = arryindex(r.array);
    if (r.calc > 0) {
       var = getname0("",r.seqName,"");
-      sprintf(r.pattern,"%s%d_%d",var,r.nRec,lix);
+      OSPRINTF( r.pattern, sizeof(r.pattern), "%s%d_%d", var, r.nRec, lix);
       if (r.hasArray == 1) {
          r = MPchopper(r); 
          r.iSuper = iph + r.nelem%r.nphSuper;
@@ -4349,7 +4349,7 @@ MPSEQ gettmrev5(char *seqName, int iph, double p, double phint, int iRec, int ca
         printf("Error in gettmrev(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(tm.seqName,"%s",seqName);
+   OSPRINTF( tm.seqName, sizeof(tm.seqName), "%s", seqName);
    tm.calc = calc;
    tm.array = parsearry(tm.array); 
 
@@ -4465,12 +4465,12 @@ MPSEQ gettmrev5(char *seqName, int iph, double p, double phint, int iRec, int ca
 
    char lpattern[NPATTERN];
    var = getname0("",tm.seqName,"");
-   sprintf(lpattern,"%s%d",var,tm.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, tm.nRec);
    tm.hasArray = hasarry(tm.array, lpattern);
    int lix = arryindex(tm.array);
    if (tm.calc > 0) {
       var = getname0("",tm.seqName,"");
-      sprintf(tm.pattern,"%s%d_%d",var,tm.nRec,lix);
+      OSPRINTF( tm.pattern, sizeof(tm.pattern), "%s%d_%d", var, tm.nRec, lix);
       if (tm.hasArray == 1) {
          tm = MPchopper(tm); 
          tm.iSuper = iph + tm.nelem%tm.nphSuper;
@@ -4493,7 +4493,7 @@ MPSEQ getpxy(char *seqName, int iph, double p, double phint, int iRec, int calc)
         printf("Error in getpxy(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(pxy.seqName,"%s",seqName);
+   OSPRINTF( pxy.seqName, sizeof(pxy.seqName), "%s", seqName);
    pxy.calc = calc;
    pxy.array = parsearry(pxy.array);
 
@@ -4581,12 +4581,12 @@ MPSEQ getpxy(char *seqName, int iph, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",pxy.seqName,"");
-   sprintf(lpattern,"%s%d",var,pxy.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pxy. nRec);
    pxy.hasArray = hasarry(pxy.array, lpattern);
    int lix = arryindex(pxy.array);
    if (pxy.calc > 0) {
       var = getname0("",pxy.seqName,"");
-      sprintf(pxy.pattern,"%s%d_%d",var,pxy.nRec,lix);
+      OSPRINTF( pxy.pattern, sizeof(pxy.pattern), "%s%d_%d", var, pxy.nRec, lix);
       if (pxy.hasArray == 1) {
          pxy = MPchopper(pxy);
          pxy.iSuper = iph + pxy.nelem%pxy.nphSuper;
@@ -4611,7 +4611,7 @@ MPSEQ getsamn(char *seqName, int iph, double p, double phint, int iRec, int calc
       printf("Error in getsamn(). The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(pm.seqName,"%s",seqName);
+   OSPRINTF( pm.seqName, sizeof(pm.seqName), "%s", seqName);
    pm.calc = calc;
    pm.array = parsearry(pm.array);
 
@@ -4715,12 +4715,12 @@ MPSEQ getsamn(char *seqName, int iph, double p, double phint, int iRec, int calc
 
    char lpattern[NPATTERN];
    var = getname0("",pm.seqName,"");
-   sprintf(lpattern,"%s%d",var,pm.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pm.nRec);
    pm.hasArray = hasarry(pm.array, lpattern);
    int lix = arryindex(pm.array);
    if (pm.calc > 0) {
       var = getname0("",pm.seqName,"");
-      sprintf(pm.pattern,"%s%d_%d",var,pm.nRec,lix);
+      OSPRINTF( pm.pattern, sizeof(pm.pattern), "%s%d_%d", var, pm.nRec, lix);
       if (pm.hasArray == 1) {
          pm = MPchopper(pm);
          pm.iSuper = iph + pm.nelem%pm.nphSuper;
@@ -4741,7 +4741,7 @@ MPSEQ getpmlgxmx(char *seqName, int iph ,double p, double phint, int iRec, int c
       printf("Error in getpmlgxmx(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(pm.seqName,"%s",seqName);
+   OSPRINTF( pm.seqName, sizeof(pm.seqName), "%s", seqName);
    pm.calc = calc;
    pm.array = parsearry(pm.array);
 
@@ -4859,12 +4859,12 @@ MPSEQ getpmlgxmx(char *seqName, int iph ,double p, double phint, int iRec, int c
 
    char lpattern[NPATTERN];
    var = getname0("",pm.seqName,"");
-   sprintf(lpattern,"%s%d",var,pm.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pm.nRec);
    pm.hasArray = hasarry(pm.array, lpattern);
    int lix = arryindex(pm.array);
    if (pm.calc > 0) {
       var = getname0("",pm.seqName,"");
-      sprintf(pm.pattern,"%s%d_%d",var,pm.nRec,lix);
+      OSPRINTF( pm.pattern, sizeof(pm.pattern), "%s%d_%d", var, pm.nRec, lix);
       if (pm.hasArray == 1) {
          pm = MPchopper(pm); 
          pm.iSuper = iph + pm.nelem%pm.nphSuper;
@@ -4888,7 +4888,7 @@ MPSEQ getsuper(char *seqName, int iph, double p, double phint, int iRec, int cal
         printf("Error in getsuper(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(super.seqName,"%s",seqName);
+   OSPRINTF( super.seqName, sizeof(super.seqName), "%s", seqName);
    super.calc = calc;
    super.array = parsearry(super.array);
 
@@ -5062,12 +5062,12 @@ MPSEQ getsuper(char *seqName, int iph, double p, double phint, int iRec, int cal
 
    char lpattern[NPATTERN];
    var = getname0("",super.seqName,"");
-   sprintf(lpattern,"%s%d",var,super.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, super.nRec);
    super.hasArray = hasarry(super.array, lpattern);
    int lix = arryindex(super.array);
    if (super.calc > 0) {
       var = getname0("",super.seqName,"");
-      sprintf(super.pattern,"%s%d_%d",var,super.nRec,lix);
+      OSPRINTF( super.pattern, sizeof(super.pattern), "%s%d_%d", var, super.nRec, lix);
       if (super.hasArray == 1) {
          super = MPchopper(super); 
          super.iSuper = iph + super.nelem%super.nphSuper;
@@ -5091,7 +5091,7 @@ MPSEQ getdumboxmx(char *seqName, int iph, double p, double phint, int iRec, int 
       printf("Error in getdumbo(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(pm.seqName,"%s",seqName);
+   OSPRINTF( pm.seqName, sizeof(pm.seqName), "%s", seqName);
    pm.calc = calc;
    pm.array = parsearry(pm.array);
 
@@ -5206,12 +5206,12 @@ MPSEQ getdumboxmx(char *seqName, int iph, double p, double phint, int iRec, int 
 
    char lpattern[NPATTERN];
    var = getname0("",pm.seqName,"");
-   sprintf(lpattern,"%s%d",var,pm.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, pm.nRec);
    pm.hasArray = hasarry(pm.array, lpattern);
    int lix = arryindex(pm.array);
    if (pm.calc > 0) {
       var = getname0("",pm.seqName,"");
-      sprintf(pm.pattern,"%s%d_%d",var,pm.nRec,lix);
+      OSPRINTF( pm.pattern, sizeof(pm.pattern), "%s%d_%d", var, pm.nRec, lix);
       if (pm.hasArray == 1) {
          pm = MPchopper(pm);
          pm.iSuper = iph + pm.nelem%pm.nphSuper;
@@ -5242,7 +5242,7 @@ MPSEQ getdumbogen(char *seqName, char *coeffName, int iph, double p, double phin
       printf("Error in getdumbogeneric(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(dumbo.seqName,"%s",seqName);
+   OSPRINTF( dumbo.seqName, sizeof(dumbo.seqName), "%s", seqName);
    
    dumbo.calc = calc;
    dumbo.array = parsearry(dumbo.array);
@@ -5411,12 +5411,12 @@ MPSEQ getdumbogen(char *seqName, char *coeffName, int iph, double p, double phin
 
    char lpattern[NPATTERN];
    var = getname0("",dumbo.seqName,"");
-   sprintf(lpattern,"%s%d",var,dumbo.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, dumbo.nRec);
    dumbo.hasArray = hasarry(dumbo.array, lpattern);
    int lix = arryindex(dumbo.array);
    if (dumbo.calc > 0) {
       var = getname0("",dumbo.seqName,"");
-      sprintf(dumbo.pattern,"%s%d_%d",var,dumbo.nRec,lix);
+      OSPRINTF( dumbo.pattern, sizeof(dumbo.pattern), "%s%d_%d", var, dumbo.nRec, lix);
       if (dumbo.hasArray == 1) {
          dumbo = MPchopper(dumbo); 
          dumbo.iSuper = iph + dumbo.nelem%dumbo.nphSuper;
@@ -5441,7 +5441,7 @@ MPSEQ getsat(char *seqName, double p, double phint, int iRec, int calc)
         printf("Error in getsat(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
-   sprintf(s.seqName,"%s",seqName);
+   OSPRINTF( s.seqName, sizeof(s.seqName), "%s", seqName);
    s.calc = calc;
    s.array = parsearry(s.array);
    extern MPSEQ MPchopper(MPSEQ s);
@@ -5543,12 +5543,12 @@ MPSEQ getsat(char *seqName, double p, double phint, int iRec, int calc)
 
    char lpattern[NPATTERN];
    var = getname0("",s.seqName,"");
-   sprintf(lpattern,"%s%d",var,s.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, s.nRec);
    s.hasArray = hasarry(s.array, lpattern);
    int lix = arryindex(s.array);
    if (s.calc > 0) {
       var = getname0("",s.seqName,"");
-      sprintf(s.pattern,"%s%d_%d",var,s.nRec,lix);
+      OSPRINTF( s.pattern, sizeof(s.pattern), "%s%d_%d", var, s.nRec, lix);
       if (s.hasArray == 1) {
          s = MPchopper(s);
       }
@@ -5573,7 +5573,7 @@ MPSEQ getpostc6(char *seqName, int iph, double p, double phint, int iRec, int ca
         psg_abort(1);
    }
 
-   sprintf(c6.seqName,"%s",seqName);
+   OSPRINTF( c6.seqName, sizeof(c6.seqName), "%s", seqName);
    c6.calc = calc;
    c6.array = parsearry(c6.array);
 
@@ -5653,12 +5653,12 @@ MPSEQ getpostc6(char *seqName, int iph, double p, double phint, int iRec, int ca
 
    char lpattern[NPATTERN];
    var = getname0("",c6.seqName,"");
-   sprintf(lpattern,"%s%d",var,c6.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, c6.nRec);
    c6.hasArray = hasarry(c6.array, lpattern);
    int lix = arryindex(c6.array);
    if (c6.calc > 0) {
       var = getname0("",c6.seqName,"");
-      sprintf(c6.pattern,"%s%d_%d",var,c6.nRec,lix);
+      OSPRINTF( c6.pattern, sizeof(c6.pattern), "%s%d_%d", var, c6.nRec, lix);
       if (c6.hasArray == 1) {
          c6 = MPchopper(c6); 
          c6.iSuper = iph + c6.nelem%c6.nphSuper;

--- a/src/nvpsg/solidobjects.h
+++ b/src/nvpsg/solidobjects.h
@@ -493,7 +493,7 @@ WMPA getbr24(char *seqName)
       printf("getbr24() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -578,7 +578,7 @@ WMPA getmrev8(char *seqName)
       printf("getmrev8() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -663,7 +663,7 @@ WMPA getswwhh4(char *seqName)
       printf("getswwhh4() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -749,7 +749,7 @@ WMPA getxx(char *seqName)
       psg_abort(1);
    }
 
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -834,7 +834,7 @@ WMPA getxmx(char *seqName)
       psg_abort(1);
    }
 
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -918,7 +918,7 @@ WMPA gettoss4(char *seqName)
       printf("gettoss4() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // INOVA ap bus delay
 
@@ -970,7 +970,7 @@ WMPA gettoss5(char *seqName)
       printf("gettoss5() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -1034,7 +1034,7 @@ WMPA getidref(char *seqName)
       printf("getidref() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -1078,7 +1078,7 @@ WMPA getwpmlg(char *seqName)
       printf("getwpmlg() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -1205,7 +1205,7 @@ GP getinept(char *seqName)
       printf("getinept() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(in.seqName,"%s",seqName);
+   OSTRCPY( in.seqName, sizeof(in.seqName), seqName);
 
 // ch1YXsuffix
 
@@ -1280,7 +1280,7 @@ WMPA getwdumbo(char *seqName)
       printf("getwdumbo() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -1412,7 +1412,7 @@ WMPA getwdumbot(char *seqName)
       printf("getwdumbot() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -1552,7 +1552,7 @@ WMPA getcpmg(char *seqName)
       psg_abort(1);
    }
 
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXcpmg
 
@@ -1638,7 +1638,7 @@ GP gethmqc(char *seqName)
       printf("gethmqc() Error: The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(hmqc.seqName,"%s",seqName);
+   OSTRCPY( hmqc.seqName, sizeof(hmqc.seqName), seqName);
 
 // ch1YXhmqc
 
@@ -1695,7 +1695,7 @@ WMPA gethssmall(char *seqName)
       printf("gethssmall() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXhssmall
 
@@ -1800,7 +1800,7 @@ WMPA getxmxwpmlg(char *seqName)
       printf("getwpmlg() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -1937,7 +1937,7 @@ WMPA getwsamn(char *seqName)
       printf("getwsamn() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -2064,7 +2064,7 @@ WMPA getwpmlgxmx(char *seqName)
       printf("getwpmlgxmx() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -2197,7 +2197,7 @@ WMPA getwdumboxmx(char *seqName)
       printf("getwdumboxmx() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -2338,7 +2338,7 @@ WMPA getwdumbogen(char *seqName, char *coeffName)
       printf("getwdumbogen() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.seqName,"%s",seqName);
+   OSTRCPY( mp.seqName, sizeof(mp.seqName), seqName);
 
 // chXsuffix
 
@@ -3078,11 +3078,14 @@ void _idref(WMPA mp, DSEQ d, int phase)
    }
 
    char ch2[NCH];
+
+   ch2[0] = (char) 0;  // BDZ: initialize to empty string!
+
    if (!strcmp(d.seq,"tppm")) {
-      sprintf(ch2,"%s",d.t.ch);
+      OSTRCPY( ch2, sizeof(ch2), d.t.ch);
    }
    if (!strcmp(d.seq,"spinal")) {
-      sprintf(ch2,"%s",d.s.ch);
+      OSTRCPY( ch2, sizeof(ch2), d.s.ch);
    }
 
    int chnl2 = 0;

--- a/src/nvpsg/solidpulses.h
+++ b/src/nvpsg/solidpulses.h
@@ -32,7 +32,7 @@ SHAPE getpulse(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(s.pars.seqName,"%s",seqName);
+   OSTRCPY( s.pars.seqName, sizeof(s.pars.seqName), seqName);
    s.pars.calc = calc;
    s.pars.array = parsearry(s.pars.array);
 
@@ -83,7 +83,7 @@ SHAPE getdfspulse(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getdfspulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(s.pars.seqName,"%s",seqName);
+   OSTRCPY( s.pars.seqName, sizeof(s.pars.seqName), seqName);
    s.pars.calc = calc;
    s.pars.array = parsearry(s.pars.array);
 
@@ -151,7 +151,7 @@ SHAPE getsfspulse(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getsfspulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(s.pars.seqName,"%s",seqName);
+   OSTRCPY( s.pars.seqName, sizeof(s.pars.seqName), seqName);
    s.pars.calc = calc;
    s.pars.array = parsearry(s.pars.array);
 
@@ -219,7 +219,7 @@ SHAPE getsfmpulse(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getsfmpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(s.pars.seqName,"%s",seqName);
+   OSTRCPY( s.pars.seqName, sizeof(s.pars.seqName), seqName);
    s.pars.calc = calc;
    s.pars.array = parsearry(s.pars.array);
 
@@ -273,7 +273,7 @@ SHAPE getsinc(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getsinc(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(s.pars.seqName,"%s",seqName);
+   OSTRCPY( s.pars.seqName, sizeof(s.pars.seqName), seqName);
    s.pars.calc = calc;
    s.pars.array = parsearry(s.pars.array);
 
@@ -335,7 +335,7 @@ SHAPE gettanramp(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getsfmpulse(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(s.pars.seqName,"%s",seqName);
+   OSTRCPY( s.pars.seqName, sizeof(s.pars.seqName), seqName);
    s.pars.calc = calc;
    s.pars.array = parsearry(s.pars.array);
 
@@ -407,7 +407,7 @@ SHAPE getcpm(char *seqName, double p, double phint, int iRec, int calc)
       printf("Error in getcpm(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(s.pars.seqName,"%s",seqName);
+   OSTRCPY( s.pars.seqName, sizeof(s.pars.seqName), seqName);
    s.pars.calc = calc;
    s.pars.array = parsearry(s.pars.array);
 
@@ -468,7 +468,7 @@ SHAPE getdumbogenshp(char *seqName, char *coeffName, double p, double phint, int
       printf("Error in getdumbogenshp(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
-   sprintf(s.pars.seqName,"%s",seqName);
+   OSTRCPY( s.pars.seqName, sizeof(s.pars.seqName), seqName);
    s.pars.calc = calc;
    s.pars.array = parsearry(s.pars.array);
 

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -434,7 +434,7 @@ CP make_cp(CP cp)
    double at;
    double t;
    double ph,dph,aLast,aCurrent;
-   sprintf(shapepath,"%s/shapelib/%s.DEC",userdir,cp.pattern);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s/shapelib/%s.DEC", userdir, cp.pattern);
 
 // Set the waveform on the designated channel
    chnl = 0;
@@ -474,7 +474,7 @@ CP make_cp(CP cp)
 
    char lpattern[NPATTERN];
    int lix = arryindex(cp.array);
-   sprintf(lpattern,"%s%d",getname0("",cp.seqName,""),cp.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", getname0("",cp.seqName,""), cp.nRec);
    savet(cp.t, lix, lpattern); //Save the total duration to the MODULE structure. 
 
    if((fp = fopen(shapepath,"w"))==NULL) {
@@ -1214,8 +1214,8 @@ MPSEQ MPchopper(MPSEQ seq)
 
 // Open the output file
 
-   sprintf(str,"%s/shapelib/",userdir);
-   sprintf(shapepath,"%s%s.DEC",str,seq.pattern);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/", userdir);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s%s.DEC", str, seq.pattern);
    if ( (fp = fopen(shapepath,"w")) == NULL) {
       printf("Error in open of %s \n",shapepath);
       psg_abort(1);
@@ -1240,7 +1240,7 @@ MPSEQ MPchopper(MPSEQ seq)
    seq.t = seq.telem*seq.nelem;
 
    char lpattern[NPATTERN];
-   sprintf(lpattern,"%s%d",getname0("",seq.seqName,""),seq.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", getname0("",seq.seqName,""), seq.nRec);
    int lix = arryindex(seq.array);
    savet(seq.t, lix, lpattern);  //Save the total duration to the MODULE structure.
    npuls = seq.nphBase*seq.nelem;
@@ -1380,8 +1380,8 @@ RAMP make_ramp(RAMP r)
    double ph,dph,aLast,aCurrent=0.0,phase;
    enum polarity {NORMAL, UP_UP, DOWN_DOWN, DOWN_UP, UP_DOWN};
    enum polarity POL = NORMAL;
-   sprintf(str,"%s/shapelib/",userdir);
-   sprintf(shapepath,"%s%s.DEC",str,r.pattern);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/", userdir);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s%s.DEC", str, r.pattern);
    if ((fp = fopen(shapepath,"w")) == NULL) {
       printf("Error in open of %s \n",shapepath);
       psg_abort(1);
@@ -1427,7 +1427,7 @@ RAMP make_ramp(RAMP r)
 
    char lpattern[NPATTERN];
    int lix = arryindex(r.array);
-   sprintf(lpattern,"%s%d",getname0("",r.seqName,""),r.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", getname0("",r.seqName,""), r.nRec);
    savet(r.t, lix, lpattern); //Save the total duration to a MODULE structure. 
 
    ph = r.phAccum;
@@ -1593,11 +1593,11 @@ RAMP update_ramp(RAMP seq, double p, double phint, int iRec)
 
    char lpattern[NPATTERN];
    var = getname0("",seq.seqName,"");
-   sprintf(lpattern,"%s%d",var,seq.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, seq.nRec);
    seq.hasArray = hasarry(seq.array, lpattern);
    int lix = arryindex(seq.array);
    var = getname0("",seq.seqName,"");
-   sprintf(seq.pattern,"%s%d_%d",var,seq.nRec,lix);
+   OSPRINTF( seq.pattern, sizeof(seq.pattern), "%s%d_%d", var, seq.nRec, lix);
    if (seq.hasArray == 1) {
       seq = make_ramp(seq);
    }
@@ -1621,11 +1621,11 @@ SHAPE update_shape(SHAPE seq, double p, double phint, int iRec)
 
    char lpattern[NPATTERN];
    var = getname0("",seq.pars.seqName,"");
-   sprintf(lpattern,"%s%d",var,seq.pars.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, seq.pars.nRec);
    seq.pars.hasArray = hasarry(seq.pars.array, lpattern);
    int lix = arryindex(seq.pars.array);
    var = getname0("",seq.pars.seqName,"");
-   sprintf(seq.pars.pattern,"%s%d_%d",var,seq.pars.nRec,lix);
+   OSPRINTF( seq.pars.pattern, sizeof(seq.pars.pattern), "%s%d_%d", var, seq.pars.nRec, lix);
    if (seq.pars.hasArray == 1) {
       seq = make_shape(seq);
    }  
@@ -1649,11 +1649,11 @@ CP update_cp(CP seq, double p, double phint, int iRec)
 
    char lpattern[NPATTERN];
    var = getname0("",seq.seqName,"");
-   sprintf(lpattern,"%s%d",var,seq.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, seq.nRec);
    seq.hasArray = hasarry(seq.array, lpattern);
    int lix = arryindex(seq.array);
    var = getname0("",seq.seqName,"");
-   sprintf(seq.pattern,"%s%d_%d",var,seq.nRec,lix);
+   OSPRINTF( seq.pattern, sizeof(seq.pattern), "%s%d_%d", var, seq.nRec, lix);
    if (seq.hasArray == 1) {
       seq = make_cp(seq);
    }  
@@ -1678,11 +1678,11 @@ MPSEQ update_mpseq(MPSEQ seq, int iph, double p, double phint, int iRec)
 
    char lpattern[NPATTERN];
    var = getname0("",seq.seqName,"");
-   sprintf(lpattern,"%s%d",var,seq.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, seq.nRec);
    seq.hasArray = hasarry(seq.array, lpattern);
    int lix = arryindex(seq.array);
    var = getname0("",seq.seqName,"");
-   sprintf(seq.pattern,"%s%d_%d",var,seq.nRec,lix);
+   OSPRINTF( seq.pattern, sizeof(seq.pattern), "%s%d_%d", var, seq.nRec, lix);
    if (seq.hasArray == 1) {
       seq = MPchopper(seq);
       seq.iSuper = iph + seq.nelem%seq.nphSuper;
@@ -1711,8 +1711,8 @@ SHAPE make_shape(SHAPE s)
 
 // Open the output file
 
-   sprintf(str,"%s/shapelib/",userdir);
-   sprintf(shapepath,"%s%s.DEC",str,s.pars.pattern);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/", userdir);
+   OSPRINTF( shapepath, sizeof(shapepath), "%s%s.DEC", str, s.pars.pattern);
    if ((fp = fopen(shapepath,"w")) == NULL) {
       printf("Error in open of %s \n",shapepath);
       psg_abort(1);
@@ -1725,7 +1725,7 @@ SHAPE make_shape(SHAPE s)
 
    char lpattern[NPATTERN];
    int lix = arryindex(s.pars.array);
-   sprintf(lpattern,"%s%d",getname0("",s.pars.seqName,""),s.pars.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d",getname0("",s.pars.seqName,""), s.pars.nRec);
    savet(s.pars.t, lix, lpattern); //  Save the total duration to the MODULE structure
 
 // Initialize the phase, the time and the ticks
@@ -1841,7 +1841,7 @@ SHAPE genericInitShape(SHAPE s, char *name, double p, double phint, int iRec)
       printf("Error in genericInitShape! The  name %s is invalid !\n",name);
       psg_abort(-1);
    }
-   sprintf(s.pars.seqName,"%s",name);
+   OSPRINTF( s.pars.seqName, sizeof(s.pars.seqName), "%s", name);
 
 // Obtain Phase Arguments
 
@@ -1880,12 +1880,12 @@ SHAPE genericInitShape(SHAPE s, char *name, double p, double phint, int iRec)
 
    char lpattern[NPATTERN];
    var = getname0("",s.pars.seqName,"");
-   sprintf(lpattern,"%s%d",var,s.pars.nRec);
+   OSPRINTF( lpattern, sizeof(lpattern), "%s%d", var, s.pars.nRec);
    s.pars.hasArray = hasarry(s.pars.array, lpattern);
    int lix = arryindex(s.pars.array);
    var = getname0("",s.pars.seqName,"");
    if (s.pars.calc > 0) {
-      sprintf(s.pars.pattern,"%s%d_%d",var,s.pars.nRec,lix);
+      OSPRINTF( s.pars.pattern, sizeof(s.pars.pattern), "%s%d_%d", var, s.pars.nRec, lix);
       if (s.pars.hasArray == 1) {
          s = make_shape(s);
       }
@@ -3435,7 +3435,7 @@ void adj_initcp_(CP a, double *b)
    char str[MAXSTR];
    FILE *fp;
    extern char userdir[];
-   sprintf(str,"%s/shapelib/PRESET.DEC",userdir);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/PRESET.DEC", userdir);
 
    if((fp = fopen(str,"w"))==NULL) {
       printf("Error in adj_initcp(): can not create file PRESET.DEC!\n");
@@ -3509,7 +3509,7 @@ void adj_initmpseq(MPSEQ a, double *b)
    char str[MAXSTR];
    FILE *fp;
    extern char userdir[];
-   sprintf(str,"%s/shapelib/PRESET.DEC",userdir);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/PRESET.DEC", userdir);
 
    if((fp = fopen(str,"w"))==NULL) {
       printf("Error in adj_initcp(): can not create file PRESET.DEC!\n");
@@ -3564,7 +3564,7 @@ void adj_initramp(RAMP a, double *b)
    char str[MAXSTR];
    FILE *fp;
    extern char userdir[];
-   sprintf(str,"%s/shapelib/PRESET.DEC",userdir);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/PRESET.DEC", userdir);
 
    if((fp = fopen(str,"w"))==NULL) {
       printf("Error in adj_initcp(): can not create file PRESET.DEC!\n");
@@ -3630,7 +3630,7 @@ void adj_initshape(SHAPE a, double *b)
    char str[MAXSTR];
    FILE *fp;
    extern char userdir[];
-   sprintf(str,"%s/shapelib/PRESET.DEC",userdir);
+   OSPRINTF( str, sizeof(str), "%s/shapelib/PRESET.DEC", userdir);
 
    if((fp = fopen(str,"w"))==NULL) {
       printf("Error in adj_initcp(): can not create file PRESET.DEC!\n");

--- a/src/nvpsg/solidstandard.h
+++ b/src/nvpsg/solidstandard.h
@@ -12,6 +12,7 @@
 #include <standard.h>
 #include <Pbox_psg.h> 
 #include "soliddefs.h"      //Structures and Definitions of Constant
+#include "safestring.h"
 #include "solidelements.h"  //Miscellaneous Programs Including getname()
 #ifdef NVPSG
 #include "solidchoppers.h"  // Replacement choppers use userDECShape
@@ -27,5 +28,3 @@
 #include "solidhhdec.h"     //Functions to support Ames contribution.
 
 #endif
-
-

--- a/src/nvpsg/solidstates.h
+++ b/src/nvpsg/solidstates.h
@@ -141,11 +141,11 @@ STATE tanramp_state(double t, SHAPE_PARS p)
    enum polarity POL = NORMAL;
    STATE s;
 
-   if(strcmp(p.flag2,"n") == 0 ) POL = NORMAL;
-   if(strcmp(p.flag2,"uu") == 0 )POL = UP_UP;
-   if(strcmp(p.flag2,"dd") == 0 )POL = DOWN_DOWN;
-   if(strcmp(p.flag2,"du") == 0 ) POL = DOWN_UP;
-   if(strcmp(p.flag2,"ud") == 0 )POL = UP_DOWN;
+   if ( strcmp(p.flag2,"n" ) == 0 ) POL = NORMAL;
+   if ( strcmp(p.flag2,"uu") == 0 ) POL = UP_UP;
+   if ( strcmp(p.flag2,"dd") == 0 ) POL = DOWN_DOWN;
+   if ( strcmp(p.flag2,"du") == 0 ) POL = DOWN_UP;
+   if ( strcmp(p.flag2,"ud") == 0 ) POL = UP_DOWN;
 
    mean = p.a;
    norm = 1023.0/(mean + fabs(p.dp[0]));
@@ -232,4 +232,3 @@ STATE dumbo_state(double t, SHAPE_PARS p)
 }
 
 #endif
-

--- a/src/nvpsg/solidwshapes.h
+++ b/src/nvpsg/solidwshapes.h
@@ -385,7 +385,7 @@ WMPSEQ getwpmlgxmx1(char *seqName)
       printf("getwpmlg() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.wvsh.mpseq.seqName,"%s",seqName);
+   OSTRCPY( mp.wvsh.mpseq.seqName, sizeof(mp.wvsh.mpseq.seqName), seqName);
 
 // chXsuffix
 
@@ -508,7 +508,7 @@ WMPSEQ getwsamn1(char *seqName)
       printf("getwsamn() Error: The type name %s is invalid !\n",seqName);
       psg_abort(1);
    }
-   sprintf(mp.wvsh.mpseq.seqName,"%s",seqName);
+   OSTRCPY( mp.wvsh.mpseq.seqName, sizeof(mp.wvsh.mpseq.seqName), seqName);
 
 // chXsuffix
 


### PR DESCRIPTION
Dan, this is all the safe string code I was using in src/nvpsg while testing various OVJ bugs. It is a big commit and I hope you'll accept it. You'll see that it is almost entirely changing strcat/strcpy/sprintf calls to OSTRCAT/OSTRCPY/OSPRINTF calls with an additional destination size parameter.

It is not entirely done. I added safestring.h and safestring.c to the nvpsg directory. But I did not know how to tweak the build system to compile safestring.c and link it into libpsglib.*. I tried messing with builds but could not figure it out. I would ask that you help complete this branch.

I do know that all the code that references safestring.h compiles. And I have tested the code by putting the safestring.c code into math.c so that it got linked in and I could run OVJ and pulse sequences in various ways with no complaints.

As for the correctness of safestring.* I shared a test.c program with you recently that can be used to verify things are ok. This safestring.c uses printf()'s while my test.c  test code wants the safe code to use text_error()'s so safestring.c needs to change minorly to be easily testable by the test.c file.