### PR TITLE
Fix some typos in error messages: before they could be misleading

### DIFF
--- a/src/nvpsg/soliddecshapes.h
+++ b/src/nvpsg/soliddecshapes.h
@@ -1435,7 +1435,7 @@ void _dseqoff(DSEQ dseq)
 
 void _dseqon2(DSEQ dseq)
 {
-  printf("Sequence uses _dseqon2 statement which will be obsolete soon.Please, use _dseqon instead which provides the same functionality\n");
+  printf("Sequence uses _dseqon2 statement which will be obsolete soon. Please, use _dseqon instead which provides the same functionality\n");
   _dseqon(dseq);
 }
 

--- a/src/nvpsg/solidmpseqs.h
+++ b/src/nvpsg/solidmpseqs.h
@@ -421,7 +421,7 @@ MPSEQ getpasl(char *seqName,int iph,double p, double phint, int iRec, int calc)
    f.nRec = iRec;
    f.phInt = phint;
    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 2) {
-      printf("Error in getpuls(). The sequence name %s is invalid!\n",seqName);
+      printf("Error in getpasl(). The sequence name %s is invalid!\n",seqName);
       psg_abort(-1);
    }
    sprintf(f.seqName,"%s",seqName);
@@ -1174,7 +1174,7 @@ MPSEQ getfslg(char *seqName, int iph, double p, double phint, int iRec, int calc
    extern MPSEQ MPchopper(MPSEQ f);
 
    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
-        printf("Error in getfslg1(). The type name %s is invalid!\n",seqName);
+        printf("Error in getfslg(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
    sprintf(f.seqName,"%s",seqName);
@@ -2732,7 +2732,7 @@ MPSEQ getpipsxy(char *seqName, int iph, double p, double phint, int iRec, int ca
    MPSEQ pips = {};
    extern MPSEQ MPchopper(MPSEQ pips);
    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
-        printf("Error in getpips(). The type name %s is invalid!\n",seqName);
+        printf("Error in getpipsxy(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
    sprintf(pips.seqName,"%s",seqName);
@@ -4354,7 +4354,7 @@ MPSEQ gettmrev5(char *seqName, int iph, double p, double phint, int iRec, int ca
    MPSEQ tm = {};
    extern MPSEQ MPchopper(MPSEQ tm);
    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
-        printf("Error in gettmrev(). The type name %s is invalid!\n",seqName);
+        printf("Error in gettmrev5(). The type name %s is invalid!\n",seqName);
         psg_abort(1);
    }
    sprintf(tm.seqName,"%s",seqName);
@@ -4998,7 +4998,7 @@ MPSEQ getsuper(char *seqName, int iph, double p, double phint, int iRec, int cal
 
    double del = taur - 2.0*taua - 8.0*lpw;
    if (del < 0.0) {
-      printf("Error in getsuper(). tauR to small!");
+      printf("Error in getsuper(). tauR too small!");
       psg_abort(1);
    }
 
@@ -5096,7 +5096,7 @@ MPSEQ getdumboxmx(char *seqName, int iph, double p, double phint, int iRec, int 
    char *var;
    extern MPSEQ MPchopper(MPSEQ pm);
    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
-      printf("Error in getdumbo(). The type name %s is invalid!\n",seqName);
+      printf("Error in getdumboxmx(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
    sprintf(pm.seqName,"%s",seqName);
@@ -5247,7 +5247,7 @@ MPSEQ getdumbogen(char *seqName, char *coeffName, int iph, double p, double phin
    extern MPSEQ MPchopper(MPSEQ dumbo);
 
    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
-      printf("Error in getdumbogeneric(). The type name %s is invalid!\n",seqName);
+      printf("Error in getdumbogen(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
    sprintf(dumbo.seqName,"%s",seqName);

--- a/src/nvpsg/solidobjects.h
+++ b/src/nvpsg/solidobjects.h
@@ -2384,7 +2384,7 @@ WMPA getwdumbogen(char *seqName, char *coeffName)
    var = getname0("q",coeffName,"");
    int steps = getval(var);
    if (steps > 512) {
-   	printf("too many steps: %d\n",steps);
+	printf("too many steps: %d (max = 512)\n",steps);
 	psg_abort(1);
    }
 

--- a/src/nvpsg/solidpulses.h
+++ b/src/nvpsg/solidpulses.h
@@ -304,7 +304,7 @@ SHAPE getsinc(char *seqName, double p, double phint, int iRec, int calc)
    var = getname0("nzc",s.pars.seqName,"");
    s.pars.ip[0] = getval(var);
    if ( s.pars.ip[0]%2) {
-      printf("Error in getSINC. Number of zero crossings must be even! \n");
+      printf("Error in getsinc(). Number of zero crossings must be even! \n");
       psg_abort(1);
    }
    s.pars.array = disarry(var, s.pars.array);
@@ -332,7 +332,7 @@ SHAPE gettanramp(char *seqName, double p, double phint, int iRec, int calc)
    s.get_state = tanramp_state;
 
    if (strlen(seqName) >= NSUFFIX  || strlen(seqName) < 1) {
-      printf("Error in getsfmpulse(). The type name %s is invalid!\n",seqName);
+      printf("Error in gettanramp(). The type name %s is invalid!\n",seqName);
       psg_abort(1);
    }
    sprintf(s.pars.seqName,"%s",seqName);


### PR DESCRIPTION
Some of the error messages in the nvpsg directory had typos that could mislead the end user on where the problems lay.