### PR TITLE
Updates to gradient shimming macros

### DIFF
--- a/src/common/maclib/Augmap
+++ b/src/common/maclib/Augmap
@@ -36,10 +36,10 @@ $dum=''
 beepoff
 if ($2 = 'lk') then
  gmapsys('setH2'):$dum
-  if $style='db' then nt=4 else nt=1 endif
+  if $style='db' or $style='atb' then nt=4 else nt=1 endif
   d1=2 pw=300 tpwr=38
   getparam('tpwr','lk'):tpwr
-  getparam('pw90','lk'):pw
+  getparam('pw90','lk'):pw90 pw(90)
   if (tpwr=0) then tpwr=38 endif
   if (pw=0) then pw=300 endif
 elseif ($2 = 'H1') then
@@ -49,7 +49,7 @@ elseif ($2 = 'hs') then
   gmapsys('setHSforH2'):$dum
   nt=2 d1=5 pw=300 tpwr=38
   getparam('tpwr','lk'):tpwr
-  getparam('pw90','lk'):pw
+  getparam('pw90','lk'):pw90 pw(90)
   if (tpwr=0) then tpwr=38 endif
   if (pw=0) then pw=300 endif
 else
@@ -114,7 +114,7 @@ IF ($1 = 1) THEN
 
  if (tn = 'lk') then
    wft('nodc') setref f full av peak:$ht,cr movetof
-   if $style='db' then nt=4 else nt=1 endif
+   if $style='db' or $style='atb' then nt=4 else nt=1 endif
    np=np/8 sb=at/3 sbs=sb/2
    if ($zgradtype='h') then
      sw=sw/8 
@@ -186,7 +186,7 @@ ENDIF
 
 IF ($1 = 3) THEN
 
-if $style='db' then gzsize=4 else gzsize=5 endif
+if $style='db' or $style='atb' then gzsize=4 else gzsize=5 endif
 gmap_findtof='n'
 
 if (tn = 'H1') then
@@ -308,7 +308,7 @@ if (tn <> 'lk') then
 endif
 seqfil='s2pul'
 d3=0 pw=0 nt=1 tpwr=0
-getparam('pw90','lk'):pw
+getparam('pw90','lk'):pw90 pw(90)
 getparam('tpwr','lk'):tpwr
 if (tpwr=0) then 
   if (pw=0) then pw=300 endif
@@ -324,7 +324,7 @@ else
    p1=2*pw nt=2
    Augmap(8)
   else
-   if $style='db' then nt=4 else nt=1 endif
+   if $style='db' or $style='atb' then nt=4 else nt=1 endif
    Augmap(3)
   endif
 endif
@@ -356,7 +356,7 @@ if ($zgradtype='h') then
  p1=2*pw nt=2 
  Augmap(8)
 else
- if $style='db' then nt=4 else nt=1 endif
+ if $style='db' or $style='atb' then nt=4 else nt=1 endif
  Augmap(3)
 endif
 beepon

--- a/src/common/maclib/gmapsys
+++ b/src/common/maclib/gmapsys
@@ -150,7 +150,7 @@ endif
 dn='H1' sw=15351 np=512 tpwr=42 pw=200 gain=26
 if probe<>'' then
   getparam('tpwr','lk'):tpwr
-  getparam('pw90','lk'):pw
+  getparam('pw90','lk'):pw90 pw(90)
 endif
 if (Console='mercury') then gain=10 endif
 d1=3 d2=0.001 d3=0,0.25 p1=0
@@ -225,7 +225,7 @@ endif
 dn='H1' tpwr=42 pw=200 sw=2000 np=512
 if probe<>'' then
   getparam('tpwr','lk'):tpwr
-  getparam('pw90','lk'):pw
+  getparam('pw90','lk'):pw90 pw(90)
 endif
 d1=3 d2=0.015 d3=0,0.25 gain=26
 fn='n' lb='n' sb='n' sbs='n' gf='n' gfs='n' awc='n'

--- a/src/common/maclib/lkGmap
+++ b/src/common/maclib/lkGmap
@@ -59,11 +59,11 @@ IF ($1 = 0) THEN
       nt=2 d1=5 pw=300 tpwr=38
     else
       gmapsys('setH2'):$dum
-      if $style='db' then nt=4 else nt=1 endif
+      if $style='db' or $style='atb' then nt=4 else nt=1 endif
       d1=2 pw=300 tpwr=38
     endif
     getparam('tpwr','lk'):tpwr
-    getparam('pw90','lk'):pw
+    getparam('pw90','lk'):pw90 pw(90)
     if (tpwr=0) then tpwr=38 endif
     if (pw=0) then pw=300 endif
     beepon
@@ -127,7 +127,7 @@ IF ($1 = 1) THEN
     cplog('s2pul','last'):$file,$asdir
     rt($asdir+'/'+$file)
     proc='ft' wft('nodc') setref f full av peak:$ht,cr movetof
-    if $style='db' then nt=4 else nt=1 endif
+    if $style='db' or $style='atb' then nt=4 else nt=1 endif
     np=np/8 sb=at/3 sbs=sb/2
     seqfil='gmapz'
     execprocess='proc=\'ft\' wft dssh'
@@ -192,7 +192,7 @@ ENDIF
 
 IF ($1 = 3) THEN
 
-    if $style='db' then gzsize=4 else gzsize=5 endif
+    if $style='db' or $style='atb' then gzsize=4 else gzsize=5 endif
     gmap_findtof='n'
     gzlvl = 1.1* gzlvl
     gmapauto('startmap','nogo','ow')
@@ -280,7 +280,7 @@ IF ($1 = 5) THEN
     gmapset('setsw')
 
     pw=0 tpwr=0
-    getparam('pw90','lk'):pw
+    getparam('pw90','lk'):pw90 pw(90)
     getparam('tpwr','lk'):tpwr
     $tpwr=tpwr
     exists('LKtpwr','parameter'):$parex
@@ -302,7 +302,7 @@ IF ($1 = 5) THEN
     else
   	full
   	d3=$d3optlk seqfil='gmapz'
-   	if $style='db' then nt=4 else nt=1 endif
+   	if $style='db' or $style='atb' then nt=4 else nt=1 endif
    	lkGmap(3)
     endif
 
@@ -332,7 +332,7 @@ IF ($1 = 6) THEN
     ds(1) full
     tpwr=$tpwr 
     d3=$d3optlk seqfil='gmapz'
-    if $style='db' then nt=4 else nt=1 endif
+    if $style='db' or $style='atb' then nt=4 else nt=1 endif
     lkGmap(3)
 
 ENDIF

--- a/src/common/maclib/lkZ0
+++ b/src/common/maclib/lkZ0
@@ -56,11 +56,11 @@ IF ($1 = 0) THEN
       nt=2 d1=5 pw=300 tpwr=38
     else
       gmapsys('setH2'):$dum
-      if $style='db' then nt=4 else nt=1 endif
+      if $style='db' or $style='atb' then nt=4 else nt=1 endif
       d1=2 pw=300 tpwr=38
     endif
     getparam('tpwr','lk'):tpwr
-    getparam('pw90','lk'):pw
+    getparam('pw90','lk'):pw90 pw(90)
     if (tpwr=0) then tpwr=38 endif
     if (pw=0) then pw=300 endif
     beepon
@@ -117,7 +117,7 @@ IF ($1 = 1) THEN
     cplog('s2pul','last'):$file,$asdir
     rt($asdir+'/'+$file)
     proc='ft' wft('nodc') setref f full av peak:$ht,cr movetof
-    if $style='db' then nt=4 else nt=1 endif
+    if $style='db' or $style='atb' then nt=4 else nt=1 endif
     np=np/8 sb=at/3 sbs=sb/2 sw=sw/4
     seqfil='gmapz'
     execprocess='proc=\'ft\' wft dssh'
@@ -182,7 +182,7 @@ ENDIF
 
 IF ($1 = 3) THEN
 
-    if $style='db' then $gzsize=4 else $gzsize=5 endif
+    if $style='db' or $style='atb' then $gzsize=4 else $gzsize=5 endif
     gmap_findtof='n'
     gzlvl = 1.1* gzlvl
     gmapauto('startmap','nogo','ow')
@@ -273,7 +273,7 @@ IF ($1 = 5) THEN
     gmapset('setsw')
 
     pw=0 tpwr=0
-    getparam('pw90','lk'):pw
+    getparam('pw90','lk'):pw90 pw(90)
     getparam('tpwr','lk'):tpwr
     $tpwr=tpwr
     exists('LKtpwr','parameter'):$parex
@@ -300,7 +300,7 @@ IF ($1 = 5) THEN
     else
   	full
   	d3=$d3optlk seqfil='gmapz'
-   	if $style='db' then nt=4 else nt=1 endif
+   	if $style='db' or $style='atb' then nt=4 else nt=1 endif
    	lkZ0(3)
     endif
 
@@ -330,7 +330,7 @@ IF ($1 = 6) THEN
     ds(1) full
     tpwr=$tpwr 
     d3=$d3optlk seqfil='gmapz'
-    if $style='db' then nt=4 else nt=1 endif
+    if $style='db' or $style='atb' then nt=4 else nt=1 endif
     lkZ0(3)
 
 ENDIF
@@ -397,8 +397,7 @@ IF ($1 = 9) THEN
     tof=0 nt=1 ss=0 at=2 f
     tpwr=45 pw=200
     getparam('tpwr','lk'):tpwr
-    getparam('pw90','lk'):pw90
-    pw(90)
+    getparam('pw90','lk'):pw90 pw(90)
     wstart='alock=\'u\' wstart=\'\'' 
     wnt='' 
     array=''


### PR DESCRIPTION
Wrong pulse angles shown during 1D gradshim. Value from probe file never loaded into pw90. Also, bad number of default scans for ATB probes. Bugs reported in SpinSights. Fixed by Bert.