### PR TITLE
Updates for using NMRPipe

### DIFF
--- a/src/scripts/vnmrpipe.sh
+++ b/src/scripts/vnmrpipe.sh
@@ -17,7 +17,7 @@ if (!($?NMRBASE)) then
       if ( x$ostype == "xLinux" ) then
          source /vnmr/nmrpipe/com/vj_nmrInit.linux9.com
       else # MacOS
-         source /vnmr/nmrpipe/com/vj_nmrInit.mac.com
+         source /vnmr/nmrpipe/com/nmrInit.mac11_64.com
       endif
    endif
    source /vnmr/nmrpipe/dynamo/com/dynInit.com


### PR DESCRIPTION
Uses better bindir directory for MacOS. Added option to ovjGetpipe to specify the binType to use. Also makes a link in nmrpipe/com to the proper nmrInit*com file, which vnmrpipe script uses. This link may be a temporary fix, since the official NMRPipe mght do it in the future.