### PR TITLE
setNIC could fail on U24.

### DIFF
--- a/src/scripts/setNIC.sh
+++ b/src/scripts/setNIC.sh
@@ -142,7 +142,7 @@ EOF
 }
 
 addToNetplan() {
-   file=$(ls /etc/netplan/*yaml)
+   file=$(ls /etc/netplan/*network-manager*yaml)
    grep OpenVnmrJ $file > /dev/null
    if [[ $? -eq 0 ]]; then
       sed --in-place '/# OpenVnmrJ Start/,/# OpenVnmrJ End/d' $file


### PR DESCRIPTION
The /etc/netplan directory on U24 has more than a single file, which caused setNIC to fail. It now looks specifically for a "network-manager" yaml file.