### PR TITLE
Fix related to Plot1D.xml

### DIFF
--- a/src/common/maclib/showmanual
+++ b/src/common/maclib/showmanual
@@ -11,13 +11,13 @@ if $1='1d' then
     dpf('off') 
     if (intstyle<>'' and intmod<>'off' and vp<12) then vp=12 endif
     if pkpick='ppf' then axis='p' dpf
-    elseif pkpick=`ppf('axish')` then
+    elseif pkpick='ppf(`axish`)' then
        dpf('axish')
-    elseif pkpick=`ppf('axisp')` then
+    elseif pkpick='ppf(`axisp`)' then
        dpf('axisp')
-    elseif pkpick=`ppf('axish','top')` then
+    elseif pkpick='ppf(`axish`,`top`)' then
        dpf('axish','top')
-    elseif pkpick=`ppf('axisp','top')` then
+    elseif pkpick='ppf(`axisp`,`top`)' then
        dpf('axisp','top')
     elseif pkpick=`axis='h' ppf axis='p'` then axis='h' dpf
     elseif pkpick=`ppf('top')` then axis='p' dpf('top') 

--- a/src/vnmr/table.c
+++ b/src/vnmr/table.c
@@ -716,7 +716,7 @@ static cmd_t vnmr_table[] = {
 	{"dosyfitv"   , dosyfit,	NO_REEXEC, 10},
 	{"dpcon"      , dpcon,	        NO_REEXEC, 1},
 	{"dpconn"     , dpcon,	        NO_REEXEC, 5},
-	{"dpf"        , dpf,	        NO_REEXEC, 7},
+	{"dpf"        , dpf,	        NO_REEXEC, 5},
 	{"dpir"       , dpir,	        NO_REEXEC, 10},
 	{"dpirN"      , dpir,	        NO_REEXEC, 5},
 	{"dps"        , dps,	        NO_REEXEC, 2},


### PR DESCRIPTION
The change in PR #871 that replaced single quotes with back quotes caused showmanual macro to fail.  Also changed the "redo" flag of dpf in table.c to remember dpf arguments.