### PR TITLE
dpcon failed on AlmaLinux 9.4

### DIFF
--- a/src/vnmrj/src/vnmr/util/VGraphics.java
+++ b/src/vnmrj/src/vnmr/util/VGraphics.java
@@ -678,18 +678,25 @@ public class VGraphics implements VGaphDef
                 }
                 ds = ins.available();
                 if (ds < rs) {
-                    while (ds < rs) {
+	            i = 2;
+                    while ((ds < rs) && (i > 0)) {
                        Thread.sleep(100);
                        ds = ins.available();
+		       i--;
                     }
                     k2 = 0;
                     d2 = 0;
                     in = (InputStream) ins;
                     if (ds > imgByteLen)
                        ds = imgByteLen;
-                    while (d2 < 4) {
+                    while ((d2 < 4) && (k2 < rs)) {
                        if (k2 >= ds)
-                           return;
+		       {
+                           i = ins.available();
+	                   if (i == 0)
+                              return;
+			   ds += i;
+		       }
                        c1 = in.read();
                        if (c1 == 0xEE)
                             d2++;


### PR DESCRIPTION
I think this is a bug in AlmaLinux 9.4. It works in AlmaLinux 9.2. dpcon sends data to java (vnmrj.jar) over a socket. java tests for the number of bytes with the available() method of DataInputStream. If fewer than expected bytes are available, it waits until they are available.  On Linux 9.4, it waits forever. The fix is to read the number of bytes that are available and then check to see if more arrived.