### PR TITLE
pageview could fail

### DIFF
--- a/src/common/maclib/pageview
+++ b/src/common/maclib/pageview
@@ -153,6 +153,10 @@ if ($1='review') then
     return
   endif
 
+  exists('pdfplotpar','parameter','global'):$plpon
+  if ($plpon = 0) then
+    {$0}('setup')
+  endif
   pdfplotpar[1]=''
   pdfplotpar[2]=emailaddr
   pdfplotpar[3]=''


### PR DESCRIPTION
On MacOS, ran into a case where pageview was called but pdfplotpar parameter did not exist. Now first tests for pdfplotpar and calls pageview('setup') if it does not exist