### PR TITLE
Removed debugging messages from some macros

### DIFF
--- a/src/Gilson/maclib/glue_vj
+++ b/src/Gilson/maclib/glue_vj
@@ -22,7 +22,6 @@ if $#>0 then
     endif
 endif
 $plateglue=userdir+'/templates/glue/'+$gluename
-$plateglue?
 
 exists($plateglue,'file'):$e1
 if not $e1 then
@@ -36,7 +35,6 @@ $numb=0
 if $gluename <> '' then
     lookup('file',$plateglue)
     lookup('read'):$num
-    $num?
 
     $count=1
     repeat

--- a/src/Gilson/maclib/read_plateglue
+++ b/src/Gilson/maclib/read_plateglue
@@ -3,13 +3,11 @@
 if $#>0 then
     if typeof('$1') then
       $gluename=$1
-      $gluename?
     else
       write('error','plate name needs to be a string')
     endif
 endif
 $plateglue=userdir+'/templates/glue/'+$gluename
-$plateglue?
 
 exists($plateglue,'file'):$e1
 if not $e1 then
@@ -21,15 +19,12 @@ $loco=''
 $numb=0
 lookup('file',$plateglue)
 lookup('read'):$num
-$num?
 
 $count=1
 $rack=vrack
 $zone=vzone
 repeat
     lookup('read'):$loco
-    $loco?
-
     if $count=1 then
        getsqdata($rack,$zone,'',$loco,pslabel)
     else

--- a/src/Gilson/maclib/vastplot
+++ b/src/Gilson/maclib/vastplot
@@ -1,12 +1,9 @@
 "macro vastplot"
 "vastplot - plots the current display"
 
-lcdisplay?
 if lcdisplay='dconi' or lcdisplay='dpcon' then $plot='pcon(10,1.3)' else
   length(lcdisplay):$length
- $length? 
   substr(lcdisplay,3,$length-2):$plot
-  $plot?
   $plot='pl'+$plot
 endif
 exec($plot)

--- a/src/biopack/maclib/BP_NLSinit
+++ b/src/biopack/maclib/BP_NLSinit
@@ -8,7 +8,6 @@
  if $lasttwo='_S' then
   SPARSE='n' 
   seqfil=$baseseq
-  seqfil?
   write('line3','Re-setting seqfil to parent value %s',seqfil)
   return
  endif

--- a/src/biopack/maclib/BP_NLSschedule
+++ b/src/biopack/maclib/BP_NLSschedule
@@ -6,7 +6,7 @@ if ($# <> 1) then
        write('error', 'Usage: BP_NLSschedule(filename)')
        return(1)
 endif
-BPfindfile(sampsched,'manual'):$path $path?
+BPfindfile(sampsched,'manual'):$path
 if $path='' then
   write('error', '2D Sampling Schedule file does not exist')
   return(1)

--- a/src/biopack/maclib/BP_NLSstop
+++ b/src/biopack/maclib/BP_NLSstop
@@ -8,7 +8,6 @@
  if $lasttwo='_S' then
   SPARSE='n' 
   seqfil=$baseseq
-  seqfil?
   write('line3','Re-setting SPARSE to %s',SPARSE)
   write('line3','Re-setting seqfil to parent value %s',seqfil)
   return
@@ -19,7 +18,6 @@
  substr(seqfil,1,$size-4):$baseseq   "parent sequence"
  if $lastfour='_TAB' then
   seqfil=$baseseq
-  seqfil?
   write('line3','Re-setting seqfil to parent value %s',seqfil)
   return
  endif

--- a/src/biopack/maclib/BPcopy_to_bin
+++ b/src/biopack/maclib/BPcopy_to_bin
@@ -36,7 +36,6 @@ else                                     "look in appdir or /vnmr/bin"
    mkdir($home+'/bin')
    cp($path,$home+'/bin')
   endif
-   $pathuser?
    shell('chmod -R 777 '+$pathuser):$dum
 endif
 

--- a/src/common/maclib/AT31_modulator
+++ b/src/common/maclib/AT31_modulator
@@ -100,8 +100,6 @@ elseif ($1='PART3') then
    $firstnullindex=$bestindex
    $ratio=$bestheight/$firstpeakheight
    $ratio=trunc($ratio*10000)/10000
-   $bestheight?
-   $firstpeakheight?
    write('line3','ratio of maximum to minimum = %2.2f',$ratio)
    if (at_printparams='y') then
      pap ATpltext

--- a/src/common/maclib/ATc31_modulator
+++ b/src/common/maclib/ATc31_modulator
@@ -103,8 +103,6 @@ elseif ($1='PART3') then
    $firstnullindex=$bestindex
    $ratio=$bestheight/$firstpeakheight
    $ratio=trunc($ratio*10000)/10000
-   $bestheight?
-   $firstpeakheight?
    write('line3','ratio of maximum to minimum = %2.2f',$ratio)
    if (at_printparams='y') then
      pap ATpltext

--- a/src/common/maclib/tttime
+++ b/src/common/maclib/tttime
@@ -4,5 +4,3 @@
 $sec=(d1+at)*(nt+ss)
 $sec=$sec+pad
 $time=$sec/60
-$time?
-  

--- a/src/solidspack/maclib/xx_pars
+++ b/src/solidspack/maclib/xx_pars
@@ -50,7 +50,6 @@ paramgroup('all','xxX','','',                                'aXxx','amplitude',
                                                              'rof3','pulse','0.2',
                                                              'tauXxx','pulse',10.0,
                                                              'npaXxx','integer',10)
-pwXxx?
 rof3=r3Xxx
 paramgroup('all','scaleX','','',                             'scalesw','real',1.0)
 paramgroup('clearparams','scalesw')

--- a/src/veripulse/maclib/VPPRESATproc
+++ b/src/veripulse/maclib/VPPRESATproc
@@ -359,7 +359,6 @@ ELSEIF ($arg = 'findsatfrqc') THEN
     endif
     $counter=$counter+1
   until $counter > arraydim
-  $best?
 
   if (($best < 4) or ($best > 17)) then
     satfrq=satfrq[$best]

--- a/src/veripulse/maclib/userC13SN
+++ b/src/veripulse/maclib/userC13SN
@@ -12,5 +12,4 @@ gain=44
 setrc
 d1=300
 array('d1',3,d1,0) satdly=0
-IPrunid?
 setinstallprocs('C13sens')


### PR DESCRIPTION
Several macros had leftover debugging essages such as $length? Bug and list of macros reported in SpinSights