### PR TITLE
ddff may return status of S_DDR bit

### DIFF
--- a/src/vnmr/ddf.c
+++ b/src/vnmr/ddf.c
@@ -303,6 +303,10 @@ int ddf(int argc, char *argv[], int retc, char *retv[])
             type[1] = '\0';
             retv[0] = newString(type);
          }
+         if (retc > 1)
+         {
+            retv[1] = intString((dhd.status & S_DDR) ? 1 : 0);
+         }
      }
 
      D_close(D_USERFILE);


### PR DESCRIPTION
If ddff is called to test the version id bit, if a second return value is requested, the status of the S_DDR bit in the status word is returned.