### PR TITLE
Fix the accuracy of degrees2Binary() [both of them]

### DIFF
--- a/src/nvpsg/RFController.cpp
+++ b/src/nvpsg/RFController.cpp
@@ -69,8 +69,8 @@ RFController::RFController(char *name,int flags)
  , mySynthesizer(name,flags)
  , powerWatch(1.0,10.0,name)
  {
-   patternDataStore = new int[4000]; // (int *) malloc(4000*sizeof(int));
         patternDataStoreSize = 4000;
+        patternDataStore = new int[patternDataStoreSize];
         patternDataStoreUsed = 0;
 
         progDecInterLock = 0;
@@ -217,7 +217,7 @@ int RFController::degrees2Binary(double xx)
    int tmp;
    while (xx < 0.0)
       xx += 360.0;
-   tmp = (int) (fmod(xx,360.0)*65536.0/360.0 + 0.49);
+   tmp = (int) (fmod(xx,360.0)*65536.0/360.0 + 0.499999999999999999999999);
    tmp &= 0xffff;
    return(tmp);
 }
@@ -228,7 +228,7 @@ int RFController::degrees2XBinary(double xx)
    while (xx < 0.0)
       xx += 360.0;
    // 2^31 precision rt math down shifts by 15!
-   tmp = (int) (fmod(xx,360.0)*32768.0*65536.0/360.0 + 0.49);
+   tmp = (int) (fmod(xx,360.0)*32768.0*65536.0/360.0 + 0.499999999999999999999999);
    return((int) tmp);
 }
 // 4095.0 is the fine power standard


### PR DESCRIPTION
It turns out the constant 0.49 was introducing very small inaccuracies. I have upp'ed the constant to have many more places of sig figs. I wrote a pure geometric test routine to prove that this code is now much more accurate with the new constants. I made the number of decimal places larger than an IEEE float can represent. This should make it as accurate as possible.

While at it I made one initialization fix to improve some code maintainability. It is a similar fix to ones we have already made elsewhere.

I am going to paste my "perfect" method code in here for future reference.

int bestDegrees2Binary(double angle) {
    double TOT_DEGREES = 360.0;
    double BINS = 65536.0;
    double degreesPerBin = TOT_DEGREES / BINS;
    double binHalfAngle = degreesPerBin / 2.0;
    angle += binHalfAngle;
    while (angle < 0.0) angle += TOT_DEGREES;
    while (angle >= TOT_DEGREES) angle -= TOT_DEGREES;
    double fraction = angle / TOT_DEGREES;  // always less than 1
    int tmp = (int) (fraction * BINS);  // so always less than 65536
    return(tmp);
}
