### PR TITLE
Fix waveform generation code to avoid controller board timing issues

### DIFF
--- a/src/nvpsg/solidchoppers.h
+++ b/src/nvpsg/solidchoppers.h
@@ -19,6 +19,8 @@
 //                      with STATE's.   
 // genericInitShape1() - SHAPE  Special version used with make_shape1.
 
+#define SAFE_MAX_FOR_TICKS 5
+
 //=======================================
 // Redeclare userDECShape
 //=======================================
@@ -218,7 +220,7 @@ SHAPE make_shape(SHAPE s)
             if (((nstep >= s.pars.n90m) && ((fabs(aCurrent - aLast) >= DWFM) || 
                                        (fabs(phCurrent - phLast) >= DPH) ||
                                        (fabs(gCurrent - gLast) > 0.0))) ||
-                                       (nstep >= 255)) { 
+                                       (nstep >= SAFE_MAX_FOR_TICKS)) { 
 //             printf("aLast = %f aCurrent = %f\n",aLast,aCurrent);
                a0Out = roundamp(aLast,1.0/WSD);
                aOut =  roundamp((aCurrent + aLast)/2.0,1.0/WSD);  
@@ -464,7 +466,7 @@ SHAPE make_shape1(SHAPE s)
             if (((nstep >= s.pars.n90m) && ((fabs(aCurrent - aLast) >= DWFM) || 
                                        (fabs(phCurrent - phLast) >= DPH) ||
                                        (fabs(gCurrent - gLast) > 0.0))) ||
-                                       (nstep >= 255)) { 
+                                       (nstep >= SAFE_MAX_FOR_TICKS)) { 
 //             printf("aLast = %f aCurrent = %f\n",aLast,aCurrent);
                a0Out = roundamp(aLast,1.0/WSD);
                aOut =  roundamp((aCurrent + aLast)/2.0,1.0/WSD);  
@@ -874,7 +876,7 @@ MPSEQ MPchopper(MPSEQ seq)
                   nstep = 0;
                }
                if (((nstep >= seq.n90m) && (fabs(phCurrent - phLast) >= DPH)) ||
-                                           (nstep >= 255)) {
+                                           (nstep >= SAFE_MAX_FOR_TICKS)) {
 //                printf("nstep = %d n90m = %d\n",nstep,seq.n90m);
 //                printf("phLast = %f phCurrent = %f\n",phLast,phCurrent);
                   ph0Out = roundphase(phLast,360.0/(PSD*8192));
@@ -1135,7 +1137,7 @@ CP make_cp(CP cp)
             }
             if (((nstep >= cp.n90m) && ((fabs(aCurrent - aLast) >= DWFM) || 
                                       (fabs(phCurrent - phLast) >= DPH)))||
-                                      (nstep >= 255.0)) {
+                                      (nstep >= SAFE_MAX_FOR_TICKS)) {
 //             printf("aLast = %f aCurrent = %f\n",aLast,aCurrent);
                a0Out = roundamp(aLast,1.0/WSD);
                aOut =  roundamp((aCurrent + aLast)/2.0,1.0/WSD);  

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -536,7 +536,7 @@ CP make_cp(CP cp)
              naccumpuls = 0;
              break;
          }
-         if (fabs(cp.phInt) >= DPH || fabs(aCurrent - aLast) >= 1.0 || naccumpuls >= SAFE_MAX_FOR_TICKS) {
+         if (fabs(cp.phInt) >= DPH || fabs(aCurrent - aLast) >= 1.0 || (naccumpuls / nmin) >= SAFE_MAX_FOR_TICKS) {
              ph = ph + cp.phInt;
              cp.phInt = 0.0;
              aLast = aCurrent;
@@ -1336,8 +1336,8 @@ MPSEQ MPchopper(MPSEQ seq)
                naccumpuls = 0;
                break;
             }
-            if (fabs(seq.phInt) >= DPH || naccumpuls >= SAFE_MAX_FOR_TICKS) { //Write a step if delta-ph > DPH, else
-               ph =  ph + seq.phInt;      //accumulate the running phase
+            if (fabs(seq.phInt) >= DPH || (naccumpuls / nmin) >= SAFE_MAX_FOR_TICKS) { //Write a step if delta-ph > DPH, else
+               ph =  ph + seq.phInt;                                                   //accumulate the running phase
                seq.phInt = 0;
                phase = roundphase(ph+seq.phBase[i%seq.nph]+seq.phSuper[iph],360.0/8192);
                if (printmode == 1)
@@ -1542,7 +1542,7 @@ RAMP make_ramp(RAMP r)
                r.phInt += r.n90*dph;
                naccumpuls = 0;
             }
-            if (fabs(r.phInt) >= DPH || fabs(aCurrent - aLast) >= 1.0 || naccumpuls >= SAFE_MAX_FOR_TICKS) {
+            if (fabs(r.phInt) >= DPH || fabs(aCurrent - aLast) >= 1.0 || (naccumpuls / r.n90) >= SAFE_MAX_FOR_TICKS) {
                ph = ph + r.phInt;
                r.phInt = 0.0;
                aLast = aCurrent;
@@ -1813,8 +1813,8 @@ SHAPE make_shape(SHAPE s)
          if (fabs(s.pars.phInt) >= DPH ||
             fabs(aCurrent - aLast) >= 1.0 ||
             fabs(phShapeCurrent - phShapeLast) >= DPH ||
-    	    naccumpuls >= SAFE_MAX_FOR_TICKS) //Write a new step if different or delta-ph > DPH, else
-	 {                                    //or delta-ph > DPH, else set the running phase.
+    	    (naccumpuls / s.pars.n90) >= SAFE_MAX_FOR_TICKS) //Write a new step if different or delta-ph > DPH, else
+	 {                                                   //or delta-ph > DPH, else set the running phase.
             ph = ph + s.pars.phInt;
             s.pars.phInt = 0.0;
             aLast = aCurrent;

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -9,6 +9,8 @@
 #ifndef SOLIDSHAPEGEN_H
 #define SOLIDSHAPEGEN_H
 
+#define SAFE_MAX_FOR_TICKS 5
+
 //###################  Please Note ################################
 // The choppers, make_shape, MPchopper and make_cp have been moved
 // to the new file solidchoppers.h. The above functions in this file
@@ -534,7 +536,7 @@ CP make_cp(CP cp)
              naccumpuls = 0;
              break;
          }
-         if (fabs(cp.phInt) >= DPH || fabs(aCurrent - aLast) >= 1.0) {
+         if (fabs(cp.phInt) >= DPH || fabs(aCurrent - aLast) >= 1.0 || naccumpuls >= SAFE_MAX_FOR_TICKS) {
              ph = ph + cp.phInt;
              cp.phInt = 0.0;
              aLast = aCurrent;
@@ -1334,7 +1336,7 @@ MPSEQ MPchopper(MPSEQ seq)
                naccumpuls = 0;
                break;
             }
-            if (fabs(seq.phInt) >= DPH) { //Write a step if delta-ph > DPH, else
+            if (fabs(seq.phInt) >= DPH || naccumpuls >= SAFE_MAX_FOR_TICKS) { //Write a step if delta-ph > DPH, else
                ph =  ph + seq.phInt;      //accumulate the running phase
                seq.phInt = 0;
                phase = roundphase(ph+seq.phBase[i%seq.nph]+seq.phSuper[iph],360.0/8192);
@@ -1540,7 +1542,7 @@ RAMP make_ramp(RAMP r)
                r.phInt += r.n90*dph;
                naccumpuls = 0;
             }
-            if (fabs(r.phInt) >= DPH || fabs(aCurrent - aLast) >= 1.0) {
+            if (fabs(r.phInt) >= DPH || fabs(aCurrent - aLast) >= 1.0 || naccumpuls >= SAFE_MAX_FOR_TICKS) {
                ph = ph + r.phInt;
                r.phInt = 0.0;
                aLast = aCurrent;
@@ -1810,8 +1812,9 @@ SHAPE make_shape(SHAPE s)
          }
          if (fabs(s.pars.phInt) >= DPH ||
             fabs(aCurrent - aLast) >= 1.0 ||
-            fabs(phShapeCurrent - phShapeLast ) >= DPH) { //Write a new step if different or delta-ph > DPH, else
-                                                          //or delta-ph > DPH, else set the running phase.
+            fabs(phShapeCurrent - phShapeLast) >= DPH ||
+    	    naccumpuls >= SAFE_MAX_FOR_TICKS) //Write a new step if different or delta-ph > DPH, else
+	 {                                    //or delta-ph > DPH, else set the running phase.
             ph = ph + s.pars.phInt;
             s.pars.phInt = 0.0;
             aLast = aCurrent;


### PR DESCRIPTION
Dan, we are continuing to test my changes to avoid the ticks problem. With my fixes in place we have not been able to recreate the bug anymore through a total of 15,000 iterations of our test program. It used to fail 1 in 100 or 1 in 50 iterations. This is a PR with our current fix. We can wait for further testing before merging. We will be doing some of that testing over the next few weeks.

The fix is basically to change the "num accum pulses >= 255" to ">= 5" in all the places it occurs in solidchoppers.h (and similar changes to solidshapegen.h). This prevents the 1st column of the shape file from ever exceeding 450 (which I think stands for 0/90/180/270/360 biased by 90 because the 1st column is never <= that). It seems somewhere in the (hardware side?) code there is an assumption that the 1st column values are normalized to 0/360 and the routines in solidchoppers.h don't do that. Maybe we can track this issue down in the code? Perhaps there is a more elegant fix.

I found 5 to be the best value by doing a binary search on 0 to 255 and continuing until the bug went away. The values 1-5 all work. Values 6 and greater fail.

As an aside I know the 1st column is a timing but it seems like maybe somewhere it is getting treated as an angle.