### PR TITLE
Postscript to PDF conversion tool missing on MacOS

### DIFF
--- a/src/common/maclib/pageview
+++ b/src/common/maclib/pageview
@@ -53,6 +53,29 @@ else
   $prog='pstopdf'
 endif
 getbinpath($prog,'bin'):$ps2pdfex,$ps2pdfwr
+if ($ps2pdfex = 0) then
+  if ($uname = 'Darwin') then
+    $prog='ps2pdf'
+    getbinpath($prog,'bin'):$ps2pdfex,$ps2pdfwr
+    if ($ps2pdfex = 0) then
+      // check two places where brew may put ps2pdf
+      $ps2pdfwr='/usr/local/bin/'+$prog
+      exists($ps2pdfwr,'file'):$ps2pdfex
+      if ($ps2pdfex = 0) then
+        $ps2pdfwr='/opt/homebrew/bin/'+$prog
+        exists($ps2pdfwr,'file'):$ps2pdfex
+      endif
+    endif
+    if ($ps2pdfex = 0) then
+      write('error','Postscript to PDF conversion tool not installed. From a terminal, run ovjGetps2pdf')
+      return
+    endif
+    $ps2pdfex=2
+  else
+    write('error','Postscript to PDF conversion tool ( %s ) not installed.',$prog)
+    return
+  endif
+endif
 
 "************************************************************"
 if ($1='setup') then
@@ -197,7 +220,11 @@ if ($1='review') then
   if ($uname <> 'Darwin') then
     shell('('+$ps2pdfwr+' '+$tmpplot+'2 '+$tmpplot+'.pdf)'):$dum
   else
-    shell('('+$ps2pdfwr+' '+$tmpplot+'2  -o '+$tmpplot+'.pdf)'):$dum
+    if ($ps2pdfex = 2) then
+      shell('('+$ps2pdfwr+' '+$tmpplot+'2 '+$tmpplot+'.pdf)'):$dum
+    else
+      shell('('+$ps2pdfwr+' '+$tmpplot+'2  -o '+$tmpplot+'.pdf)'):$dum
+    endif
   endif
   exists($tmpplot+'.pdf','file'):$isok
   if ($isok<>0) then

--- a/src/macos/ovjGetps2pdf.sh
+++ b/src/macos/ovjGetps2pdf.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright (C) 2017  Dan Iverson
+#
+# You may distribute under the terms of either the GNU General Public
+# License or the Apache License, as specified in the LICENSE file.
+#
+# For more information, see the LICENSE file.
+#
+#Uncomment next line for debugging output
+#set -x
+
+
+ovj_usage() {
+    cat <<EOF
+
+usage:
+
+    $SCRIPT will install the Postscript to PDF conversion (ps2pdf)
+    tool for MacOS. It will first install brew if needed. The ps2pdf
+    script is part of Ghostscript.
+EOF
+    exit 1
+}
+
+# process flag args
+while [ $# -gt 0 ]; do
+    key="$1"
+    case $key in
+        -h|--help)              ovj_usage                   ;;
+        -vv|--debug)            set -x ;;
+        *)
+            # unknown option
+            echo "unrecognized argument: $key"
+            ovj_usage
+            ;;
+    esac
+    shift
+done
+
+ostype=$(uname -s)
+if [[ $ostype != "Darwin" ]] && [[ $ostype != "darwin" ]]; then
+   echo "$0 only works on MacOS systems"
+   exit
+fi
+
+if [[ ! -z $(type -t ps2pdf) ]]; then
+   echo "Postscript to PDF conversion tool already installed"
+   exit
+fi
+
+if [[ ! -z $(type -t pstopdf) ]]; then
+   echo "Postscript to PDF conversion tool already installed"
+   exit
+fi
+
+if [[ -z $(type -t brew) ]]; then
+   echo "Installing brew"
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+echo "Installing Postscript to PDF conversion tool"
+
+brew install ghostscript

--- a/src/scripts/ovjmacout.sh
+++ b/src/scripts/ovjmacout.sh
@@ -94,6 +94,8 @@ cp vnmrj.sh $vjdir/bin/vnmrj
 chmod 755 $vjdir/bin/vnmrj
 cp ovjFixMac.sh $vjdir/bin/ovjFixMac
 chmod 755 $vjdir/bin/ovjFixMac
+cp ovjGetps2pdf.sh $vjdir/bin/ovjGetps2pdf
+chmod 755 $vjdir/bin/ovjGetps2pdf
 
 echo "vnmrs" >> $vjdir/vnmrrev 
 cd $vjdir/adm/users


### PR DESCRIPTION
Newer versions of MacOS (14.4, Sonoma) no longer support postscript. Added ovjGetps2pdf script to install ps2pdf from ghostscript for MacOS. Modified pageview to look for ps2pdf in the places ghostscript puts it.