### PR TITLE
cexp will make maclib directory if needed

### DIFF
--- a/src/common/maclib/cexp
+++ b/src/common/maclib/cexp
@@ -46,6 +46,10 @@ endif
 "macro as a link to /vnmr/maclib/jexp1"
 
 if ($estr <> '' and $enum > 9) then
+    exists(userdir+'/maclib','directory'):$e
+    if ($e = 0) then
+       mkdir(userdir+'/maclib')
+    endif
     $jmacro=userdir+'/maclib/jexp'+$estr
     delete($jmacro,'')
     cp(systemdir+'/maclib/jexp1',$jmacro,'symlink'):$x


### PR DESCRIPTION
On MacOS, it was reported that ~/vnmrsys/maclib may not exist.