### PR TITLE
getfile on MacOS could fail when used with alphasort

### DIFF
--- a/src/vnmrbg/dirfuncs.c
+++ b/src/vnmrbg/dirfuncs.c
@@ -750,9 +750,17 @@ int getitem_sorted(char *dirname, int index, char *filename, char *fileCmp, int 
       if (found)
       {
          if ( (recurse) || (regExp == 3) )
+         {
+#ifdef MACOS
+            if ( node->fts_path[len] == '/')
+               len++;
+#endif
             strcpy(sortPath[cnt-1].path, &node->fts_path[len]);
+         }
          else
+         {
             strcpy(sortPath[cnt-1].path, node->fts_name);
+         }
       }
    }
    qsort( &sortPath[0], cnt, sizeof(struct sort), doSort);


### PR DESCRIPTION
The returned pathnames could be prefaced with a /
This is related to PR #892 and the fix is the same.