### PR TITLE
Make the constant definitions and uses safer in the solids code

### DIFF
--- a/src/nvpsg/pboxpulse.h
+++ b/src/nvpsg/pboxpulse.h
@@ -80,7 +80,7 @@ void dump_pboxpulse(PBOXPULSE a)
 void dump_pboxpulse_array(PBOXPULSE a)
 {
    int i,j,m,k,l;
-   char temp[MAXSTR]; 
+   char temp[PAR_NAME_SZ]; 
    printf("PBOXPULSE WAVEFORM ARRAY INFORMATION\n"); 
    printf("pattern = %10s : Filename for Pulse\n",a.pattern); 
    printf("array.c = %10d : Number of Parameters\n", a.array.c);

--- a/src/nvpsg/soliddefs.h
+++ b/src/nvpsg/soliddefs.h
@@ -61,7 +61,8 @@
 // Common character array sizes
 //======================================
 
-#define NSUFFIX MAXSTR
+#define NSUFFIX 256
+#define PAR_NAME_SZ 256
 
 //Contents:
 
@@ -77,7 +78,7 @@
 //=======================
 
 typedef struct {
-    char a[20*MAXSTR]; // A string with the arrayed parameter names
+    char a[20*PAR_NAME_SZ]; // A string with the arrayed parameter names
     int  b[20];        // Number of characters in each name
     int  c;            // Number of parameters
     int  d;            // Number of indicies

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -3728,7 +3728,7 @@ void dump_mpseq(MPSEQ a)
 void dump_mpseq_array(MPSEQ a)
 {
    int i,j,m,k,l;
-   char temp[MAXSTR]; 
+   char temp[PAR_NAME_SZ]; 
    printf("MPSEQ WAVEFORM ARRAY INFORMATION\n"); 
    printf("pattern = %10s : Filename for Shape\n",a.pattern); 
    printf("array.c = %10d : Number of Parameters\n", a.array.c);
@@ -3792,7 +3792,7 @@ void dump_cp(CP a)
 void dump_cp_array(CP a)
 {
    int i,j,m,k,l;
-   char temp[MAXSTR]; 
+   char temp[PAR_NAME_SZ]; 
    printf("CP WAVEFORM ARRAY INFORMATION\n"); 
    printf("pattern = %10s : Filename for Shape\n",a.pattern); 
    printf("array.c = %10d : Number of Parameters\n", a.array.c);
@@ -3852,7 +3852,7 @@ void dump_ramp(RAMP a)
 void dump_ramp_array(RAMP a)
 {
    int i,j,m,k,l;
-   char temp[MAXSTR]; 
+   char temp[PAR_NAME_SZ]; 
    printf("RAMP WAVEFORM ARRAY INFORMATION\n"); 
    printf("pattern = %10s : Filename for Shape\n",a.pattern); 
    printf("array.c = %10d : Number of Parameters\n", a.array.c);
@@ -3917,7 +3917,7 @@ void dump_shape(SHAPE a)
 void dump_shape_array(SHAPE a)
 {
    int i,j,m,k,l;
-   char temp[MAXSTR]; 
+   char temp[PAR_NAME_SZ]; 
    printf("SHAPE WAVEFORM ARRAY INFORMATION\n"); 
    printf("pattern = %10s : Filename for Shape\n",a.pars.pattern); 
    printf("array.c = %10d : Number of Parameters\n", a.pars.array.c);


### PR DESCRIPTION
I ended up making sure that soliddefs.h does not rely on mercurial MAXSTR constant. I used compiler pragmas to show that MAXSTR was always 256 in the default compilation case. I added the 256 constant as PAR_NAME_SZ and removed dependence upon MAXSTR. I also did similar for NSUFFIX. The soliddefs.h file is now not open to unpredictable bugs if people messed with MAXSTR in their pulse sequences etc. All the code that accesses the AR struct of soliddefs.h now uses PAR_NAME_SZ for its local variables.

Closes issue #788 