### PR TITLE
added fiddlecf command

### DIFF
--- a/src/common/manual/fiddle
+++ b/src/common/manual/fiddle
@@ -12,6 +12,9 @@ SYNOPSIS
 	fiddle2dd  perform 2D reference deconvolution subtracting alternate fids
 	fiddle2Dd  perform 2D reference deconvolution subtracting alternate fids
 
+        fiddlecf   calculate the correction function for fiddle based on
+                   two FIDs in an experiment.
+
 
 DESCRIPTION 
 	This program performs reference deconvolution, using a reference signal
@@ -128,6 +131,18 @@ arraydim will no longer match the arrays set and it may be necessary to set
 the arguments to wft2d explicitly rather than using wft2da, or adjust the 
 parameters manually).
 
+Calculate fiddle correction function 
+
+The command fiddlecf will calculate the fiddle correction function based on
+the first and second FIDs in an experiment. By default, the correction function
+will be saved in the current experiment directory with the name fiddlecf.fid.
+An alternate file name may be specified with the 'file' option, which must
+immediately be followed by the <filename>.  If '<filename>' does not begin
+with / it is assumed to be in the current working directory. If the directory
+exists, fiddlecf will abort. One can use the 'force' option to first remove
+an existing correction function.
+
+This correction function may then be used by fiddle with the 'readcf' option.
 
 
 OPTIONS

--- a/src/common/manual/sconsPostAction
+++ b/src/common/manual/sconsPostAction
@@ -147,6 +147,7 @@ ln -s expl pexpl
 ln -s fiddc3d ntype3d
 ln -s fiddc3d ptspec3d
 ln -s fiddc3d specdc3d
+ln -s fiddle fiddlecf
 ln -s flush flush2
 ln -s foldcc foldj
 ln -s foldcc foldt

--- a/src/vnmr/table.c
+++ b/src/vnmr/table.c
@@ -210,7 +210,8 @@ extern int export_files();			/* magnetom */
 extern int expl_cmd();
 extern int f_cmd();
 extern int fidarea();
-extern int fiddle();
+extern int fiddle(int argc, char *argv[], int retc, char *retv[]);
+extern int fiddlecf(int argc, char *argv[], int retc, char *retv[]);
 extern int fidmax();
 extern int fidproc(int argc, char *argv[], int retc, char *retv[]);
 #ifndef VNMRJ
@@ -762,6 +763,7 @@ static cmd_t vnmr_table[] = {
 	{"fiddle2D"   , fiddle,		NO_REEXEC, 5},
 	{"fiddle2Dd"  , fiddle,		NO_REEXEC, 5},
 	{"fiddle2dd"  , fiddle,		NO_REEXEC, 5},
+	{"fiddlecf"   , fiddlecf,	NO_REEXEC, 5},
 	{"fidmax"     , fidmax,		NO_REEXEC, 10},
 	{"fidproc"    , fidproc,	NO_REEXEC, 10},
 	{"wfidproc"   , fidproc,	NO_REEXEC, 10},


### PR DESCRIPTION
This calculates the correction function based on two FIDs in an experiment. Documented the commmand. Removed deprecated register keyword (this causes problems with newer gcc compilers).