### PR TITLE
Error during Edit Probe when adding solvent factors.

### DIFF
--- a/src/common/maclib/ProbeEdit
+++ b/src/common/maclib/ProbeEdit
@@ -258,7 +258,7 @@ elseif $1='addSF' then
 
   $nfile=userdir+'/persistence/ProbeEdit_NewNuc'
   write('reset',$nfile)
-  SFSPcorrect(updateprobe,$nfile)
+  SFSPcorrect('updateprobe',$nfile)
 
   $nnattr='' $nnval=''
   readfile($nfile,'$nnattr','$nnval','','local'):$ns2


### PR DESCRIPTION
Variable updateprobe undefined. Bug reported in SpinSights. Fixed by Bert.