### PR TITLE
Updated ovjBuild and some installation scripts

### DIFF
--- a/src/common/manual/ovjBuild
+++ b/src/common/manual/ovjBuild
@@ -23,3 +23,8 @@ on the releases page of github ( https://github.com/OpenVnmrJ/OpenVnmrJ/releases
 has undergone a beta test. The Notes.txt file in the dvd image
 is the change log for OpenVnmrJ.
 
+Using ovjBuild with the -c (or --codeonly) option will only download
+the OpenVnmrJ sources from github. It will not try to compile them.
+The git command is required for ovjBuild to work. It will be installed
+if it is not present. The ovjBuild command should not be executed from
+the root account. It will test that the HOME parameter is not "/root".

--- a/src/scripts/chksystempkgs.sh
+++ b/src/scripts/chksystempkgs.sh
@@ -13,6 +13,20 @@
 # check for the packages required for installation of OpenVnmrJ
 status=0
 
+setDistMajor() {
+   distmajor=16
+   if [[ -f /etc/lsb-release ]]; then
+      . /etc/lsb-release
+      distmajor=${DISTRIB_RELEASE:0:2}
+   elif [[ -f /etc/os-release ]]; then
+      . /etc/os-release
+      distmajor=${VERSION_ID:0:2}
+   elif [[ ! -z $(type -t hostnamectl) ]]; then
+      ver=$(hostnamectl | grep "Operating" | cut -d " " -f 4)
+      distmajor=${ver:0:2}
+   fi
+}
+
 #
 # rpm (RedHat and CentOS) vs dpkg (Debian)
 #
@@ -56,8 +70,7 @@ if [ ! -x /usr/bin/dpkg ]; then
 
 else
    echo "Checking for Ubuntu / Debian packages required by OpenVnmrJ"
-   . /etc/lsb-release
-   distmajor=${DISTRIB_RELEASE:0:2}
+   setDistMajor
    packagecommonlist='tcsh make gcc gfortran expect openssh-server mutt sharutils sendmail-cf gnome-power-manager kdiff3 ghostscript imagemagick xterm'
    if [ $distmajor -ge 22 ] ; then
      packageXlist='default-jre bc libmotif-dev'

--- a/src/scripts/ins_vnmr2.sh
+++ b/src/scripts/ins_vnmr2.sh
@@ -52,6 +52,20 @@ logmsg() {
       # echo $1 >> $logfile 2>&1
 }
 
+setDistMajor() {
+   distmajor=16
+   if [[ -f /etc/lsb-release ]]; then
+      . /etc/lsb-release
+      distmajor=${DISTRIB_RELEASE:0:2}
+   elif [[ -f /etc/os-release ]]; then
+      . /etc/os-release
+      distmajor=${VERSION_ID:0:2}
+   elif [[ ! -z $(type -t hostnamectl) ]]; then
+      ver=$(hostnamectl | grep "Operating" | cut -d " " -f 4)
+      distmajor=${ver:0:2}
+   fi
+}
+
 #-----------------------------------------------
 update_user_group() {
    # Just make the group. groupadd will fail if it
@@ -432,8 +446,7 @@ case x$os_version in
             lflvr="suse"
         elif [  -r /etc/debian_version ]
         then
-            . /etc/lsb-release
-            distmajor=${DISTRIB_RELEASE:0:2}
+            setDistMajor
             lflvr="debian"
                  # Ubuntu has awk
                  NAWK="awk"

--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -57,6 +57,20 @@ exclude=turbovnc-*.*.9[0-9]-*
 EOF
 }
 
+setDistMajor() {
+   distmajor=16
+   if [[ -f /etc/lsb-release ]]; then
+      . /etc/lsb-release
+      distmajor=${DISTRIB_RELEASE:0:2}
+   elif [[ -f /etc/os-release ]]; then
+      . /etc/os-release
+      distmajor=${VERSION_ID:0:2}
+   elif [[ ! -z $(type -t hostnamectl) ]]; then
+      ver=$(hostnamectl | grep "Operating" | cut -d " " -f 4)
+      distmajor=${ver:0:2}
+   fi
+}
+
 if [ -x /usr/bin/dpkg ]; then
    if [[ -f /etc/apt/sources.ovj ]]; then
      ovjRepo=1
@@ -638,8 +652,7 @@ if [ ! -x /usr/bin/dpkg ]; then
   fi
   echo " "
 else
-  . /etc/lsb-release
-  distmajor=${DISTRIB_RELEASE:0:2}
+  setDistMajor
   if [ $distmajor -lt 18 ] ; then
     echo "Only Ubuntu 18 or newer is supported"
     echo " "

--- a/src/scripts/ovjBuild.sh
+++ b/src/scripts/ovjBuild.sh
@@ -34,10 +34,13 @@ usage:
 
 options:
     -h|--help                 Display this help information
+    -c|--cloneonly            Only clone the repositories
 
 EOF
     exit 1
 }
+
+cloneOnly=0
 
 if [[ $(uname -s) != "Linux" ]]; then
     echo "$SCRIPT can only be used on Linux systems"
@@ -53,6 +56,10 @@ do
       ovj_usage
   elif [[ "x$arg" = "x--help" ]]; then
       ovj_usage
+  elif [[ "x$arg" = "x-c" ]]; then
+      cloneOnly=1
+  elif [[ "x$arg" = "x--cloneonly" ]]; then
+      cloneOnly=1
   else
       echo "unrecognized argument: $arg"
       ovj_usage
@@ -75,6 +82,25 @@ else
 fi
 
 runToolChain=0
+
+if [[ $HOME = "/root" ]]; then
+   echo "$0 cannot be executed as root"
+   echo "rerun as OpenVnmrJ user (e.g., vnmr1)"
+   exit 1
+fi
+
+# if git does not exist
+if [[ -z $(type -t git) ]] ; then
+   echo "git command not installed but is required"
+   if [[ -x /usr/bin/dpkg ]]; then
+      echo "If requested, enter the admin (sudo) password"
+      sudo apt update
+      sudo apt install -y git
+   else
+      echo "Please enter this system's root user password"
+      (su root -c "yum -y install git";)
+   fi
+fi
 
 if [[ ! -d $HOME/ovjbuild ]]; then
     mkdir $HOME/ovjbuild
@@ -108,6 +134,12 @@ else
     rm -rf src
     git checkout src
     cd ..
+fi
+
+if [[ $cloneOnly -eq 1 ]]; then
+    echo "Finished cloning repositories"
+    echo "Exiting"
+    exit 1
 fi
 
 cd bin


### PR DESCRIPTION
ovjBuild requires git to function. It will be installed if needed. Added -c (--codeonly) option to just clone the repositories. Documented changes.
On some Ubuntu systems, it seems that the /etc/lsb-release file may not exist. Generalized the mechanism to determine the release version to use lsb-release, os-release, or the hostnamectl command.