### PR TITLE
copyf command could fail

### DIFF
--- a/src/vnmr/shellcmds.c
+++ b/src/vnmr/shellcmds.c
@@ -2176,6 +2176,7 @@ int appendCmd(int argc, char *argv[], int retc, char *retv[])
             lineCount = 0;
             headCount = 0;
             skipCount = 0;
+            wordCount = 0;
          }
       }
       len = strlen(inLine);          /* get buf length */


### PR DESCRIPTION
If the tail option was used, the returned "word count" from the '|wc w' option was wrong.