### PR TITLE
Typo in rtpipe macro

### DIFF
--- a/src/common/maclib/rtpipe
+++ b/src/common/maclib/rtpipe
@@ -23,7 +23,7 @@ writeparam(curexp+'/pipe/PipePar','file','current','add')
     	setvalue('procdim',2)
     	setvalue('procdim',2,'processed')
 	readparam(curexp+'/pipe/PipePar','proccmd procplane','current')
-	readparam(curexp+'/pipe/pipePar','proccmd procplane','processed')
+	readparam(curexp+'/pipe/PipePar','proccmd procplane','processed')
     	nm2d
     	dconi
 //    endif


### PR DESCRIPTION
On line 26, pipePar should be PipePar