### PR TITLE
The _cp_() routine in solidshapegen.h messes with wrong decoupler

### DIFF
--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -3288,7 +3288,7 @@ void _rampon(RAMP r, codeint phase)
          }
          break;
       case 3:
-         decunblank();
+         dec2unblank();
          if (p1 == 0) {
             dec2phase(phase);
             dec2on();

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -837,8 +837,8 @@ void _cp_(CP cp, int phase1, int phase2)
       case 4:
          dec3unblank();
          if (p1 == 0) {
-            dec2phase(cphase);
-            dec2on();
+            dec3phase(cphase);
+            dec3on();
          }
          break;
       default:

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -2816,7 +2816,7 @@ void _shapeon(SHAPE s, codeint phase)
          dec2unblank();
          if (p1 == 0) {
             dec2phase(phase);
-            decon();
+            dec2on();
          }
          if ((PWRF_DELAY == 0.0) || (p2 == 0)) dec2pwrf(ampl);
 	 if (s.pars.t > 0.0) {
@@ -3318,7 +3318,7 @@ void _rampon(RAMP r, codeint phase)
          }
          if (p1 != 0) {
             dec3phase(phase);
-            decon();
+            dec3on();
          }
          break;
       default:


### PR DESCRIPTION
Inspecting _cp_() in solidshapegen.h shows that case 4 on the constant channel was accidentally messing with the phase on the wrong decoupler channel. It looks like code was cut and pasted and not edited correctly. 