### PR TITLE
Add sample loc to accounting logs

### DIFF
--- a/src/kpsg/psg.c
+++ b/src/kpsg/psg.c
@@ -75,6 +75,7 @@ void checkGradtype();
 void first_done();
 void reset();
 void check_for_abort();
+void write_shr_info(double exp_time);
 /****************************************/
 /*		EXTERNALS		*/
 /****************************************/
@@ -121,6 +122,7 @@ extern int	v14;		/* offset in code to v14 */
 extern int	v15;		/* offset in code to v15 */
 extern int	v16;		/* offset in code to v16 */
 
+extern int loc;
 extern long	rt_tab[];
 
 extern unsigned long 	ix;	/* FID currently in Acode generation */
@@ -2241,8 +2243,7 @@ double getExpTime()
   return(usertime);
 }
 
-write_shr_info(exp_time)
-double	exp_time;
+void write_shr_info(double exp_time)
 {
     int Infofd;	/* file discriptor Code disk file */
     int bytes;
@@ -2254,6 +2255,7 @@ double	exp_time;
     else
        ExpInfo.ExpDur = usertime;
 
+    ExpInfo.SampleLoc = loc;
     if (newacq)
     {
        ExpInfo.NumTables = num_tables; /* set number of tables */

--- a/src/nvpsg/initacqparms.c
+++ b/src/nvpsg/initacqparms.c
@@ -1025,6 +1025,7 @@ void write_shr_info(double exp_time)
     else
        ExpInfo.ExpDur = usertime;
 
+    ExpInfo.SampleLoc = loc;
     /*
        BKJ: CAUTION: need to check ExpInfo.NumTables
        ExpInfo.NumTables = num_tables;

--- a/src/psg/initacqparms.c
+++ b/src/psg/initacqparms.c
@@ -1339,8 +1339,7 @@ double getExpTime()
   return(usertime);
 }
 
-write_shr_info(exp_time)
-double exp_time;
+void write_shr_info(double exp_time)
 {
     int Infofd;	/* file discriptor Code disk file */
     int bytes;
@@ -1352,6 +1351,7 @@ double exp_time;
     else
        ExpInfo.ExpDur = usertime;
 
+    ExpInfo.SampleLoc = loc;
     if (newacq)
     {
        ExpInfo.NumTables = num_tables; /* set number of tables */
@@ -1378,7 +1378,7 @@ double exp_time;
     close(Infofd);
 }
 
-write_exp_info()
+void write_exp_info()
 {
     int Infofd;	/* file discriptor Code disk file */
     int bytes;

--- a/src/psg/psg.c
+++ b/src/psg/psg.c
@@ -151,11 +151,12 @@ extern char *newString();
 extern char *realString();
 extern symbol **getTreeRoot();
 extern varInfo *rfindVar();
-extern char *getenv();
 extern int createPS();		/* create Pulse Sequence routine */
 extern double getval();
 extern double sign_add();
 extern codeint *init_acodes();
+extern void write_shr_info(double exp_time);
+extern void write_exp_info();
 
 static void checkGradAlt();
 void checkGradtype();


### PR DESCRIPTION
This was a request in spinsights. The SampleLoc in the shared experiment structure is now set by PSG.