### PR TITLE
Fixed two PSG function prototypes

### DIFF
--- a/src/kpsg/apdelay.h
+++ b/src/kpsg/apdelay.h
@@ -88,7 +88,7 @@
 #define OBLIQUEGRADIENT_EVENT	29
 #define PWRF_EVENT		30
 
-extern double eventovrhead();
+extern double eventovrhead(int event_type);
 
 
 #define POWER_DELAY  		( eventovrhead(POWER_EVENT) )

--- a/src/psg/apdelay.h
+++ b/src/psg/apdelay.h
@@ -239,7 +239,7 @@
 #define OBLIQUEGRADIENT_EVENT	29
 #define PWRF_EVENT		30
 
-extern double eventovrhead();
+extern double eventovrhead(int event_type);
 
 
 #ifdef NVPSG


### PR DESCRIPTION
These were causing thousands of warnings by the new clang compiler.