### PR TITLE
setpage to display parameter pages did not always work

### DIFF
--- a/src/common/maclib/customizepar
+++ b/src/common/maclib/customizepar
@@ -297,7 +297,7 @@ IF ($arg='start') or ($arg='updateacqpars') THEN
 	showtray('close')
    	$page='Quick'
    	if (seqfil='s2pul') and (seqfil<>pslabel) then
-	    $page='Quick'+tn
+	    $page='Default '+tn
    	endif
    	vnmrjcmd('setpage','Acquire',$page)
    else

--- a/src/vnmrj/src/vnmr/ui/ParamLayout.java
+++ b/src/vnmrj/src/vnmr/ui/ParamLayout.java
@@ -42,6 +42,7 @@ public class ParamLayout extends ParamPanel
     private Vector<Component> tabs;
     private Component seltab=null;
     private String selLabel=null;
+    private String selectedPage=null;
     private JList tabList=null;
     private HashMap menu_names;
     private ParameterPanel paramPanel=null;
@@ -90,6 +91,10 @@ public class ParamLayout extends ParamPanel
     }
     public ParameterPanel getParameterPanel() {
         return paramPanel;
+    }
+
+    public void saveSelectedPage(String name) {
+        selectedPage = name;
     }
 
     public void setTabList(JList t) {
@@ -462,7 +467,14 @@ public class ParamLayout extends ParamPanel
         boolean inlist=isTabLabel(s);
         if((inlist && !vis) || (!inlist && vis)){
             buildTabMenu();
-            setLastSelectedTab();
+            if (vis && (selectedPage!= null ) &&
+                selectedPage.equals(s) )
+            {
+                selectTab(selectedPage);
+                selectedPage = null;
+            } else {
+                setLastSelectedTab();
+            }
         }
     }
 

--- a/src/vnmrj/src/vnmr/ui/ParameterPanel.java
+++ b/src/vnmrj/src/vnmr/ui/ParameterPanel.java
@@ -225,6 +225,8 @@ public class ParameterPanel extends JLayeredPane implements StatusListenerIF, Pr
         setDebug("selectPage("+page+") index "+listModel.indexOf(page));
         if (paramLayout != null && listModel.contains(page)){
             tabList.setSelectedValue(page, true);
+        } else if (paramLayout != null ) {
+            paramLayout.saveSelectedPage(page);
         }
     }
 


### PR DESCRIPTION
The call to vnmrjcmd('setpage',...) may fail because it is received by vnmrj.jar before the "show conditions" to determine if the page is active may not have been evaluated yet. Also, the setpage uses the page label, not the xml file from which it is made.