### PR TITLE
showarrays would not always show all elements

### DIFF
--- a/src/common/maclib/showarrays
+++ b/src/common/maclib/showarrays
@@ -36,7 +36,7 @@ if arraystop>$maxindex then arraystop=$maxindex endif
 if arraystart>arraystop then arraystart=1 write('error','Array Start > Stop: reset to 1!') endif 
 if arraydelta>(arraystop-arraystart) then 
   arraydelta=1 
-  if($maxindex > 1) then
+  if($maxindex > 1) and (arraystop <> arraystart) then
      write('error','Array Delta > Stop - Start: reset to 1!') 
   endif
 endif

--- a/src/vnmr/dsww.c
+++ b/src/vnmr/dsww.c
@@ -817,14 +817,14 @@ int dsww(int argc, char *argv[], int retc, char *retv[])
   integral = 0;
 
 // now set arraystart, arraystop, arraydelta parameters
-  if(!P_getreal(CURRENT,"arraystart",&d,1) && firstindex > (int)d) {
+  if(!P_getreal(CURRENT,"arraystart",&d,1) && firstindex != (int)d) {
   	P_setreal(CURRENT,"arraystart", (double)firstindex, 1);
 #ifdef VNMRJ
         appendJvarlist("arraystart");
   	// writelineToVnmrJ("pnew", "1 arraystart");
 #endif
   }
-  if(!P_getreal(CURRENT,"arraystop",&d,1) && lastindex < (int)d) {
+  if(!P_getreal(CURRENT,"arraystop",&d,1) && lastindex != (int)d) {
   	P_setreal(CURRENT,"arraystop", (double)lastindex, 1);
 #ifdef VNMRJ
         appendJvarlist("arraystop");


### PR DESCRIPTION
dsww now updates arraystart and arraystop.
showarrays macro does not display waring about arraydelta if arraystart and arraystop are equal.