### PR TITLE
Updated SConstruct.pulsetool

### DIFF
--- a/src/bin/SConstruct.pulsetool
+++ b/src/bin/SConstruct.pulsetool
@@ -25,12 +25,11 @@ pulseEnv = Environment(CCFLAGS    = '-O2',
 
 if ('darwin' in platform):
      pulseEnv.Replace(CC = 'clang')
-     pulseEnv.Replace(CCFLAGS = '-Wall -Os -arch x86_64 -I/opt/X11/include -I/Applications/OpenMotif21/include -Wno-implicit-function-declaration ')
+     pulseEnv.Replace(CCFLAGS = '-Wall -Os -arch x86_64 -Wno-implicit-function-declaration ')
      osxflags = os.getenv('osxflags')
      if osxflags:
         pulseEnv.Append(CCFLAGS = os.getenv('osxflags'))
-     pulseEnv.Replace(LINKFLAGS = '-Wall -Os -arch x86_64 -L/opt/X11/lib -L/Applications/OpenMotif21/lib ')
-     pulseEnv.Replace(LIBS = ['Xm', 'Xext', 'Xt', 'Xp', 'X11', 'm'])
+     pulseEnv.Replace(LINKFLAGS = '-Wall -Os -arch x86_64')
 
 
 # actual builds


### PR DESCRIPTION
On MacOS, it uses newer OpenMotif and XQuartz files. See OSX.md in ovjTools