### PR TITLE
Install of ghostscript on MacOS was failing

### DIFF
--- a/src/common/user_templates/.vnmrenvsh
+++ b/src/common/user_templates/.vnmrenvsh
@@ -51,7 +51,7 @@ DCMDICTPATH=$vnmrsystem/lib/dicom.dic
 export DCMDICTPATH
 
 if [ -f /opt/homebrew/bin/brew ]; then
-   eval "$(/opt/homebrew/bin/brew shellenv > /dev/null 2>&1)"
+   eval "$(/opt/homebrew/bin/brew shellenv)"
 elif [ -f /usr/local/bin/brew ]; then
-   eval "$(/usr/local/bin/brew shellenv > /dev/null 2>&1)"
+   eval "$(/usr/local/bin/brew shellenv)"
 fi

--- a/src/macos/ovjGetps2pdf.sh
+++ b/src/macos/ovjGetps2pdf.sh
@@ -60,9 +60,9 @@ if [[ -z $(type -t brew) ]]; then
 fi
 
 if [ -f /opt/homebrew/bin/brew ]; then
-   eval "$(/opt/homebrew/bin/brew shellenv > /dev/null 2>&1)"
+   eval "$(/opt/homebrew/bin/brew shellenv)"
 elif [ -f /usr/local/bin/brew ]; then
-   eval "$(/usr/local/bin/brew shellenv > /dev/null 2>&1)"
+   eval "$(/usr/local/bin/brew shellenv)"
 fi
 echo "Installing Postscript to PDF conversion tool"
 


### PR DESCRIPTION
The ovjGetps2pdf script was not setting the path environmental parameter so the command brew was not found. Also fixed the .vnmrenvsh file