### PR TITLE
Improve code that relies on adding 0.4999 etc to values

### DIFF
--- a/src/bin/imcalc.c
+++ b/src/bin/imcalc.c
@@ -34,7 +34,7 @@
 #include <fcntl.h>
 #include "data.h" 
 
-#define NRND(x)	((x) >= 0 ? ((int)((x)+0.5)) : (-(int)(-(x)+0.49999999999)))
+#define NRND(x)	((x) >= 0 ? ((int)((x)+0.5)) : (-(int)(-(x)+0.499999999999999999999999)))
 
 struct datafilehead main_header1, main_header2;
 

--- a/src/common/maclib/svfj
+++ b/src/common/maclib/svfj
@@ -216,7 +216,7 @@ if $mdiff<0 then
 else
   $date=$date+' +'
 endif
-$mdiff=5*trunc($mdiff/5+0.4999)
+$mdiff=5*trunc($mdiff/5+0.499999999999999999999999)
 $hdiff=trunc($mdiff/60)
 $mdiff=$mdiff-60*$hdiff
 $tdiff=100*$hdiff+$mdiff

--- a/src/ib/oval.c
+++ b/src/ib/oval.c
@@ -38,8 +38,8 @@ static char *Sid(){
 *     rectangle corners.  Then hold down the LEFT button and drag.      *
 *  4. An oval can be moved by holding down the LEFT button while the  	*
 *     mouse cursor position is inside an oval.                        	*
-*  5. An oval can be rotated by holding down the 'CTRL' keyborad and	*
-*     draging the curosr (at any position) left to right or right to	*
+*  5. An oval can be rotated by holding down the 'CTRL' keyboard and	*
+*     dragging the cursor (at any position) left to right or right to	*
 *     left.  Each pixel which the cursor has moved (to the left or 	*
 *     right) corresponds to the rotation of 1 degree.			*
 *									*
@@ -501,16 +501,16 @@ Oval::edges_create(void)
       if ((prev_y - y) > 1)
 	 break;
 
-      tempval = (int)(rot_x(fx,fy,cost,sint)+0.4999);
+      tempval = (int)(rot_x(fx,fy,cost,sint)+0.499999999999999999999999);
       ovptr->x1 = x_ctr + tempval;
       ovptr->x3 = x_ctr - tempval + 1;
-      tempval = (int)(rot_y(fx,fy,cost,sint)+0.4999);
+      tempval = (int)(rot_y(fx,fy,cost,sint)+0.499999999999999999999999);
       ovptr->y1 = y_ctr + tempval;
       ovptr->y3 = y_ctr - tempval + 1;
-      tempval = (int)(rot_x(-fx,fy,cost,sint)+0.4999);
+      tempval = (int)(rot_x(-fx,fy,cost,sint)+0.499999999999999999999999);
       ovptr->x2 = x_ctr + tempval;
       ovptr->x4 = x_ctr - tempval + 1;
-      tempval = (int)(rot_y(-fx,fy,cost,sint)+0.4999);
+      tempval = (int)(rot_y(-fx,fy,cost,sint)+0.499999999999999999999999);
       ovptr->y2 = y_ctr + tempval;
       ovptr->y4 = y_ctr - tempval + 1;
 
@@ -532,17 +532,17 @@ Oval::edges_create(void)
       fx = (float)rx * (float)sqrt(1.0 - (double)(y*y)/r2_f);  // Eq. 3
       fy = (float)y;
 
-      tempval = (int)(rot_x(fx,fy,cost,sint)+0.4999);
+      tempval = (int)(rot_x(fx,fy,cost,sint)+0.499999999999999999999999);
       ovptr->x1 = x_ctr + tempval;
       ovptr->x3 = x_ctr - tempval + 1;
-      tempval = (int)(rot_y(fx,fy,cost,sint)+0.4999);
+      tempval = (int)(rot_y(fx,fy,cost,sint)+0.499999999999999999999999);
       ovptr->y1 = y_ctr + tempval;
       ovptr->y3 = y_ctr - tempval + 1;
-      tempval = (int)(rot_x(-fx,fy,cost,sint)+0.4999);
+      tempval = (int)(rot_x(-fx,fy,cost,sint)+0.499999999999999999999999);
       ovptr->x2 = x_ctr + tempval;
       ovptr->x4 = x_ctr - tempval + 1;
-      tempval = (int)(rot_y(-fx,fy,cost,sint)+0.4999);
-      ovptr->y2 = y_ctr + tempval ;
+      tempval = (int)(rot_y(-fx,fy,cost,sint)+0.499999999999999999999999);
+      ovptr->y2 = y_ctr + tempval;
       ovptr->y4 = y_ctr - tempval + 1;
 
       // If no previous list available, create a new list for next item

--- a/src/nvpsg/Controller.cpp
+++ b/src/nvpsg/Controller.cpp
@@ -970,7 +970,7 @@ int Controller::closeWaveformFile(int option)
 
 long long Controller::calcTicks(double xx)
 {
-  return( (long long) ((xx * 80000000.0L)+0.49999) );
+  return( (long long) ((xx * 80000000.0L)+0.499999999999999999999999) );
 }
 
 

--- a/src/vnmr/ll2d.c
+++ b/src/vnmr/ll2d.c
@@ -1662,9 +1662,9 @@ static void interpolate_cg(double *pointbuffer, double *point, double *inten)
     sum = l_diff + r_diff;
     *point = (l_diff - r_diff)/(2.0*sum);
     if (*point < -0.5)		/* make sure interpolated point is less than */
-      *point = -0.499999;	/* 0.5 away from real point so that it will */
+      *point = -0.499999999999999999999999;	/* 0.5 away from real point so that it will */
     if (*point > 0.5)		/* round back to correct point */
-      *point = 0.499999;
+      *point = 0.499999999999999999999999;
     if (pointbuffer[1] > 0.0)
       *inten = pointbuffer[INTERP_PTS/2]+fabs(*point)*((l_diff>r_diff) ? l_diff : r_diff);
     else


### PR DESCRIPTION
There are numerous places in OVJ where code utilizing 0.499 etc was not consistent and less accurate than possible. Use a consistent constant throughout.