### PR TITLE
Eliminated some error messges

### DIFF
--- a/src/scripts/patchuninstall.sh
+++ b/src/scripts/patchuninstall.sh
@@ -78,12 +78,15 @@ uninstallPatch () {
       source $dir/p_uninstall
       rm p_uninstall
    fi
-   zip -qry patch.zip *
-   mv patch.zip $vnmrsystem
-   cd $vnmrsystem
+   fileList=$(ls)
+   if [[ ! -z $fileList ]]; then
+      zip -qry patch.zip *
+      mv patch.zip $vnmrsystem
+      cd $vnmrsystem
+      unzip -q -o patch.zip
+      rm patch.zip
+   fi
    rm -rf $dir
-   unzip -q -o patch.zip
-   rm patch.zip
    return 0
 }
 

--- a/src/scripts/vnmrpipe.sh
+++ b/src/scripts/vnmrpipe.sh
@@ -20,7 +20,9 @@ if (!($?NMRBASE)) then
          source /vnmr/nmrpipe/com/nmrInit.mac11_64.com
       endif
    endif
-   source /vnmr/nmrpipe/dynamo/com/dynInit.com
+   if ( -f /vnmr/nmrpipe/dynamo/com/dynInit.com ) then
+      source /vnmr/nmrpipe/dynamo/com/dynInit.com
+   endif
 endif
 
 if ($#argv == 1) then

--- a/src/vnmrbg/dfid.c
+++ b/src/vnmrbg/dfid.c
@@ -1244,7 +1244,7 @@ static int freebuffers()
   if(c_buffer>=0) /* release last used block */
     if ( (res=D_release(D_PHASFILE,c_buffer)) )
     {
-      D_error(res); 
+      // D_error(res); 
       D_close(D_PHASFILE);  
       return(ERROR);
     }


### PR DESCRIPTION
patchuninstall would give error about "zip had nothing to do" if the patchinstall only added files and directories but did not modify any existing files.
vnmrpipe would give error is the NMRPpe dynamo application was not installed.
If a fid is displayed (df) and then makefid makes a new fid, a subsequent ft would give a message about data file not open.