### PR TITLE
accounting gave incorrect charges

### DIFF
--- a/src/jaccount/src/accounting/AccountJCB.java
+++ b/src/jaccount/src/accounting/AccountJCB.java
@@ -95,6 +95,8 @@ public class AccountJCB extends JComboBox{
         re = new RateEntry();
         st = new StringTokenizer(str);
         re.day = st.nextToken();
+        if (re.day.endsWith("."))
+           re.day = re.day.substring(0,3);
         re.time = st.nextToken();
         re.login = st.nextToken();
         re.loginhr = st.nextToken();


### PR DESCRIPTION
The days in the rate schedule could include periods after the day names, (eg. Mon. rather than Mon).
This caused comparisions with days of the week to fail, giving incorrect changes.