### PR TITLE
vnmr_accounting failed in Canada

### DIFF
--- a/src/scripts/vnmr_accounting.sh
+++ b/src/scripts/vnmr_accounting.sh
@@ -25,5 +25,6 @@ then
    javabin="java"
 fi
 
+LANG=en_US.UTF8
 $javabin -jar $vnmrsystem/java/account.jar "$@"
 exit 0


### PR DESCRIPTION
The LANG env parameter controls the format of date strings. The acctLog.xml saves records based on US date format. vnmr_accounting fails in other locales since it cannot interpret the date string. The fix is to set LANG=en_US.UTF8 in the vnmr_accounting script