### PR TITLE
Updates for NMRPipe

### DIFF
--- a/src/scripts/ovjGetpipe.sh
+++ b/src/scripts/ovjGetpipe.sh
@@ -19,6 +19,7 @@ SCRIPT=$(basename "$0")
 : ${OVJ_PIPETEST=0}
 : ${OVJ_BIN=""}
 : ${OVJ_PACKAGES=""}
+: ${OVJ_NO_PACKAGES=""}
 
 ovj_usage() {
     cat <<EOF
@@ -60,7 +61,8 @@ options:
     -v|--verbose              Use verbose output (default)
     -vv|--debug               Debug script
     -b|--bintype              Specify binary type of the OS
-    -p|--packages             Install Linux OS packages require by NMRPipe
+    -p|--packages             Install Linux OS packages required by NMRPipe
+    -n|--no-packages          Do not ask about installing Linux OS packages required by NMRPipe
 
 EOF
     exit 1
@@ -83,6 +85,7 @@ while [ $# -gt 0 ]; do
         -vv|--debug)            set -x ;;
         -b|--bintype)           OVJ_BIN="$2"; shift    ;;
         -p|--packages)          OVJ_PACKAGES="y"  ;;
+        -n|--no-packages)       OVJ_NO_PACKAGES="y"  ;;
         *)
             # unknown option
             echo "unrecognized argument: $key"
@@ -338,7 +341,6 @@ if [ -d /vnmr/nmrpipe ]; then
 fi
 mv nmrpipetmp  nmrpipe
 cd nmrpipe
-ask=0
 if [ "x${OVJ_INSTALL}" != "x" ] ; then
    $OVJ_VECHO "Copying NMRPipe files from ${OVJ_INSTALL}"
    cp ${OVJ_INSTALL}/install.com .
@@ -349,7 +351,6 @@ if [ "x${OVJ_INSTALL}" != "x" ] ; then
    cp ${OVJ_INSTALL}/talos_nmrPipe.tZ .
    cp ${OVJ_INSTALL}/plugin.smile.tZ .
 else
-   ask=1
    downloadFiles "/vnmr/nmrpipe"
 fi
 if [[ $? -ne 0 ]]; then
@@ -396,7 +397,7 @@ cleanup
 $OVJ_VECHO ""
 $OVJ_VECHO "NMRPipe installation complete"
 $OVJ_VECHO ""
-if [ $ask -eq 1 ] && [ x$(uname -s) = "xLinux" ]; then
+if [ "x${OVJ_NO_PACKAGES}" != "xy" ] && [ x$(uname -s) = "xLinux" ]; then
    echo " "
    echo "Would you like to install OS packages required by NMRPipe?"
    echo "It will require a sudo or root password. (y/n) "

--- a/src/scripts/vnmrsetup.sh
+++ b/src/scripts/vnmrsetup.sh
@@ -601,12 +601,6 @@ if [ -e /tmp/.ovj_installed ]; then
          su - $nmr_user -c "/vnmr/bin/ovjGetpipe $noPing -l $insLog"
       fi
       echo " "
-   elif [[ x$oldVnmr != "x" ]] ; then
-      if [[ -d $oldVnmr/nmrpipe ]] ; then
-         echo "Collecting NMRpipe from $oldVnmr"
-         cd $oldVnmr
-         tar cf - nmrpipe | (cd /vnmr && tar xpf -)
-      fi
    fi
    echo " "
    echo "New updates of NMRPipe may be installed at any time by running"


### PR DESCRIPTION
Added option to not ask if OS packages should be installed. If a previous nmrpipe installation exists, do not copy it to a new install since it may not have the link file and the latest 64-bit executables.