### PR TITLE
Fixes for beta1

### DIFF
--- a/src/scripts/upgrade.nmr.sh
+++ b/src/scripts/upgrade.nmr.sh
@@ -358,7 +358,7 @@ doUpgrade () {
                 echo $content | grep -w psglib  >& /dev/null
                 if [[ $? -eq 0 ]]; then
                     seq=$(echo $content | sed 's/psglib/seqlib/' | sed 's/\.c$//')
-                    mv $upgrade_temp_dir/$seq $vnmrsystem/$seq
+                    cp $upgrade_temp_dir/$seq $vnmrsystem/$seq
                 fi
             fi
         done

--- a/src/vnmrbg/SConstruct
+++ b/src/vnmrbg/SConstruct
@@ -644,7 +644,7 @@ vnmrBgCEnv = Environment(CCFLAGS    = ccflags_32_64,
 if (platform=="darwin"):
     vnmrBgCEnv.Append(CPPDEFINES = 'MACOS')
     vnmrBgCEnv.Replace(CC = 'clang')
-    vnmrBgCEnv.Append(CCFLAGS = ' -Wno-implicit-function-declaration ')
+    vnmrBgCEnv.Append(CCFLAGS = ' -Wno-implicit-function-declaration -Wno-deprecated-declarations -Wno-deprecated-non-prototype ')
     osxflags = os.getenv('osxflags')
     if osxflags:
        vnmrBgCEnv.Append(CCFLAGS = os.getenv('osxflags'))


### PR DESCRIPTION
upgrade.nmr fails if installing a new psglib/seqlib entry, such as DbppLED and INADEQUATE for Mercury.  Modified SConstruct for vnmrbg to reduce number of warnings when compiled on MacOS