### PR TITLE
Renamed ovjGetps2pdf to ovjMacTools

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,6 +1,51 @@
 OpenVnmrJ Release Notes.
 
 August 2024 -
+    pageview could fail on MacOS due to missing ps2pdf script.
+      Added ovjMacTools script to install it. It will also install
+      ImageMagick and xterm. For help information, run
+      ovjMacTools -h
+    ArrayedSpectra vertical panel could reset display to a full array when
+      a partial set of array elements had been selected (Thanks to Bert Heise).
+    Documented how to set fonts in a dialog popup (see manual/dialog).
+    load.nmr will run a non-interactive config to reset values to those from
+      a previous installation.
+    When double clicking the carbon experiment in the study queue to adjust any
+      Carbon parameters, the window usually opens to the Acquisition parameter
+      window instead of the Default C13. It now works like everything else.
+    Removed CRAFT and ChemPack information from getversion
+    Added unit 't' for 'msec'
+    Help Overlay no longer is displayed by default
+      It is still available from the Help menu.
+    Added a button to mtune interface to toggle normal and wide line widths
+      Suggestion from Ken Knott
+    Fix some typos in  solidspack PSG error messages
+    Additions from Bert Heise.
+      new centerprobe macro and corresponding button on the gmapz panel
+      Autotest calibration does Hdec and Cobs in addition to Hobs & Cdec.
+      The Edit Probe popup window had overlapping widgets making it difficult
+        to click/select the widgets in the top row (Add/Delete Nucleus etc.)
+      LkGmap creates a z5 shimmap even for db-style probes while lkZ0 checks
+        for the probe style and (correctly so) creates a z4 map only.
+        Changed lkGmap to do the same style check and z4 map making.
+      3D gradshim log file reading & writing of temporary best shims fails
+        on widebore shim sets because
+        (A) Wide-Bore shims (shimset=12) is unnecessarily excluded from writing
+            the power dissipation into the log file
+        (B) the latter creates a second "NA" entry into the log file which is
+            then later being searched for (to determine the first word in each
+            data line which is a poor way to read the second column via
+            lookup('seekcs','NA','read') because there MIGHT be a number in
+            Linewidth column whereupon the lookup will completely fail
+            or the second NA entry lets the lookup fall over as well, leading
+            to an "expected REAL value" error because the next column behind
+            the "NA" power is a name, not a number
+      Added INADEQUATE experiment for Mercury
+      Added DbppLED DOSY experiment for all consoles
+        Longitudinal eddy current compensation (may greatly improve phase behaviour)
+      Veripulse now has faster 3D gradient shimming with doped ASTM
+    Added tools to build a patch for ARM architecture. Change into patch directory and run
+      scons -f SConstructpath_arm
     makeuser no longer removes files from psg, seqlib, or
       persistence user directories. These operations are now
       performed by the fixuser script.
@@ -32,10 +77,6 @@ August 2024 -
       DSS  -  Fiddle definition for DSS
       TMSc -  Fiddle definition for TMS, without using 13C satellites
       DSSc -  Fiddle definition for DSS, without using 13C satellites
-    Added INADEQUATE experiment for Mercury (Thanks to Bert Heise)
-    Added DbppLED DOSY experiment for all consoles (Thanks to Bert Heise)
-      Longitudinal eddy current compensation (may greatly improve phase behaviour)
-    Veripulse now has faster 3D gradient shimming with doped ASTM (Thanks to Bert Heise)
     getfile on MacOS could fail when used with -R. The returned pathnames
       could be prefaced with a /
     Compile Vnmrbg on MacOS for both x86_64 and arm64 architectures
@@ -91,8 +132,6 @@ August 2024 -
     Added support for parentheses "()" in filenames
     Updated installpkgs to support Ubuntu ARM architecture
     Updated build documentation for Macs. See ovjTools/OSX.md.
-    pageview could fail on MacOS due to missing ps2pdf script.
-      Added ovjGetps2pdf script to install it.
     Vnmr.jar was failing to compile with java 22.
     Updates to support compiling on Mac Silicon systems.
     upgrade.nmr should not replace loggingParamList

--- a/src/common/maclib/pageview
+++ b/src/common/maclib/pageview
@@ -67,7 +67,7 @@ if ($ps2pdfex = 0) then
       endif
     endif
     if ($ps2pdfex = 0) then
-      write('error','Postscript to PDF conversion tool not installed. From a terminal, run ovjGetps2pdf')
+      write('error','Postscript to PDF conversion tool not installed. From a terminal, run ovjMacTools')
       return
     endif
     $ps2pdfex=2

--- a/src/common/user_templates/.vnmrenvbash
+++ b/src/common/user_templates/.vnmrenvbash
@@ -48,3 +48,9 @@ export XFILESEARCHPATH=$home/%T/%N%S:$vnmrsystem/%T/%N%S
 
 # DICOM dcmtk dictionary path
 export DCMDICTPATH=$vnmrsystem/lib/dicom.dic
+
+if [ -f /opt/homebrew/bin/brew ]; then
+   eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -f /usr/local/bin/brew ]; then
+   eval "$(/usr/local/bin/brew shellenv)"
+fi

--- a/src/macos/ovjMacTools.sh
+++ b/src/macos/ovjMacTools.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# Copyright (C) 2017  Dan Iverson
+#
+# You may distribute under the terms of either the GNU General Public
+# License or the Apache License, as specified in the LICENSE file.
+#
+# For more information, see the LICENSE file.
+#
+#Uncomment next line for debugging output
+# set -x
+
+SCRIPT=$(basename "$0")
+
+ovj_usage() {
+    cat <<EOF
+
+usage:
+
+    $SCRIPT will install the Postscript to PDF conversion (ps2pdf)
+    tool for MacOS and / or ImageMagick and / or xterm. It will first
+    install brew if needed. The ps2pdf script is part of Ghostscript.
+
+    $SCRIPT
+       Installs ghostScript, ImageMagick, and xterm and brew if needed
+
+    $SCRIPT -h
+       Displays this help information
+
+    $SCRIPT -b
+       Installs brew only
+
+    $SCRIPT -g
+       Installs ghostScript (i.e., ps2pdf) and brew if needed
+
+    $SCRIPT -i
+       Installs ImageMagick and brew if needed
+
+    $SCRIPT -x
+       Installs xterm and brew if needed
+EOF
+    exit 1
+}
+
+brewOnly="n"
+ghostOnly="n"
+imageOnly="n"
+xtermOnly="n"
+# process flag args
+while [ $# -gt 0 ]; do
+    key="$1"
+    case $key in
+        -h|--help)              ovj_usage    ;;
+        -vv|--debug)            set -x ;;
+        -b)                     brewOnly="y"  ;;
+        -i)                     imageOnly="y"; ghostOnly="n"; xtermOnly="n" brewOnly="n"  ;;
+        -g)                     ghostOnly="y"; imageOnly="n"; xtermOnly="n" brewOnly="n"  ;;
+        -x)                     xtermOnly="y"; imageOnly="n"; ghostOnly="n" brewOnly="n"  ;;
+        *)
+            # unknown option
+            echo "unrecognized argument: $key"
+            ovj_usage
+            ;;
+    esac
+    shift
+done
+
+ostype=$(uname -s)
+if [[ $ostype != "Darwin" ]] && [[ $ostype != "darwin" ]]; then
+   echo "$0 only works on MacOS systems"
+   exit
+fi
+
+if [[ -z $(type -t brew) ]]; then
+   echo "Installing brew"
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+if [ -f /opt/homebrew/bin/brew ]; then
+   eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -f /usr/local/bin/brew ]; then
+   eval "$(/usr/local/bin/brew shellenv)"
+fi
+if [[ $brewOnly = "n" ]]; then
+   if [[ $ghostOnly = "n" ]] && [[ $imageOnly = "n" ]] &&
+      [[ $xtermOnly = "n" ]]; then
+      echo "Installing Postscript to PDF conversion tool, ImageMagick and xterm"
+      brew install ghostscript imagemagick xterm
+      brew install --cask xquartz
+   elif [[ $ghostOnly = "y" ]]; then
+      echo "Installing Postscript to PDF conversion tool"
+      brew install ghostscript
+   elif [[ $imageOnly = "y" ]]; then
+      echo "Installing ImageMagick"
+      brew install imagemagick
+   elif [[ $xtermOnly = "y" ]]; then
+      echo "Installing xterm"
+      brew install xterm
+      brew install --cask xquartz
+   fi
+fi
+

--- a/src/scripts/ovjmacout.sh
+++ b/src/scripts/ovjmacout.sh
@@ -94,8 +94,8 @@ cp vnmrj.sh $vjdir/bin/vnmrj
 chmod 755 $vjdir/bin/vnmrj
 cp ovjFixMac.sh $vjdir/bin/ovjFixMac
 chmod 755 $vjdir/bin/ovjFixMac
-cp ovjGetps2pdf.sh $vjdir/bin/ovjGetps2pdf
-chmod 755 $vjdir/bin/ovjGetps2pdf
+cp ovjMacTools.sh $vjdir/bin/ovjMacTools
+chmod 755 $vjdir/bin/ovjMacTools
 mv $vjdir/maclib/_sw_ddr $vjdir/maclib/_sw
 
 echo "vnmrs" >> $vjdir/vnmrrev 


### PR DESCRIPTION
ovjMacTools now gets other items for OVJ that may be missing. These include convert (ImageMagick) and xterm (xQuartz and xterm). Updated Notes.txt