### PR TITLE
Define helper methods that can help us improve other code later

### DIFF
--- a/src/kpsg/psg.c
+++ b/src/kpsg/psg.c
@@ -2375,3 +2375,39 @@ void checkGradtype()
         specialGradtype = 'h';
     }
 }
+
+// Useful methods that can be adopted in many places to cut down code duplication
+
+int rfChanNum(const char* rf_ch_name, const char* comment) {
+    if      (strcmp( rf_ch_name, "obs"  ) == 0) return OBSch;
+    else if (strcmp( rf_ch_name, "dec"  ) == 0) return DECch;
+    else if (strcmp( rf_ch_name, "dec2" ) == 0) return DEC2ch;
+    else if (strcmp( rf_ch_name, "dec3" ) == 0) return DEC3ch;
+    else if (strcmp( rf_ch_name, "dec4" ) == 0) return DEC4ch;
+    else abort_message("unknown rf channel (%s): %s", rf_ch_name, comment);
+}
+
+int isObsChannel(int rf_ch_num) {
+ 
+    return rf_ch_num == OBSch;
+}
+
+int isDecChannel(int rf_ch_num) {
+ 
+    return rf_ch_num == DECch;
+}
+
+int isDec2Channel(int rf_ch_num) {
+ 
+    return rf_ch_num == DEC2ch;
+}
+
+int isDec3Channel(int rf_ch_num) {
+ 
+    return rf_ch_num == DEC3ch;
+}
+
+int isDec4Channel(int rf_ch_num) {
+ 
+    return rf_ch_num == DEC4ch;
+}

--- a/src/nvpsg/psgmain.cpp
+++ b/src/nvpsg/psgmain.cpp
@@ -2490,5 +2490,48 @@ void checkGradtype()
 
 //--------------------- methods for writing nv macros ----------------------------
 
-/* END OF FILE */
 
+// Useful methods that can be adopted in many places to cut down code duplication
+
+extern "C" int rfChanNum(const char* rf_ch_name, const char* comment);
+extern "C" int isObsChannel(int rf_ch_num);
+extern "C" int isDecChannel(int rf_ch_num);
+extern "C" int isDec2Channel(int rf_ch_num);
+extern "C" int isDec3Channel(int rf_ch_num);
+extern "C" int isDec4Channel(int rf_ch_num);
+
+int rfChanNum(const char* rf_ch_name, const char* comment) {
+    if      (strcmp( rf_ch_name, "obs"  ) == 0) return OBSch;
+    else if (strcmp( rf_ch_name, "dec"  ) == 0) return DECch;
+    else if (strcmp( rf_ch_name, "dec2" ) == 0) return DEC2ch;
+    else if (strcmp( rf_ch_name, "dec3" ) == 0) return DEC3ch;
+    else if (strcmp( rf_ch_name, "dec4" ) == 0) return DEC4ch;
+    else abort_message("unknown rf channel (%s): %s", rf_ch_name, comment);
+}
+
+int isObsChannel(int rf_ch_num) {
+ 
+    return rf_ch_num == OBSch;
+}
+
+int isDecChannel(int rf_ch_num) {
+ 
+    return rf_ch_num == DECch;
+}
+
+int isDec2Channel(int rf_ch_num) {
+ 
+    return rf_ch_num == DEC2ch;
+}
+
+int isDec3Channel(int rf_ch_num) {
+ 
+    return rf_ch_num == DEC3ch;
+}
+
+int isDec4Channel(int rf_ch_num) {
+ 
+    return rf_ch_num == DEC4ch;
+}
+
+/* END OF FILE */

--- a/src/psg/psg.c
+++ b/src/psg/psg.c
@@ -2892,3 +2892,39 @@ void checkGradtype()
 void diplexer_override(int state)
 {
 }
+
+// Useful methods that can be adopted in many places to cut down code duplication
+
+int rfChanNum(const char* rf_ch_name, const char* comment) {
+    if      (strcmp( rf_ch_name, "obs"  ) == 0) return OBSch;
+    else if (strcmp( rf_ch_name, "dec"  ) == 0) return DECch;
+    else if (strcmp( rf_ch_name, "dec2" ) == 0) return DEC2ch;
+    else if (strcmp( rf_ch_name, "dec3" ) == 0) return DEC3ch;
+    else if (strcmp( rf_ch_name, "dec4" ) == 0) return DEC4ch;
+    else abort_message("unknown rf channel (%s): %s", rf_ch_name, comment);
+}
+
+int isObsChannel(int rf_ch_num) {
+ 
+    return rf_ch_num == OBSch;
+}
+
+int isDecChannel(int rf_ch_num) {
+ 
+    return rf_ch_num == DECch;
+}
+
+int isDec2Channel(int rf_ch_num) {
+ 
+    return rf_ch_num == DEC2ch;
+}
+
+int isDec3Channel(int rf_ch_num) {
+ 
+    return rf_ch_num == DEC3ch;
+}
+
+int isDec4Channel(int rf_ch_num) {
+ 
+    return rf_ch_num == DEC4ch;
+}


### PR DESCRIPTION
The RF channel checking code has been cut and pasted everywhere and makes code very messy. I made some helpful routines that can be used elsewhere. For simplicity's sake they are defined where the global variables OBSch, DECch, DEC2ch, etc. are defined. There are indeed 3 copies this way but that could still be a huge savings of space in the long run. If we can eliminate three copies by putting them in one place then please recommend where that should be.

Note there are certain places in the existing code where it's ok to pass "obs", "dec", and "dec2" but not "dec3" etc. Those methods often confuse the problem of getting a name with the problem of using an illegal channel. These new methods allow one to test one or both depending upon the context. So it should be useful for code clarification as well.