### PR TITLE
atcmd active keyword re-defined

### DIFF
--- a/src/common/manual/atcmd
+++ b/src/common/manual/atcmd
@@ -19,10 +19,10 @@ a jexp or run commands or macros which do not need experiment parameters.
 It will have access to global and systemglobal parameters.  The bootup macro
 will not be executed automatically. It can be called from the atcmd macro.
 
-If the 'active' argument is given, the macro will be executed
-by the Vnmr process that specified the atcmd. If that process is no longer
-active, the macro will be removed from the database. If that Vnmr process
-is still active, then the background Vnmr sends a message to the "active"
+If the 'active' argument is given, the macro will be executed by the Vnmr
+process that specified the atcmd. If that process is no longer running,
+any currently running foreground Vnmr process executed by the same user
+will be used. The background Vnmr sends a message to the "active"
 foreground Vnmr with the write('net',....) command. The actual format is
 
 write('net',<host>,<port>,`<atCommand>`)

--- a/src/vnmr/acqfuncs.c
+++ b/src/vnmr/acqfuncs.c
@@ -141,6 +141,7 @@ extern void      sleepMilliSeconds(int secs);
 extern double round_freq(double baseMHz, double offsetHz,
                   double init_offsetHz, double stepsizeHz);
 extern void setAppdirs();
+extern void checkVnmrch(char *name, int *port, int *pid);
 
 static int  no_experiment(char  *);
 static int  stop_acquisition(int, char *[], char [], char [], char []);
@@ -2510,17 +2511,21 @@ int atCmd(int argc, char *argv[], int retc, char *retv[])
             res = sscanf(cmd2do,"%d %d %[^\n]\n", &port, &pid, cmd2);
             if (res == 3)
             {
-		int err;
-		err = kill(pid, 0); /* Test for existence */
-		if (err == -1 && errno == ESRCH)
-                {
-                   repeatAt = 0;
-		}
-		else
-                {
-                   sprintf(cmd2do,"write('net','%s',%d,`%s`)\n", host, htons(port), cmd2);
+               int err;
+               err = kill(pid, 0); /* Test for existence */
+               if (err == -1 && errno == ESRCH)
+               {
+                  port = pid = 0;
+                  checkVnmrch(user, &port, &pid);
+                  if (port)
+                     sprintf(cmd,"%d %d %s",port,pid,cmd2);
+               }
+               if (port)
+               {
+                   sprintf(cmd2do,"write('net','%s',%d,`%s`)\n",
+                            host, htons(port), cmd2);
                    doCmd = 1;
-                }
+               }
                
             }
             else


### PR DESCRIPTION
It used to mean the OVJ that initially called the atcmd. It now means the OVJ that initially called atcmd or any currently running foreground OVJ started by the same user. An atcmd entry called with the 'active' keyword will not be removed from the atcmd queue if there is no OVJ to execute it.