### PR TITLE
Make sure all RFController member variables have some default value

### DIFF
--- a/src/nvpsg/RFController.cpp
+++ b/src/nvpsg/RFController.cpp
@@ -69,6 +69,15 @@ RFController::RFController(char *name,int flags)
  , mySynthesizer(name,flags)
  , powerWatch(1.0,10.0,name)
  {
+    // these were missing and added by BDZ on 8-14-23
+
+    decTicks = 0;
+    baseTpwrF = 0;
+    currentOffset = 0;
+    logicalID = -1;
+
+    // done adding the missing ones
+	 
         patternDataStoreSize = 4000;
         patternDataStore = new int[patternDataStoreSize];
         patternDataStoreUsed = 0;


### PR DESCRIPTION
I have made sure that all uninitialized values in the RFController constructor are assigned some default values under the maxim that default values are better than random values.

I took some care with defining the logicalID as -1. There is not a lot of references to logical IDs in the code and the initialization in various places seems to safely assign non-default values.

Closes https://github.com/OpenVnmrJ/OpenVnmrJ/issues/761