### PR TITLE
Link for Spinsights Community Help Site fixed

### DIFF
--- a/src/common/templates/vnmrj/interface/MainMenuHelp.xml
+++ b/src/common/templates/vnmrj/interface/MainMenuHelp.xml
@@ -13,8 +13,8 @@
                 show="exists('/vnmr/help/WebHelp/whnjs.htm','file','r'):$SHOW"
                 style="Menu1"
         />
-	<mchoice label = "Spinsights Slack Community Help Site..."
-		vc = " vnmrjcmd('help','http://ivan-spinsights.slack.com')"
+	<mchoice label = "Spinsights Community Help Site..."
+		vc = " vnmrjcmd('help','http://ivan-spinsights.zulipchat.com')"
 		style="Menu1"
 	/>
 	<mchoice label = "Help Overlay..."


### PR DESCRIPTION
In the Help menu, it now points to the site on zulip