### PR TITLE
Gradient shimming failed due to active / not active test on tpwr

### DIFF
--- a/src/common/maclib/fixpar
+++ b/src/common/maclib/fixpar
@@ -23,6 +23,7 @@ elseif (parversion < 5.05) then
    parfix
 endif
 
+setprotect('tpwr dpwr dlp fb','off',2)
 substr(rftype,1,1):$chan
 substr(amptype,2,1):$decamp
 if (($decamp = 'c')and(Console<>'mercury')) then
@@ -30,6 +31,7 @@ if (($decamp = 'c')and(Console<>'mercury')) then
    on('dlp')
 else
    on('dpwr')
+   setprotect('dhp','off',2)
    off('dhp')
    off('dlp')
 endif
@@ -51,7 +53,6 @@ if (Console = 'mercury') then
   setvalue('gain',gain,'processed')
   setlimit('fb',55000,1000,200)
   setlimit('fb',55000,1000,200,'processed')
-  setprotect('fb','off',2)
   setprotect('fb','off',2,'processed')
   dp='y'
   setenumeral('alock',5,'a','n','s','u','y')


### PR DESCRIPTION
Updated fixpar to turn off permission bit 1 for tpwr, dpwr, dlp, and fb