### PR TITLE
Vnmrbg could crash after df display

### DIFF
--- a/src/Asp/AspDataInfo.C
+++ b/src/Asp/AspDataInfo.C
@@ -142,10 +142,17 @@ void AspDataInfo::getYminmax(string nucleus, double &ymin, double &ymax) {
      float maxy=-0.1*FLT_MAX, miny=FLT_MAX;
      float y, *data;
      int i;
+     char str[20];
+     Wgetgraphicsdisplay(str, 20);
+     string type;
+     if (!strcmp(str,"df"))
+        type = string("FID");
+     else
+        type = string("SPEC");
      for(i=0;i<npts;i++) {
 
 
-        data = SpecDataMgr::get()->getTrace("SPEC", i, 1.0, haxis.npts);
+        data = SpecDataMgr::get()->getTrace(type, i, 1.0, haxis.npts);
         if(!data) continue;
 
 // should be getDataMinMax

--- a/src/vnmr/init2d.c
+++ b/src/vnmr/init2d.c
@@ -698,6 +698,7 @@ int init2d_getfidparms(int dis_setup)
   }
 
   set_fid_display();
+  set_fid_proc(HORIZ,SW0_DIM,NORMDIR, VERT,SW1_DIM,REVDIR);
   get_sfrq(HORIZ,&sfrq);
   get_scale_axis(HORIZ,&axisHoriz);
   axisVert = '\0';


### PR DESCRIPTION
If ds is not called, some pointers are not initialized. Crash happened when df displayed and window resized.