### PR TITLE
upgrade.nmr should not replace loggingParamList

### DIFF
--- a/src/scripts/upgrade.nmr.sh
+++ b/src/scripts/upgrade.nmr.sh
@@ -262,6 +262,7 @@ doUpgrade () {
     ignoreFiles="
         acq/info
         p11/part11Config
+        adm/accounting/loggingParamList
         adm/users/profiles/accPolicy
         adm/users/userDefaults
         pulsecal


### PR DESCRIPTION
If someone modifies the parameters saved in the accounting logs, the upgrade.nmr script should not replace it with the default list.