### PR TITLE
Allow file names with spaces for mkdir and write

### DIFF
--- a/src/vnmr/go.c
+++ b/src/vnmr/go.c
@@ -4527,12 +4527,17 @@ char    recDir[MAXPATH];
          {
             *ptr++ = '_';
             aptr++;
-	    dlen--;
+	         dlen--;
+         }
+         else if ((*aptr == ' ') && (replaceSpaceFlag == FALSE))
+         {
+            *ptr++ = *aptr++;
+	         dlen--;
          }
          else if (verify_fnameChar( *aptr )==0)
          {
             *ptr++ = *aptr++;
-	    dlen--;
+	         dlen--;
          }
          else
          {
@@ -4690,7 +4695,8 @@ char    recDir[MAXPATH];
    }
    if (replaceSpaceFlag == TRUE)
       replaceSpace(dirname);
-   if (verify_fname(dirname))
+   if (((replaceSpaceFlag == TRUE) && verify_fname(dirname)) ||
+       ((replaceSpaceFlag == FALSE) && verify_fname2(dirname)))
    {  Werrprintf( "file path '%s%s' not valid", dirname, suffix );
       ABORT;
    }

--- a/src/vnmr/shellcmds.c
+++ b/src/vnmr/shellcmds.c
@@ -1275,7 +1275,7 @@ int mk_dir(int argc, char *argv[], int retc, char *retv[])
     {
 	int	ival=0;
 
-	if (verify_fname( argv[ i ] ) != 0)
+	if (verify_fname2( argv[ i ] ) != 0)
 	{
 	    Werrprintf(
 		"%s:  cannot use '%s' as a directory name", argv[ 0 ], argv[ i ]

--- a/src/vnmr/text.c
+++ b/src/vnmr/text.c
@@ -1182,7 +1182,7 @@ int nmr_write(int argc, char *argv[], int retc, char *retv[])
     }
   if (device==TFILE || device==RESET)
         {
-            if (verify_fname( argv[ argnum ] )) {
+            if (verify_fname2( argv[ argnum ] )) {
                Werrprintf( "file path '%s' not valid", argv[ argnum ] );
                ABORT;
             }

--- a/src/vnmr/tools.c
+++ b/src/vnmr/tools.c
@@ -618,6 +618,31 @@ int verify_fname(char *fnptr )
 	return( 0 );
 }
 
+/* Same as verify_fname except it allows the space ' ' character */
+int verify_fname2(char *fnptr )
+{
+	char lchar;
+        unsigned int tchar;
+	int  iter, jter, len;
+
+	len = strlen( fnptr );
+	if (len < 0 || len > MAXPATH) return( -1 );
+
+	for (iter = 0; iter < len; iter++) {
+		tchar = *(fnptr+iter);
+		if (tchar < 32 )
+		  return( -1 );
+      if (tchar != ' ')
+      {
+		   jter = 0;
+		   while ((lchar = illegal_fchars[ jter++ ]) != '\0')
+		     if (lchar == tchar)
+		       return( -1 );
+      }
+	}
+	return( 0 );
+}
+
 /*
  * Alternative to strtok and strtok_r
  * s is string to search

--- a/src/vnmr/tools.h
+++ b/src/vnmr/tools.h
@@ -39,6 +39,7 @@ extern int     isReal(char *s);
 extern int     isFinite(char *s);
 extern void    space(FILE *f, int n);
 extern int     verify_fname(char *fnptr);
+extern int     verify_fname2(char *fnptr);
 
 extern int     isHardLink(char *lptr);
 extern int     isSymLink(char *lptr);


### PR DESCRIPTION
The 'keepspaces' argument for Svfname also was not working. Added a verify_fname2 to tools that allows the space character.