### PR TITLE
Suppress message about PDF conversion tool on OVJ startup.

### DIFF
--- a/src/common/maclib/pageview
+++ b/src/common/maclib/pageview
@@ -67,12 +67,16 @@ if ($ps2pdfex = 0) then
       endif
     endif
     if ($ps2pdfex = 0) then
-      write('error','Postscript to PDF conversion tool not installed. From a terminal, run ovjGetps2pdf')
+      if ($1 <> 'setup') then
+        write('error','Postscript to PDF conversion tool not installed. From a terminal, run ovjMacTools')
+      endif
       return
     endif
     $ps2pdfex=2
   else
-    write('error','Postscript to PDF conversion tool ( %s ) not installed.',$prog)
+    if ($1 <> 'setup') then
+      write('error','Postscript to PDF conversion tool ( %s ) not installed.',$prog)
+    endif
     return
   endif
 endif


### PR DESCRIPTION
Calling pageview('setup') is called on startup and would display the message. No more.