### PR TITLE
Added H2('lk') under Other Nuclei in the Experiment menu

### DIFF
--- a/src/common/templates/vnmrj/interface/MainMenuExpts.xml
+++ b/src/common/templates/vnmrj/interface/MainMenuExpts.xml
@@ -18,6 +18,7 @@
             <mchoice label = "Cd111" vc = "AuNuc('Cd111')" style="Menu1" />
             <mchoice label = "Cd113" vc = "AuNuc('Cd113')" style="Menu1" />
             <mchoice label = "H2" vc = "AuNuc('H2')" style="Menu1" />
+            <mchoice label = "H2(lk)" vc = "AuNuc('lk')" style="Menu1" />
             <mchoice label = "N15" vc = "AuNuc('N15')" style="Menu1" />
             <mchoice label = "O17" vc = "AuNuc('O17')" style="Menu1" />
             <mchoice label = "Pd105" vc = "AuNuc('Pd105')" style="Menu1" />


### PR DESCRIPTION
Sets up a deuterium experiment using the lock channel. Often used for debugging. (Thanks to Bert Heise)