### PR TITLE
No longer set LD_LIBRARY_PATH

### DIFF
--- a/src/common/user_templates/.vnmrenvbash
+++ b/src/common/user_templates/.vnmrenvbash
@@ -43,7 +43,6 @@ export CSIDIR=$vnmruser/csi_initdir
 # export BROWSERDIR INITDIR AIPDIR CSIDIR
 
 export DELEGATE_PATH=$vnmrsystem/user_templates/ImageMagick
-export LD_LIBRARY_PATH=$vnmrsystem/java:$vnmrsystem/lib:$PGLIB
 export XFILESEARCHPATH=$home/%T/%N%S:$vnmrsystem/%T/%N%S
 # export DELEGATE_PATH LD_LIBRARY_PATH XFILESEARCHPATH
 

--- a/src/common/user_templates/.vnmrenvsh
+++ b/src/common/user_templates/.vnmrenvsh
@@ -44,9 +44,8 @@ CSIDIR=$vnmruser/csi_initdir
 export BROWSERDIR INITDIR AIPDIR CSIDIR
 
 DELEGATE_PATH=$vnmrsystem/user_templates/ImageMagick
-LD_LIBRARY_PATH=$vnmrsystem/java:$vnmrsystem/lib:$PGLIB
 XFILESEARCHPATH=$home/%T/%N%S:$vnmrsystem/%T/%N%S
-export DELEGATE_PATH LD_LIBRARY_PATH XFILESEARCHPATH
+export DELEGATE_PATH XFILESEARCHPATH
 
 # DICOM dcmtk dictionary path
 DCMDICTPATH=$vnmrsystem/lib/dicom.dic

--- a/src/macos/vnmrj.sh
+++ b/src/macos/vnmrj.sh
@@ -109,13 +109,6 @@ else
 fi
 
 
-if [ x$LD_LIBRARY_PATH = "x" ]
-then
-    LD_LIBRARY_PATH=$vnmrsystem/java:$vnmruser/psg:$vnmrsystem/lib
-    export LD_LIBRARY_PATH
-fi
-
-
 # Set the name of the host where the Database is located.
 # Default to "localhost".
 if [ x$PGHOST = "x" ]

--- a/src/scripts/vnmrj.sh
+++ b/src/scripts/vnmrj.sh
@@ -109,13 +109,6 @@ else
 fi
 
 
-if [ x$LD_LIBRARY_PATH = "x" ]
-then
-    LD_LIBRARY_PATH=$vnmrsystem/java:$vnmruser/psg:$vnmrsystem/lib
-    export LD_LIBRARY_PATH
-fi
-
-
 # Set the name of the host where the Database is located.
 # Default to "localhost".
 if [ x$PGHOST = "x" ]


### PR DESCRIPTION
In Ubuntu 22, LD_LIBRARY_PATH takes precedence over compiling a program with rpath. This prevented pulse sequences from using locally compiled libpsglib.so. The LD_LIBRAY_PATH overrode the rport to select the local libpsglib and used the one in /vnmr/lib instead. Since OVJ programs are compiled with rpath as needed, LD_LIBRAY_PATH should no longer be required.