### PR TITLE
getfile on MacOS could fail when used with -R.

### DIFF
--- a/src/common/maclib/_sw_ddr
+++ b/src/common/maclib/_sw_ddr
@@ -1,5 +1,6 @@
 "macro _sw_ddr"
 
+if (system='datastation') then _at return endif
 $stages=0
 
 on('ddrstages'):$usepars

--- a/src/scripts/ovjmacout.sh
+++ b/src/scripts/ovjmacout.sh
@@ -96,6 +96,7 @@ cp ovjFixMac.sh $vjdir/bin/ovjFixMac
 chmod 755 $vjdir/bin/ovjFixMac
 cp ovjGetps2pdf.sh $vjdir/bin/ovjGetps2pdf
 chmod 755 $vjdir/bin/ovjGetps2pdf
+mv $vjdir/maclib/_sw_ddr $vjdir/maclib/_sw
 
 echo "vnmrs" >> $vjdir/vnmrrev 
 cd $vjdir/adm/users

--- a/src/vnmrbg/SConstruct
+++ b/src/vnmrbg/SConstruct
@@ -627,8 +627,8 @@ interixgcc= os.path.join(os.sep,'opt','gcc.3.3','bin','gcc')
 interixgpp= os.path.join(os.sep,'opt','gcc.3.3','bin','g++')
 
 if (platform=="darwin"):
-    ccflags_32_64 = compileFlag +' -Os -Wall -Wno-format-security ' + compileOption
-    linkflags_32_64 = compileFlag +' -O '
+    ccflags_32_64 = compileFlag +' -arch x86_64 -arch arm64 -O3 -Wall -Wno-format-security ' + compileOption
+    linkflags_32_64 = compileFlag +' -arch x86_64 -arch arm64 -O3 '
 else:
     ccflags_32_64 = compileFlag +' -Wall ' + compileOption
     linkflags_32_64 = compileFlag +' -O -rdynamic'
@@ -816,7 +816,7 @@ magicAllObjs = magicCObjs + magicComSpcObjs # MAGIC_ALL_OBJ
 
 if ('interix' not in platform):    # Interix
    if (platform=="darwin"):
-       linkflags2_32_64 = compileFlag +' -Os '
+       linkflags2_32_64 = compileFlag +' -arch x86_64 -arch arm64 -O3 '
        vnmrBgCppEnv.Replace(CXX = 'clang++')
    else:
        linkflags2_32_64 = compileFlag +' -O2 -rdynamic'


### PR DESCRIPTION
The returned pathnames could be prefaced with a /
Compile Vnmrbg on MacOS for both x86_64 and arm64 architectures Use _sw_ddr as _sw for MacOS.