### PR TITLE
Infostat could fail

### DIFF
--- a/src/stat/SConstruct
+++ b/src/stat/SConstruct
@@ -42,7 +42,7 @@ infoServerFileList = ['acqinfo_xdr.c',
 acqMeterFileList = ['acqmeter_win.c']
 
 # build environment
-statEnv = Environment(CCFLAGS    = '-O -m32',
+statEnv = Environment(CCFLAGS    = '-O2 -m32',
                       CPPDEFINES = ['ACQSTAT', 'LINUX', 'SUN', 'BSDACQ', 'X11'],
                       LINKFLAGS  = '-O2 -m32 -Wl,-rpath,/vnmr/lib ',
                       CPPPATH    = [cwd])


### PR DESCRIPTION
It could core dump and/or write random values into the log files if the -l option is used. It only fails if compiled with newer versions of gcc (eg, gcc 8). Also, compiling as 64-bit does not show the problem, only 32-bit fails. It seems related to the new -fno-omit-frame-pointer option. Compiling with no optimization (-O0) or with -O2 works. Only using -O (eg -O1) fails.