### PR TITLE
Improve the initialization code in the Shim constructor

### DIFF
--- a/src/nvpsg/Shim.cpp
+++ b/src/nvpsg/Shim.cpp
@@ -174,6 +174,7 @@ unsigned short valid_mask[NUM_SHIMSET][4] = {
 
 Shim::Shim()
 {
+   memset(codes, 0, sizeof(codes));  // this was missing
    shimset = 1;
    init_shimnames(GLOBAL);
 }


### PR DESCRIPTION
This initialization seemed to be missing. I have not done any testing here and others may know best how to init the codes.