### PR TITLE
Infoproc failed on Ubuntu

### DIFF
--- a/src/infoproc/SConstruct
+++ b/src/infoproc/SConstruct
@@ -39,11 +39,11 @@ buildMethods.makeSymLinks(env, procTarget, cwd, vwacqPath, vwacqHdrList)
 buildMethods.makeSymLinks(env, procTarget, cwd, expProcPath, expProcHdrList)
 buildMethods.makeSymLinks(env, procTarget, cwd, statPath, statHdrList)
 
-if os.path.exists('/usr/include/tirpc'):
-   env.Append(  CPPPATH=[ '/usr/include/tirpc']  )
-   LibList = [ 'tirpc' ]
-else:
-   LibList = []
+# if os.path.exists('/usr/include/tirpc'):
+#    env.Append(  CPPPATH=[ '/usr/include/tirpc']  )
+#    LibList = [ 'tirpc' ]
+# else:
+LibList = []
 # actual builds
 envProg = env.Program(target  = procTarget,
                                source  = [infoProcFileList],

--- a/src/infoproc/info_svc.c
+++ b/src/infoproc/info_svc.c
@@ -6,13 +6,10 @@
  *
  * For more information, see the LICENSE file.
  */
-/* 
- */
+
+#ifdef USE_RPC
 
 #include <sys/types.h>
-#ifdef AIX
-#include <sys/select.h>	/* IBM AIX OS needs it, but not present on SUN */
-#endif
 #include <stdio.h>
 #include <errno.h>
 #include <rpc/types.h>
@@ -467,3 +464,5 @@ SVCXPRT        *transp;
       exit(1);
    }
 }
+
+#endif // USE_RPC

--- a/src/infoproc/infoproc.c
+++ b/src/infoproc/infoproc.c
@@ -21,14 +21,6 @@
 #include <sys/socket.h>
 #include <sys/resource.h>
 
-#ifdef AIX
-#include <sys/select.h>
-#endif
-
-#ifndef AIX
-#include <sys/termios.h>
-#endif
-
 #include <signal.h>
 #include <netinet/in.h>
 #include <netdb.h>
@@ -129,7 +121,9 @@ char *argv[];
 
     this_hp = gethostbyname(LocalAcqHost);      /* see note at definition of this_hp */
 
+#ifdef USE_RPC
     acqinfo_svc();
+#endif
 }
 
 
@@ -347,14 +341,18 @@ setuppipehandler()
 static void
 terminated()
 {
+#ifdef USE_RPC
     close_rpc();
+#endif
     exit(1);
 }
 
 static void
 SigQuit()
 {
+#ifdef USE_RPC
     close_rpc();
+#endif
     exit(1);
 }
 

--- a/src/nvinfoproc/SConstruct
+++ b/src/nvinfoproc/SConstruct
@@ -6,7 +6,14 @@ import sys
 sys.path.append(os.path.join(os.getcwd(), os.pardir, os.pardir, 'scripts'))
 import buildMethods
 
+# current working directory
+cwd = os.getcwd()
 ovjtools=os.getenv('OVJ_TOOLS')
+if not ovjtools:
+# If not defined, try the default location
+    print("OVJ_TOOLS env not found. Trying default location.")
+    ovjtools = os.path.join(cwd, os.pardir, os.pardir, os.pardir, 'ovjTools')
+
 if not ovjtools:
     print("OVJ_TOOLS env not found.")
     print("For bash and variants, use export OVJ_TOOLS=<path>")
@@ -18,12 +25,6 @@ Import("*")
 
 # define target file names
 infoProcTarget = 'Infoproc'
-
-# we need to specify an absolute path so this SConstruct file
-# can be called from any other SConstruct file
-cwd = os.getcwd()
-
-javaPath = os.path.join(ovjtools, 'java', 'bin')
 
 ## NDDS include/lib paths
 # get options settings, use parameter to determine NDDS 3x, 4x, 4.2d varients
@@ -162,11 +163,11 @@ infoProcObjEnv.Append(CPPDEFINES = ['SUN', 'DATASEG'])
 
 # if 'Infoproc4x' in COMMAND_LINE_TARGETS:
 infoProcEnv.Append(CPPDEFINES = 'RTI_NDDS_4x')
-if os.path.exists('/usr/include/tirpc'):
-   infoProcEnv.Append(  CPPPATH=[ '/usr/include/tirpc']  )
-   LibList = [ 'pthread', 'nddscz', 'nddscorez', 'dl', 'tirpc' ]
-else:
-   LibList = [ 'pthread', 'nddscz', 'nddscorez', 'dl' ]
+# if os.path.exists('/usr/include/tirpc'):
+#    infoProcEnv.Append(  CPPPATH=[ '/usr/include/tirpc']  )
+#    LibList = [ 'pthread', 'nddscz', 'nddscorez', 'dl', 'tirpc' ]
+# else:
+LibList = [ 'pthread', 'nddscz', 'nddscorez', 'dl' ]
 
 # define Builders
 #nddsBld = Builder(action = 'export NDDSHOME; NDDSHOME=' + nddsHome + '; ' + \

--- a/src/nvinfoproc/info_svc.c
+++ b/src/nvinfoproc/info_svc.c
@@ -19,7 +19,7 @@
  */
 
 
-#ifndef __INTERIX    /* not used in SFU, svc functions not supported, just ifdef out the entire file */
+#ifdef USE_RPC
 
 
 
@@ -336,4 +336,4 @@ void *acqinfo_svc(void *arg)
 }
 
 
-#endif
+#endif // USE_RPC

--- a/src/nvinfoproc/info_svc_funcs.c
+++ b/src/nvinfoproc/info_svc_funcs.c
@@ -9,7 +9,7 @@
 /* 
  */
 
-#ifndef __INTERIX    /* not used in SFU, svc functions not supported, just ifdef out the entire file */
+#ifdef USE_RPC
 
 
 #include <sys/types.h>
@@ -666,4 +666,4 @@ SVCXPRT        *transp;
 }
 #endif
 
-#endif
+#endif  // USE_RPC

--- a/src/nvinfoproc/infoproc.c
+++ b/src/nvinfoproc/infoproc.c
@@ -163,7 +163,7 @@ char *argv[];
 
     /* acqinfo_svc(); never return, need to make thread safe and call in a separate thread */
 
-#ifndef __INTERIX    /* not used in SFU, svc / rpc functions not supported */
+#ifdef USE_RPC
     start_svc_thread();
 #endif
 
@@ -247,7 +247,7 @@ void asyncMainLoop(sigset_t sigMask)
                case SIGTERM: /* TERM */
                case SIGQUIT: /* QUIT */
                     /* DPRINT1(-1,"Infproc: Received SIGINIT, SIGTERM, or SIGQUIT; SigNumber: %d\n",signo); */
-#ifndef __INTERIX
+#ifdef USE_RPC
     		    close_rpc();
 #endif
                     DestroyDomain();
@@ -261,7 +261,7 @@ void asyncMainLoop(sigset_t sigMask)
                     break;
  
                default:
-#ifndef __INTERIX
+#ifdef USE_RPC
     		    close_rpc();
 #endif
                     exit(1);

--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -135,6 +135,11 @@ do
   fi
 done
 
+if [[ $ddrAcq -eq 0 ]] && [[ $miAcq -eq 0 ]] && [[ $b12Acq -eq 0 ]]
+then
+   ddrAcq=1
+fi
+
 if [[ $ovjRepo -eq 0 ]] && [[ $noPing -eq 0 ]]
 then
   ping -4 -W 1 -c 1 google.com > /dev/null 2>&1
@@ -407,7 +412,6 @@ if [ ! -x /usr/bin/dpkg ]; then
   elif [ $version -ge 8 ]; then
     epelList="$epelList kdiff3 k3b ImageMagick rsh rsh-server"
     commonList="$commonList tcsh compat-openssl10 compat-libgfortran-48"
-    package68List="$package68List libtirpc-devel"
     packageList="$item68List $commonList $pipeList java-1.8.0-openjdk libnsl gnuplot xinetd"
   else
     epelList="$epelList scons meld x11vnc"
@@ -532,11 +536,6 @@ if [ ! -x /usr/bin/dpkg ]; then
           subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms" &>> $logfile
         fi
         yumList="$yumList sharutils"
-    elif [[ $version -ge 8 ]]; then
-      if [ "$(rpm -q libtirpc-devel.i686 |
-	    grep 'not installed' > /dev/null;echo $?)" == "0" ]; then
-          yum -y install --enablerepo="crb" libtirpc-devel.i686 &>> $logfile
-      fi
     fi
     if [ "x$yumList" != "x" ]; then
       yum -y install $yumList &>> $logfile
@@ -731,7 +730,8 @@ else
      apt-get -y install dpkg-dev &>> $logfile
      dpkg --add-architecture i386
   fi
-  apt-get $repoArg -y install tcsh make expect bc git scons g++ gfortran \
+  apt-get $repoArg -o DPkg::Options::="--force-confnew" -y install \
+      tcsh make expect bc git scons g++ gfortran \
       openssh-server mutt sharutils sendmail-cf gnome-power-manager \
       kdiff3 libcanberra-gtk-module ghostscript imagemagick vim xterm \
       gedit dos2unix zip cups gnuplot gnome-terminal enscript rpcbind \

--- a/src/stat/SConstruct
+++ b/src/stat/SConstruct
@@ -47,13 +47,13 @@ statEnv = Environment(CCFLAGS    = '-O2 -m32',
                       LINKFLAGS  = '-O2 -m32 -Wl,-rpath,/vnmr/lib ',
                       CPPPATH    = [cwd])
 
-if os.path.exists('/usr/include/tirpc'):
-   statEnv.Append(  CPPPATH=[ '/usr/include/tirpc']  )
-   LibList = [ 'm', 'acqcomm', 'tirpc' ]
-   LibList2 = [ 'tirpc' ]
-else:
-   LibList = [ 'm', 'acqcomm' ]
-   LibList2 = []
+# if os.path.exists('/usr/include/tirpc'):
+#    statEnv.Append(  CPPPATH=[ '/usr/include/tirpc']  )
+#    LibList = [ 'm', 'acqcomm', 'tirpc' ]
+#    LibList2 = [ 'tirpc' ]
+# else:
+LibList = [ 'm', 'acqcomm' ]
+LibList2 = []
 
 buildMethods.makeSymLinks(statEnv, infostatTarget, cwd, xracqPath, xracqHdrList)
 buildMethods.makeSymLinks(statEnv, infostatTarget, cwd, acqProcPath, acqProcHdrList)

--- a/src/stat/acqinfo_proc.c
+++ b/src/stat/acqinfo_proc.c
@@ -7,6 +7,7 @@
  * For more information, see the LICENSE file.
  */
 
+#ifdef USE_RPC
 /*
 * acqinfo_proc.c: implementation of remote procedure for acqinfo_svc
 *       There must be a file in /vnmr/acqqueue named acqinfo in the form:
@@ -238,3 +239,4 @@ ft3ddata	*ft3dargs;
 
    return(&status);
 }
+#endif // USE_RPC

--- a/src/stat/acqinfo_xdr.c
+++ b/src/stat/acqinfo_xdr.c
@@ -7,10 +7,9 @@
  * For more information, see the LICENSE file.
  */
 
+#ifdef USE_RPC
+
 #include <sys/types.h>
-#ifdef AIX
-#include <sys/select.h>	/* IBM AIX OS needs it, but not present on SUN */
-#endif
 #include <rpc/rpc.h>
 #include "acqinfo.h"
 /*-------------------------------------------------------------
@@ -88,3 +87,5 @@ ft3ddata	*objp;
    }
    return (TRUE);
 }
+
+#endif  // USE_RPC

--- a/src/stat/showstat.c
+++ b/src/stat/showstat.c
@@ -8,6 +8,8 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/file.h>
@@ -15,15 +17,14 @@
 #include <fcntl.h>
 #include <pwd.h>
 #include <sys/socket.h>
-#ifdef SOLARIS
-#include <sys/sockio.h>
-#endif
 #include <netinet/in.h>
 #include <netdb.h>
+#ifdef USE_RPC
 #include <rpc/types.h>
 #include <rpc/rpc.h>
-
 #include "acqinfo.h"
+#endif
+
 #include "ACQPROC_strucs.h"
 #include "STAT_DEFS.h"
 
@@ -65,6 +66,7 @@ static int  Acqmsgport; /* acquisition's async message socket port */
 static char AcqHost[HOSTLEN]; /* acquisition's machine name */
 
 
+#ifdef USE_RPC
 static CLIENT *client = NULL;  /* RPC client handle */
 
 /*-------------------------------------------------------------
@@ -191,6 +193,7 @@ char *hostname;
 
 	return(info.pid_active);
 }
+#endif // USE_RPC
 
 /*--------------------------------------------------------------------*/
 
@@ -233,12 +236,14 @@ char *argv[];
 /*  WARNING:  any address fields in local_entry not explicitly set
               may be reset the next time you call gethostbyname.	*/
 
+#ifdef USE_RPC
 	if (argc > 1) {
 		strcpy( RemoteHost, argv[ 1 ] );
 		if (initrpctcp( RemoteHost ) < 0)
 		  exit( 1 );
 	}
 	else
+#endif
 	  strcpy(RemoteHost,LocalHost);
 
     /* --- get user's name --- */
@@ -364,10 +369,12 @@ char *remotehost;
 	FILE *stream;
 	extern char *getenv();
  
+#ifdef USE_RPC
 	if ( (remotehost != NULL) &&
 	     (remotehost[0] != '\0') &&
 	     (strcmp(remotehost,LocalHost) != 0) )
 	  return(getinfo(remotehost));
+#endif
 
 	tmpptr = (char *)getenv("vnmrsystem");            /* vnmrsystem */
 	strcpy(filepath,tmpptr);

--- a/src/stat/statusscrn.c
+++ b/src/stat/statusscrn.c
@@ -385,8 +385,10 @@ int main(int argc, char *argv[])
 	create_Bframe(argc, argv);
 	create_Statuspanel();
 #endif
+#ifdef USE_RPC
 	if ((strcmp(RemoteHost, LocalHost)) && (RemoteHost[0] != '\0'))
 		initrpctcp(RemoteHost);
+#endif
 	/* to obtain acq. status info */
 	DoTheChores(0);
 #ifdef MOTIF


### PR DESCRIPTION
By compiling  beta1 on AlmaLinux 8, it included the tirpc library in Infoproc, Infostat, and showstat. However, tirpc does not exist on Ubuntu. Only the (unused) rpc functions of Infoproc, Infostat, and showstat need rpc functionality. Put all rpc functions within "#ifdef USE_RPC" sections of code.