### PR TITLE
Replace some nonstandard constants with the DTCK define

### DIFF
--- a/src/nvpsg/pboxpulse.h
+++ b/src/nvpsg/pboxpulse.h
@@ -302,7 +302,7 @@ PBOXPULSE getpboxpulse(char *seqName, int iRec, int calc)
    double srate = getval("srate");
    double taur = 2.0e-4;
    if (srate >= 500.0)
-      taur = roundoff((1.0/srate), 0.0125e-6);
+      taur = roundoff((1.0/srate), DTCK);
    else {
       printf("ABORT: Spin Rate (srate) must be greater than 500\n");
       psg_abort(1);
@@ -411,7 +411,7 @@ PBOXPULSE getrefpboxpulse(char *seqName, int iRec, int calc)
    double srate = getval("srate");
    double taur = 2.0e-4;
    if (srate >= 500.0)
-      taur = roundoff((1.0/srate), 0.0125e-6);
+      taur = roundoff((1.0/srate), DTCK);
    else {
       printf("ABORT: Spin Rate (srate) must be greater than 500\n");
       psg_abort(1);

--- a/src/nvpsg/solidobjects.h
+++ b/src/nvpsg/solidobjects.h
@@ -1158,7 +1158,7 @@ WMPA getwpmlg(char *seqName)
 
 // Set PMLG pulse
 
-   mp.pw  = roundoff(mp.pw/mp.q, 0.0125e-6);
+   mp.pw  = roundoff(mp.pw/mp.q, DTCK);
 
 // Double mp.q for +/- phase steps and and create v-vars for the nested loop
 
@@ -1355,7 +1355,7 @@ WMPA getwdumbo(char *seqName)
 
 // Set DUMBO pulse
 
-   mp.pw  = roundoff(mp.pw/64.0, 0.0125e-6);
+   mp.pw  = roundoff(mp.pw/64.0, DTCK);
 
 // Double mp.q for +/- phase steps and and create v-vars for the nested loop
 
@@ -1492,7 +1492,7 @@ WMPA getwdumbot(char *seqName)
 
 // Set DUMBO pulse
 
-   mp.pw  = roundoff(mp.pw/64.0, 0.0125e-6);
+   mp.pw  = roundoff(mp.pw/64.0, DTCK);
 
 // Double mp.q for +/- phase steps and and create v-vars for the nested loop
 
@@ -1890,7 +1890,7 @@ WMPA getxmxwpmlg(char *seqName)
 
 // Set PMLG pulse
 
-   mp.pw  = roundoff(mp.pw/mp.q, 0.0125e-6);
+   mp.pw  = roundoff(mp.pw/mp.q, DTCK);
 
 // Double mp.q for +/- phase steps and and create v-vars for the nested loop
 
@@ -2149,7 +2149,7 @@ WMPA getwpmlgxmx(char *seqName)
 
 // Set PMLG pulse
 
-   mp.pw  = roundoff(mp.pw/mp.q, 0.0125e-6);
+   mp.pw  = roundoff(mp.pw/mp.q, DTCK);
 
 // Double mp.q for +/- phase steps and and create v-vars for the nested loop
 
@@ -2274,7 +2274,7 @@ WMPA getwdumboxmx(char *seqName)
 
 // Set the DUMBO pulse
 
-   mp.pw  = roundoff(mp.pw/64.0, 0.0125e-6);
+   mp.pw  = roundoff(mp.pw/64.0, DTCK);
 
 // Double mp.q for +/- phase steps and and create v-vars for the nested loop
 
@@ -2451,7 +2451,7 @@ WMPA getwdumbogen(char *seqName, char *coeffName)
 
 // Set DUMBO pulse
 
-   mp.pw  = roundoff(mp.pw/steps, 0.0125e-6);
+   mp.pw  = roundoff(mp.pw/steps, DTCK);
 
 // Double mp.q for +/- phase steps and and create v-vars for the nested loop
 


### PR DESCRIPTION
There were places in the solids derived code that used a 0.0125e-6 constant where it would be more clear and appropriate to use DTCK from soliddefs.h (which is 12.5e-9 and is the same as the former constant). This constant comes in for free when you include solidstandard.h which happens everywhere in the project that is relevant.

Dan, no rush. Merge at your convenience.