### PR TITLE
write, copystr, and appendstr support writing to multiple files

### DIFF
--- a/src/common/manual/append
+++ b/src/common/manual/append
@@ -114,6 +114,11 @@ will be the same as the array size of the $strvar. For example,
   $strvar=''
   append(<fromFile>, <optional filters>, '$strvar'):$total
 
+For copystr and appendstr, toFile can be a list of files if the list is preceded
+by the keyword 'tee'. For example
+  copystr('some string', <optional filters>, 'tee', toFile1, toFile2, toFile3)
+All arguments following the 'tee' keyword are treated as file names.
+
 If the input file is a "dos" type file, that is, the lines are terminated with a
 carriage return and line feed ('\r\n'), then any lines outputted to a file of returned
 to a calling macro will have the carriage returns ('\r') removed.

--- a/src/common/manual/write
+++ b/src/common/manual/write
@@ -13,6 +13,11 @@ write(device,template,arg,arg,..)	write formatted text to a device
 		'fileline', 'filename'		writes to file with no
                                                 automatic linefeed
                 'net',host, port                write to network
+                'files','$parname'              write to files specified by parameter
+                'filesline','$parname'          write to files specified by parameter with
+                                                no automatic linefeed
+                'filesline3','$parname'         write to files specified by parameter and
+                                                message on line 3.
   color:	'red','green','blue','cyan','magenta','yellow','orange','black','white'
                 'cursor','integral','threshold','scale','fid','spectrum','imaginary','parameter'
   template:	as template string in printf command
@@ -66,6 +71,10 @@ write(device,template,arg,arg,..)	write formatted text to a device
    If the output starts with "Warning: ", then writing to 'line3' with this output will
    strip the "Warning: " from the output and display the rest of the output in yellow
    in the toolbar message box. Note that a space is required after the colon.
+   A special format for 'line3' is where the first argument is a null string ('') and
+   'line3' is the second argument, as in write('','line3',...). This gives macros the
+   flexibility to do something like $dev='file' $file='/vnmr/tmp/a' or
+   $dev='' $file='line3' write($dev,$file,...)
 
    When writing to a file using the keyword 'file',  each write command
    automatically appends a carriage return (linefeed) to the end of the
@@ -76,6 +85,20 @@ write(device,template,arg,arg,..)	write formatted text to a device
    backslashes (\\) are interpreted as a carriage return.  With the
    'fileline' keyword, two backslashes will output a single backslash
    into the file.
+
+   Using the keywords 'files', 'filesline', or 'filesline3' allows writing to
+   multiple files. In each case, the second argument is the name of a local
+   parameter (i.e., $filenames) that has as its array elements the path names
+   of the files to write to. In all other ways, these keywords are analogous to
+   the 'file', 'fileline', and 'line3' keywords, respectively. For example,
+
+   $filenames='file1','file2','/vnmr/tmp/file3'
+   write('files','$filenames',template,arg1, arg2, ...)
+   write('filesline','$filenames',template,arg1, arg2, ...)
+   write('filesline3','$filenames',template,arg1, arg2, ...)
+
+   will write to file1, file2, and /vnmr/tmp/file3. Note the single quotes
+   around the $filenames parameter.
 
    When using the 'reset' option, the write command will create an empty file
    by the name of filename, the second argument. If the 'filename' file already

--- a/src/vnmr/shellcmds.c
+++ b/src/vnmr/shellcmds.c
@@ -709,7 +709,7 @@ int Cp(int argc, char *argv[], int retc, char *retv[])
        inode = buf.st_ino;
        nlink = buf.st_nlink;
        buf.st_ino = 0;
-       if ( (stat(toFile, &buf) == 0) && (S_ISDIR(buf.st_mode)) )
+       if ( ((res = stat(toFile, &buf)) == 0) && (S_ISDIR(buf.st_mode)) )
        {
           char tmpFile[MAXPATH];
           char *bname;
@@ -718,10 +718,10 @@ int Cp(int argc, char *argv[], int retc, char *retv[])
           bname = basename(tmpFile);
           strcat(toFile,"/");
           strcat(toFile,bname);
-          if (stat(toFile, &buf))
+          if ( (res = stat(toFile, &buf)) )
              buf.st_ino = 0;
        }
-       if ((inode == buf.st_ino) && (nlink == buf.st_nlink) )
+       if ((res == 0) && (inode == buf.st_ino) && (nlink == buf.st_nlink) )
        {
           if (retc)
           {
@@ -2016,6 +2016,7 @@ int appendCmd(int argc, char *argv[], int retc, char *retv[])
    int tailStage = -1;
    int headOK = 1;
    int lineOK = 0;
+   int teeFlag = 0;
    int fromStr;
    char *fromStrPtr = NULL;
    varInfo *v1 = NULL;
@@ -2610,6 +2611,25 @@ int appendCmd(int argc, char *argv[], int retc, char *retv[])
                      }
                   }
                }
+               else if ( !strcmp(argv[index],"tee") )
+               {
+                  if ( ! fromStr )
+                  {
+                     Werrprintf("%s: 'tee' option only available with copystr and appendstr",
+                                argv[0]);
+                     if (inFile)
+                        fclose(inFile);
+                     if (outFile)
+                        fclose(outFile);
+                     ABORT;
+                  }
+                  else
+                  {
+                     teeFlag = index;
+                     headOK = 0;
+                     break;
+                  }
+               }
                else
                {
                   if ( strcmp(argv[index],"nn") )
@@ -2625,7 +2645,7 @@ int appendCmd(int argc, char *argv[], int retc, char *retv[])
             }
          }
       }
-      if (lineOK)
+      if (lineOK && ! teeFlag)
       {
          lineCount++;
          if (wordCount >= 0)
@@ -2644,8 +2664,38 @@ int appendCmd(int argc, char *argv[], int retc, char *retv[])
       }
    }
 
+   if (lineOK && teeFlag)
+   {
+      int index;
+      if (outFile)
+         fprintf(outFile,"%s\n",inLine);
+      index = argc -2;
+      while ( strcmp(argv[index], "tee") )
+      {
+         fclose(outFile);
+         if ( !strncmp(argv[0], "app", 3) ) 
+            outFile = fopen(argv[index],"a");
+         else
+            outFile = fopen(argv[index],"w");
+         if (outFile == NULL)
+         {
+            if (retc)
+            {
+               retv[ 0 ] = intString(0);
+               RETURN;
+            }
+            Werrprintf("%s: cannot write to file %s",argv[0],argv[index]);
+            RETURN;
+         }
+         else
+         {
+            fprintf(outFile,"%s\n",inLine);
+         }
+         index--;
+      }
+   }
    // Handle case where only a null string is given
-   if (lineOK && !lineCount)
+   else if (lineOK && !lineCount)
    {
       lineCount++;
       if (outFile && tailStage && fromStr)


### PR DESCRIPTION
The write command supports three new devices, files, filesline, and filesline3. The second argument is a parameter name with the list of file names. The copystr and appendstr commands support the tee keyword. Changes are documented.