### PR TITLE
The copy command could fail.

### DIFF
--- a/src/vnmr/shellcmds.c
+++ b/src/vnmr/shellcmds.c
@@ -709,7 +709,7 @@ int Cp(int argc, char *argv[], int retc, char *retv[])
        inode = buf.st_ino;
        nlink = buf.st_nlink;
        buf.st_ino = 0;
-       if ( (stat(toFile, &buf) == 0) && (S_ISDIR(buf.st_mode)) )
+       if ( ((res = stat(toFile, &buf)) == 0) && (S_ISDIR(buf.st_mode)) )
        {
           char tmpFile[MAXPATH];
           char *bname;
@@ -718,10 +718,10 @@ int Cp(int argc, char *argv[], int retc, char *retv[])
           bname = basename(tmpFile);
           strcat(toFile,"/");
           strcat(toFile,bname);
-          if (stat(toFile, &buf))
+          if ( (res = stat(toFile, &buf)) )
              buf.st_ino = 0;
        }
-       if ((inode == buf.st_ino) && (nlink == buf.st_nlink) )
+       if ((res == 0) && (inode == buf.st_ino) && (nlink == buf.st_nlink) )
        {
           if (retc)
           {


### PR DESCRIPTION
If the to_file does not exist, the logic could decide the from_file and to_file were the same. It depends an how the buf variable is initialized when the stat call fails. Now also checks the result of the stat call, which will be -1 if the file does not exist.