### PR TITLE
Install will fail on PC with pre-loaded Ubuntu

### DIFF
--- a/src/scripts/ins_vnmr2.sh
+++ b/src/scripts/ins_vnmr2.sh
@@ -487,6 +487,19 @@ echo "NMR Destination directory= $dest_dir"
 echo "NMR host='$(/bin/hostname)' domain='$domainname'"
 
 source_dir=$(dirname "$src_code_dir")
+if [ x$lflvr != "xdebian" ]
+then
+   (su $nmr_adm -fc "ls $source_dir > /dev/null 2>&1 ")
+else
+   (sudo -u $nmr_adm ls $source_dir > /dev/null 2>&1)
+fi
+if [ $? -ne 0 ]
+then
+   echo ""
+   echo "$nmr_adm does not have permission to access $source_dir"
+   echo "Updating permissions with: chmod 775 $(dirname $source_dir)"
+   chmod 775 $(dirname $source_dir)
+fi
 acq_pid=-1
  
 chown_cmd="chown "


### PR DESCRIPTION
If the dvdimage directory is in the pre-defined user home directory, vnmr1 does not have read access. load.nmr will fail. Doing chmod 775 on the home directory of the pre-defined user fixes it.