### PR TITLE
Miscalculation in dsnpeak macro

### DIFF
--- a/src/common/maclib/dsnpeak
+++ b/src/common/maclib/dsnpeak
@@ -30,7 +30,7 @@ endif
 if ($peak=llfrq) then
 	$i=1
 	repeat
-		$peak[$i]=llfrq[$i]-rfl-rfp
+		$peak[$i]=llfrq[$i]-rfl+rfp
 		$i=$i+1
 	until $i>size('$peak')
 endif


### PR DESCRIPTION
Typo is calculating reference frequencies (-rfp -> +rfp) This resolves issue #910