### PR TITLE
getfile behaved differently on MacOS

### DIFF
--- a/src/vnmrbg/dirfuncs.c
+++ b/src/vnmrbg/dirfuncs.c
@@ -381,6 +381,10 @@ int getitem(char *dirname, int index, char *filename, char *fileCmp, int recurse
    argv2[0] = dirname;
    argv2[1] = NULL;
 
+#ifdef MACOS
+   if ( dirname[strlen(dirname)-1] == '/')
+      dirname[strlen(dirname)-1] = '\0';
+#endif
    if (recurse)
    {
       len = strlen(dirname);


### PR DESCRIPTION
Running getfile(userdir,'RETURNPAR','$f','-R','lib') on Linux might return 'parlib' while on MacOS it would return '/parlib'. The fts_read function returns an fts_path with an extra '/' on MacOS.