### PR TITLE
More support for data station version

### DIFF
--- a/src/scripts/fixpsg.sh
+++ b/src/scripts/fixpsg.sh
@@ -60,7 +60,7 @@ then
       Wextra=${Wextra}" -Wno-format-overflow"
    fi
    arch=""
-   file $vnmrsystem/lib/libpsglib.so | grep "32-bit" $file >& /dev/null
+   file -L $vnmrsystem/lib/libpsglib.so | grep "32-bit" $file >& /dev/null
    if [[ $? -eq 0 ]]; then
       arch="-m32"
    fi

--- a/src/scripts/psggen.sh
+++ b/src/scripts/psggen.sh
@@ -102,7 +102,7 @@ then
    then
       Wextra=${Wextra}" -Wno-format-overflow"
    fi
-   file $vnmrsystem/lib/libpsglib.so | grep "32-bit" $file >& /dev/null
+   file -L $vnmrsystem/lib/libpsglib.so | grep "32-bit" $file >& /dev/null
    if [[ $? -eq 0 ]]; then
       arch="-m32"
    fi

--- a/src/scripts/vnmrseqgen.sh
+++ b/src/scripts/vnmrseqgen.sh
@@ -98,7 +98,7 @@ if [ x$osname = "xLinux" ]; then
    then
       Wextra=${Wextra}" -Wno-format-overflow"
    fi
-   file $vnmrsystem/lib/libpsglib.so | grep "32-bit" $file >& /dev/null
+   file -L $vnmrsystem/lib/libpsglib.so | grep "32-bit" $file >& /dev/null
    if [[ $? -eq 0 ]]; then
       arch="-m32"
    fi

--- a/src/scripts/wtgen.sh
+++ b/src/scripts/wtgen.sh
@@ -120,7 +120,12 @@ then
 fi
 if test x$ostype = "xLinux"
 then
-   cc -m32 -O $file.c usrwt.o -lm -o $file > errmsg
+   arch=""
+   file $vnmrsystem/bin/Vnmrbg | grep "32-bit" $file >& /dev/null
+   if [[ $? -eq 0 ]]; then
+      arch="-m32"
+   fi
+   cc $arch -O $file.c usrwt.o -lm -o $file > errmsg
 else
    cc -O $file.c usrwt.o -lm -o $file > errmsg
 fi


### PR DESCRIPTION
Test for psg uses file -L option, since libpsglib.so is sometimes a link to libpsglib.so.6.0. Updated the wtgen script.