### PR TITLE
cleanup solids cp code some more

### DIFF
--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -184,7 +184,7 @@ void obswfgHSoff()
 void decwfgHSoff()
 {
    // this one changed substantially by just matching other cases.
-   // BDZ 8-15-23
+   // BDZ 1-9-24
 
    if (DECch == 1) HSgate(CH1WG,FALSE);
    if (DECch == 2) HSgate(CH2WG,FALSE);
@@ -212,10 +212,8 @@ void initobswfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 { 
-   // this was moved up out of if statement so that it matched decoupler
-   // behavior. is that correct? BDZ 8-15-23
-   obspwrf(lamplitude);
    if (PWRF_DELAY > 0.0) {
+      obspwrf(lamplitude);
       obsprgon(lpattern,lstep,ldres);
       delay(WFG_START_DELAY - WFG_OFFSET_DELAY);
       obsprgoff();
@@ -226,8 +224,8 @@ void initdecwfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 {        
-   decpwrf(lamplitude);
    if (PWRF_DELAY > 0.0) {
+      decpwrf(lamplitude);
       decprgon(lpattern,lstep,ldres);
       delay(WFG_START_DELAY - WFG_OFFSET_DELAY);
       decprgoff();
@@ -238,8 +236,8 @@ void initdec2wfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 {         
-   dec2pwrf(lamplitude);
    if (PWRF_DELAY > 0.0) {
+      dec2pwrf(lamplitude);
       dec2prgon(lpattern,lstep,ldres);
       delay(WFG_START_DELAY - WFG_OFFSET_DELAY);
       dec2prgoff();
@@ -250,8 +248,8 @@ void initdec3wfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 {        
-   dec3pwrf(lamplitude); 
    if (PWRF_DELAY > 0.0) {
+      dec3pwrf(lamplitude); 
       dec3prgon(lpattern,lstep,ldres);
       delay(WFG_START_DELAY - WFG_OFFSET_DELAY);
       dec3prgoff();
@@ -262,10 +260,8 @@ void setobswfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 {  
-   // this was moved up out of if statement so that it matched decoupler
-   // behavior. is that correct? BDZ 8-15-23
-   obspwrf(lamplitude);
    if (PWRF_DELAY > 0.0) {
+      obspwrf(lamplitude);
       obsprgon(lpattern, lstep, ldres); 
       obswfgHSoff();
    }
@@ -275,8 +271,8 @@ void setdecwfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 {      
-   decpwrf(lamplitude);
    if (PWRF_DELAY > 0.0) {
+      decpwrf(lamplitude);
       decprgon(lpattern, lstep, ldres);
       decwfgHSoff();
    } 
@@ -286,8 +282,8 @@ void setdec2wfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 {        
-   dec2pwrf(lamplitude);
    if (PWRF_DELAY > 0.0) {
+      dec2pwrf(lamplitude);
       dec2prgon(lpattern, lstep, ldres); 
       dec2wfgHSoff();
    }
@@ -297,8 +293,8 @@ void setdec3wfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 {        
-   dec3pwrf(lamplitude);
    if (PWRF_DELAY > 0.0) {
+      dec3pwrf(lamplitude);
       dec3prgon(lpattern, lstep, ldres);
       dec3wfgHSoff();
    }
@@ -327,7 +323,8 @@ void cleardec2wfg()
 
 void cleardec3wfg()
 {
-   // this one changed to match the other decoupler clear methods
+   // BDZ added this if test on 1-9-24 to match similar methods
+   
    if (PWRF_DELAY > 0.0) {
       dec3prgoff();
    }

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -149,20 +149,36 @@ void obswfgHSon()
    if (OBSch == 4) HSgate(CH4WG,TRUE);
 }
 
-void obswfgHSoff()
-{
-   if (OBSch == 1) HSgate(CH1WG,FALSE);
-   if (OBSch == 2) HSgate(CH2WG,FALSE);
-   if (OBSch == 3) HSgate(CH3WG,FALSE);
-   if (OBSch == 4) HSgate(CH4WG,FALSE);
-}
-
 void decwfgHSon()
 {
    if (DECch == 1) HSgate(CH1WG,TRUE);
    if (DECch == 2) HSgate(CH2WG,TRUE);
    if (DECch == 3) HSgate(CH3WG,TRUE);
    if (DECch == 4) HSgate(CH4WG,TRUE);
+}
+
+void dec2wfgHSon()
+{
+   if (DEC2ch == 1) HSgate(CH1WG,TRUE);
+   if (DEC2ch == 2) HSgate(CH2WG,TRUE);
+   if (DEC2ch == 3) HSgate(CH3WG,TRUE);
+   if (DEC2ch == 4) HSgate(CH4WG,TRUE);
+}
+
+void dec3wfgHSon()
+{
+   if (DEC3ch == 1) HSgate(CH1WG,TRUE);
+   if (DEC3ch == 2) HSgate(CH2WG,TRUE);
+   if (DEC3ch == 3) HSgate(CH3WG,TRUE);
+   if (DEC3ch == 4) HSgate(CH4WG,TRUE);
+}
+
+void obswfgHSoff()
+{
+   if (OBSch == 1) HSgate(CH1WG,FALSE);
+   if (OBSch == 2) HSgate(CH2WG,FALSE);
+   if (OBSch == 3) HSgate(CH3WG,FALSE);
+   if (OBSch == 4) HSgate(CH4WG,FALSE);
 }
 
 void decwfgHSoff()
@@ -176,28 +192,12 @@ void decwfgHSoff()
    else decprgoff();   
 }
 
-void dec2wfgHSon()
-{
-   if (DEC2ch == 1) HSgate(CH1WG,TRUE);
-   if (DEC2ch == 2) HSgate(CH2WG,TRUE);
-   if (DEC2ch == 3) HSgate(CH3WG,TRUE);
-   if (DEC2ch == 4) HSgate(CH4WG,TRUE);
-}
-
 void dec2wfgHSoff()
 {
    if (DEC2ch == 1) HSgate(CH1WG,FALSE);
    if (DEC2ch == 2) HSgate(CH2WG,FALSE);
    if (DEC2ch == 3) HSgate(CH3WG,FALSE);
    if (DEC2ch == 4) HSgate(CH4WG,FALSE);
-}
-
-void dec3wfgHSon()
-{
-   if (DEC3ch == 1) HSgate(CH1WG,TRUE);
-   if (DEC3ch == 2) HSgate(CH2WG,TRUE);
-   if (DEC3ch == 3) HSgate(CH3WG,TRUE);
-   if (DEC3ch == 4) HSgate(CH4WG,TRUE);
 }
 
 void dec3wfgHSoff()
@@ -220,24 +220,6 @@ char lpattern[MAXSTR];
    }
 }
 
-void setobswfg(lpattern,lstep,ldres,lamplitude)
-double lstep,ldres,lamplitude;
-char lpattern[MAXSTR];
-{  
-   if (PWRF_DELAY > 0.0) {
-      obspwrf(lamplitude);
-      obsprgon(lpattern, lstep, ldres); 
-      obswfgHSoff();
-   }
-}
-
-void clearobswfg()
-{
-   if (PWRF_DELAY > 0.0) {
-      obsprgoff();
-   }
-}
-
 void initdecwfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
@@ -246,24 +228,6 @@ char lpattern[MAXSTR];
    if (PWRF_DELAY > 0.0) {
       decprgon(lpattern,lstep,ldres);
       delay(WFG_START_DELAY - WFG_OFFSET_DELAY);
-      decprgoff();
-   }
-}
-
-void setdecwfg(lpattern,lstep,ldres,lamplitude)
-double lstep,ldres,lamplitude;
-char lpattern[MAXSTR];
-{      
-   decpwrf(lamplitude);
-   if (PWRF_DELAY > 0.0) {
-      decprgon(lpattern, lstep, ldres);
-      decwfgHSoff();
-   } 
-}
-
-void cleardecwfg()
-{   
-   if (PWRF_DELAY > 0.0) {
       decprgoff();
    }
 }
@@ -280,24 +244,6 @@ char lpattern[MAXSTR];
    }
 }
 
-void setdec2wfg(lpattern,lstep,ldres,lamplitude)
-double lstep,ldres,lamplitude;
-char lpattern[MAXSTR];
-{        
-   dec2pwrf(lamplitude);
-   if (PWRF_DELAY > 0.0) {
-      dec2prgon(lpattern, lstep, ldres); 
-      dec2wfgHSoff();
-   }
-}
-
-void cleardec2wfg()
-{   
-   if (PWRF_DELAY > 0.0) {
-      dec2prgoff(); 
-   }
-}
-
 void initdec3wfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
@@ -310,6 +256,39 @@ char lpattern[MAXSTR];
    }
 }
 
+void setobswfg(lpattern,lstep,ldres,lamplitude)
+double lstep,ldres,lamplitude;
+char lpattern[MAXSTR];
+{  
+   if (PWRF_DELAY > 0.0) {
+      obspwrf(lamplitude);
+      obsprgon(lpattern, lstep, ldres); 
+      obswfgHSoff();
+   }
+}
+
+void setdecwfg(lpattern,lstep,ldres,lamplitude)
+double lstep,ldres,lamplitude;
+char lpattern[MAXSTR];
+{      
+   decpwrf(lamplitude);
+   if (PWRF_DELAY > 0.0) {
+      decprgon(lpattern, lstep, ldres);
+      decwfgHSoff();
+   } 
+}
+
+void setdec2wfg(lpattern,lstep,ldres,lamplitude)
+double lstep,ldres,lamplitude;
+char lpattern[MAXSTR];
+{        
+   dec2pwrf(lamplitude);
+   if (PWRF_DELAY > 0.0) {
+      dec2prgon(lpattern, lstep, ldres); 
+      dec2wfgHSoff();
+   }
+}
+
 void setdec3wfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
@@ -318,6 +297,27 @@ char lpattern[MAXSTR];
    if (PWRF_DELAY > 0.0) {
       dec3prgon(lpattern, lstep, ldres);
       dec3wfgHSoff();
+   }
+}
+
+void clearobswfg()
+{
+   if (PWRF_DELAY > 0.0) {
+      obsprgoff();
+   }
+}
+
+void cleardecwfg()
+{   
+   if (PWRF_DELAY > 0.0) {
+      decprgoff();
+   }
+}
+
+void cleardec2wfg()
+{   
+   if (PWRF_DELAY > 0.0) {
+      dec2prgoff(); 
    }
 }
 
@@ -344,19 +344,6 @@ double lstep,ldres,lpredelay;
       obsprgon(lpattern,lstep,ldres);
 }
 
-void obswfgoff(lpreset)
-int lpreset;
-{
-   if (PWRF_DELAY > 0.0) {
-      if (lpreset == 0)
-         obsprgoff();
-      else
-         obswfgHSoff();
-   }
-   else
-      obsprgoff(); 
-}
-
 void decwfgon(lpattern,lstep,ldres,lpreset,lpredelay)
 char lpattern[MAXSTR];
 int lpreset;
@@ -372,19 +359,6 @@ double lstep,ldres,lpredelay;
       dps_on();
    }
    else decprgon(lpattern,lstep,ldres);
-}
-
-void decwfgoff(lpreset)
-int lpreset;
-{   
-   if (PWRF_DELAY > 0.0) {
-      if (lpreset == 0)
-         decprgoff();
-      else
-         decwfgHSoff();
-   }
-   else
-      decprgoff(); 
 }
 
 void dec2wfgon(lpattern,lstep,ldres,lpreset,lpredelay)
@@ -405,19 +379,6 @@ double lstep,ldres,lpredelay;
       dec2prgon(lpattern,lstep,ldres);
 }
 
-void dec2wfgoff(lpreset)
-int lpreset;
-{   
-   if (PWRF_DELAY > 0.0) {
-      if (lpreset == 0)
-         dec2prgoff();
-      else
-         dec2wfgHSoff();
-   }   
-   else
-      dec2prgoff(); 
-}
-
 void dec3wfgon(lpattern,lstep,ldres,lpreset,lpredelay)
 char lpattern[MAXSTR];
 int lpreset;
@@ -434,6 +395,45 @@ double lstep,ldres,lpredelay;
    }
    else
       dec3prgon(lpattern,lstep,ldres); 
+}
+
+void obswfgoff(lpreset)
+int lpreset;
+{
+   if (PWRF_DELAY > 0.0) {
+      if (lpreset == 0)
+         obsprgoff();
+      else
+         obswfgHSoff();
+   }
+   else
+      obsprgoff(); 
+}
+
+void decwfgoff(lpreset)
+int lpreset;
+{   
+   if (PWRF_DELAY > 0.0) {
+      if (lpreset == 0)
+         decprgoff();
+      else
+         decwfgHSoff();
+   }
+   else
+      decprgoff(); 
+}
+
+void dec2wfgoff(lpreset)
+int lpreset;
+{   
+   if (PWRF_DELAY > 0.0) {
+      if (lpreset == 0)
+         dec2prgoff();
+      else
+         dec2wfgHSoff();
+   }   
+   else
+      dec2prgoff(); 
 }
 
 void dec3wfgoff(lpreset)

--- a/src/nvpsg/solidshapegen.h
+++ b/src/nvpsg/solidshapegen.h
@@ -183,13 +183,13 @@ void obswfgHSoff()
 
 void decwfgHSoff()
 {
-   if (PWRF_DELAY > 0.0) {
-      if (DECch == 1) HSgate(CH1WG,FALSE);
-      if (DECch == 2) HSgate(CH2WG,FALSE);
-      if (DECch == 3) HSgate(CH3WG,FALSE);
-      if (DECch == 4) HSgate(CH4WG,FALSE);
-   }
-   else decprgoff();   
+   // this one changed substantially by just matching other cases.
+   // BDZ 8-15-23
+
+   if (DECch == 1) HSgate(CH1WG,FALSE);
+   if (DECch == 2) HSgate(CH2WG,FALSE);
+   if (DECch == 3) HSgate(CH3WG,FALSE);
+   if (DECch == 4) HSgate(CH4WG,FALSE);
 }
 
 void dec2wfgHSoff()
@@ -212,8 +212,10 @@ void initobswfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 { 
+   // this was moved up out of if statement so that it matched decoupler
+   // behavior. is that correct? BDZ 8-15-23
+   obspwrf(lamplitude);
    if (PWRF_DELAY > 0.0) {
-      obspwrf(lamplitude);
       obsprgon(lpattern,lstep,ldres);
       delay(WFG_START_DELAY - WFG_OFFSET_DELAY);
       obsprgoff();
@@ -260,8 +262,10 @@ void setobswfg(lpattern,lstep,ldres,lamplitude)
 double lstep,ldres,lamplitude;
 char lpattern[MAXSTR];
 {  
+   // this was moved up out of if statement so that it matched decoupler
+   // behavior. is that correct? BDZ 8-15-23
+   obspwrf(lamplitude);
    if (PWRF_DELAY > 0.0) {
-      obspwrf(lamplitude);
       obsprgon(lpattern, lstep, ldres); 
       obswfgHSoff();
    }
@@ -323,7 +327,10 @@ void cleardec2wfg()
 
 void cleardec3wfg()
 {
-   dec3prgoff();
+   // this one changed to match the other decoupler clear methods
+   if (PWRF_DELAY > 0.0) {
+      dec3prgoff();
+   }
 }
 
 void obswfgon(lpattern,lstep,ldres,lpreset,lpredelay)


### PR DESCRIPTION
A little while ago I sent an email to Dan detailing troubling code in solidshapegen.h. We had found some bugs we fixed already. The troubling code (in cp related methods) may have arose out of previous devs trying to work around the bugs we found and squashed recently.

I found the troubling code by rearranging some code to explain it to a scientist. The 1st commit in this branch is just rearranging the code again like I did for the scientist. It also is a nicer way to organize the code.

The second commit is my proposed fixes to the actual shapegen.h code. Please look at these commits separately and you will understand the logic of the proposed fixes.