### PR TITLE
Could not view manuals with some versions of FireFox

### DIFF
--- a/src/scripts/vnmr_open.sh
+++ b/src/scripts/vnmr_open.sh
@@ -12,12 +12,6 @@ if [ ! -z "$url" ] ; then
    path=$url
 fi
 case "$ostype" in
-   cygwin | Interix )
-      opencmd="cmd /c start"
-      if [ -z "$url" ]; then 
-         path=$(unixpath2win "$1")
-      fi
-        ;;
    *inux*)   # Linux, linux, etc.
       # echo "linux"
       # opencmd="gnome-open"  deprecated
@@ -29,6 +23,7 @@ case "$ostype" in
       else 
          opencmd="gnome-open"
       fi
+      path=$(readlink -f $path)
         
         ;;
    *arwin*)  # Darwin, darwin


### PR DESCRIPTION
The snap version of FireFox does not allow access to pathnames with symbolic links. Since /vnmr is a link to /home/openvnmrj_<something>, it fails. Added readlink to vnmr_open to convert symbolic links to their cononical path name.