### PR TITLE
Updates for MacOS calling ps2pdf

### DIFF
--- a/src/common/user_templates/.vnmrenvsh
+++ b/src/common/user_templates/.vnmrenvsh
@@ -1,6 +1,5 @@
 #!/bin/sh
 #
-#  A version for Linux
 #
 
 vnmruser=$HOME/vnmrsys
@@ -50,3 +49,9 @@ export DELEGATE_PATH XFILESEARCHPATH
 # DICOM dcmtk dictionary path
 DCMDICTPATH=$vnmrsystem/lib/dicom.dic
 export DCMDICTPATH
+
+if [ -f /opt/homebrew/bin/brew ]; then
+   eval "$(/opt/homebrew/bin/brew shellenv > /dev/null 2>&1)"
+elif [ -f /usr/local/bin/brew ]; then
+   eval "$(/usr/local/bin/brew shellenv > /dev/null 2>&1)"
+fi

--- a/src/macos/ovjGetps2pdf.sh
+++ b/src/macos/ovjGetps2pdf.sh
@@ -59,6 +59,11 @@ if [[ -z $(type -t brew) ]]; then
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
+if [ -f /opt/homebrew/bin/brew ]; then
+   eval "$(/opt/homebrew/bin/brew shellenv > /dev/null 2>&1)"
+elif [ -f /usr/local/bin/brew ]; then
+   eval "$(/usr/local/bin/brew shellenv > /dev/null 2>&1)"
+fi
 echo "Installing Postscript to PDF conversion tool"
 
 brew install ghostscript


### PR DESCRIPTION
The ovjGetps2pdf script could fail since brew may not be in the PATH. Updated .vnmrenvsh to set PATH to access ps2pdf installed by brew.