### PR TITLE
Plot1D.xml gave syntax error

### DIFF
--- a/src/common/maclib/doplotoption
+++ b/src/common/maclib/doplotoption
@@ -96,7 +96,7 @@ if ($mode = 'all' ) then
 	if $intvalex then $plotoption[$intvalex]='' endif
 	teststr('$plotoption','pklabels','local'):$pklabelex
 	if $pklabelex then $plotoption[$pklabelex]='' endif
-	array2array($plotoption):$$plotoption
+	array2array($plotoption):$plotoption
     endif
 
   // DONE
@@ -212,7 +212,8 @@ ELSEIF ($1='plfidarray') THEN
     plfid('all')
     intmod=$intmod pkpick=$pkpick
 
-ELSEIF ($1='intval' and $plarray=0) THEN
+ELSEIF ($1='intval') THEN
+  if ($plarray=0) then
     if intstyle='pirN' then
 	on('insref'):$n
 	insref='n'
@@ -224,13 +225,16 @@ ELSEIF ($1='intval' and $plarray=0) THEN
 	exec(intstyle):$dum
 	if($n) then insref='y' else insref='n' endif
     endif
+  endif
 
-ELSEIF ($1='pklabels' and $plarray=0) THEN
+ELSEIF ($1='pklabels') THEN
+  if ($plarray=0) then
     if pkpick<>'' then
 	exec(pkpick)
     else 
 	ppf
     endif
+  endif
 
 ELSEIF ($1='plarray') THEN
     pldeptarray

--- a/src/layouts/layout/default/Plot1D.xml
+++ b/src/layouts/layout/default/Plot1D.xml
@@ -360,19 +360,19 @@
         >
         <mlabel 
           label="Hz"
-          chval="ppf('axish')"
+          chval="ppf(`axish`)"
           />
         <mlabel 
           label="ppm"
-          chval="ppf('axisp')"
+          chval="ppf(`axisp`)"
           />
         <mlabel 
           label="Hz,  top"
-          chval="ppf('axish','top')"
+          chval="ppf(`axish`,`top`)"
           />
         <mlabel 
           label="ppm, top"
-          chval="ppf('axisp','top')"
+          chval="ppf(`axisp`,`top`)"
           />
         <mlabel 
           label="Default"


### PR DESCRIPTION
Single quotes were causing a problem. This may be related to newer java versions. Not all systems show the error. Replaced single quotes with back quotes. Also found a couple of bugs in the doplotoption macro. Bugs reported in SpinSights