### PR TITLE
A scons issue caused vnmrbg compile to fail

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -103,6 +103,7 @@ buildList = """
 #                        kpsg  done by kpsglib
 
 buildList = """
+                         vnmrbg
                          3D
                          autotest
                          backproj
@@ -130,7 +131,6 @@ buildList = """
                          stars
                          tcl
                          veripulse
-                         vnmrbg
                          """.split();
 
 acqBuildList = """


### PR DESCRIPTION
This happened on Ubuntu 24.04. During the vnmrbg compile, files from the Asp directory are linked. The scons tried to compile some of them before the link was complete. This did not happen if "scons -j 1" is used. Also found that moving the compile of vnmrbg to the start of the compilation list seems to fix it.