### PR TITLE
Compiling imaging sequences gave warnings.

### DIFF
--- a/src/nvpsg/sglCommon.c
+++ b/src/nvpsg/sglCommon.c
@@ -6749,7 +6749,7 @@ int mergeGradient (char *waveform1, char *waveform2,
 
    while (!strstr(inString1, start))
    {
-      ret = fscanf(fpin1, "%s", inString1);
+      ret = fscanf(fpin2, "%s", inString1);
    }
    while (!feof(fpin2))
    {
@@ -6771,7 +6771,6 @@ int mergeGradient (char *waveform1, char *waveform2,
          points2 += atoi(inString2);
       }
    }
-   fclose(fpin1); /* close first input file */   
    fclose(fpin2); /* close second input file */
    fclose(fpout);  /* close output file */
 

--- a/src/nvpsg/sglHelper.c
+++ b/src/nvpsg/sglHelper.c
@@ -14,6 +14,8 @@
 #include "sglCommon.h"
 #include "sglHelper.h"
 
+extern void getParSum(const char *par, double *val);
+extern void getParSum2(const char *par1, const char *par2, double *val);
 extern int checkflag;
 
 /*********************************************************************
@@ -1024,7 +1026,7 @@ double shapedbval_cross(double g1, double d1, double D1, int shape1, double g2, 
 void calc_mean_nt_tr()
 {
   int nnt,ntr;
-  double *ntvals,*trvals;
+  double sum;
   int i;
 
   if (ix > 1) return;
@@ -1037,35 +1039,23 @@ void calc_mean_nt_tr()
   else ntr=1;
 
   /* Calculate the mean */
-  if ((trvals=(double *)malloc(ntr*sizeof(double))) == NULL) abort_message("Insufficient memory");
-  if (ntr>1) S_getarray("tr",trvals,ntr*sizeof(double));
-  else trvals[0]=tr;
-  trmean = 0.0;
-  for (i=0;i<ntr;i++) trmean += trvals[i];
-  trmean /= ntr;
+  getParSum("tr", &sum);
+  trmean = sum / ntr;
 
   /* If nt is arrayed get the size of the nt array */
   if (array_check("nt",&arraypars)) nnt=get_nvals("nt",&arraypars);
   else nnt=1;
 
-  /* Get the array */
-  if ((ntvals=(double *)malloc(nnt*sizeof(double))) == NULL) abort_message("Insufficient memory");
-  if (nnt>1) S_getarray("nt",ntvals,nnt*sizeof(double));
-  else ntvals[0]=nt;
-
   /* Check if nt and tr are arrayed together */
-  ntmean = 0.0;
-  if ((nnt>1) && (ntr>1) && (get_cycle("nt",&arraypars)==get_cycle("tr",&arraypars))) {
-    for (i=0;i<nnt;i++) ntmean += (ntvals[i]*trvals[i]);
-    ntmean /= nnt;
+  if ((nnt>1) && (ntr>1) &&
+      (get_cycle("nt",&arraypars)==get_cycle("tr",&arraypars))) {
+    getParSum2("nt", "tr",  &sum);
+    ntmean = sum / nnt;
     ntmean /= trmean;
   } else {
-    for (i=0;i<nnt;i++) ntmean += ntvals[i];
-    ntmean /= nnt;
+    getParSum("nt", &sum);
+    ntmean = sum / nnt;
   }
-
-  free(trvals);
-  free(ntvals);
 }
 
 /***********************************************************************

--- a/src/nvpsg/sglPrepulses.c
+++ b/src/nvpsg/sglPrepulses.c
@@ -874,7 +874,9 @@ fpwrscale=1.0;
                 for (i=0;i<npssvals;i++) {
                   if (FP_EQ(minpss,pssval[i])) sliceindex=i;
                 }
+#ifndef DPS
                 aslctrlpos=controlpos[sliceindex];
+#endif
               }
               else {
                 if (!checkflag) abort_message("ASL control positions (controlpos) have not been set correctly, run prep");
@@ -910,7 +912,9 @@ fpwrscale=1.0;
                 for (i=0;i<npssvals;i++) {
                   if (FP_EQ(minpss,pssval[i])) sliceindex=i;
                 }
+#ifndef DPS
                 aslctrlpos=controlpos[sliceindex];
+#endif
               }
               else {
                 if (!checkflag) abort_message("ASL control positions (controlpos) have not been set correctly, run prep");

--- a/src/psg/getparm.c
+++ b/src/psg/getparm.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include "abort.h"
 #include "group.h"
+#include "variables.h"
 #include "pvars.h"
 /*--------------------------------------------------------------
 |  getparm(variable_name,variable_type,tree,variable_address,varsize)
@@ -103,4 +104,56 @@ int getArrayparval(const char *parname, double *parval[])
   }
   return nn;
 }
+
+#ifdef NVPSG
+void getParSum(const char *parname, double *val)
+{
+    int      size,i;
+    vInfo    varinfo;
+    double value;
+
+    if ( P_getVarInfo(CURRENT, parname, &varinfo) )
+        abort_message("getarray: could not find the parameter \"%s\"\n",parname);
+    if ((int)varinfo.basicType != 1)
+        abort_message("getarray: \"%s\" is not an array of reals.\n",parname);
+
+    size = (int)varinfo.size;
+
+    *val = 0.0;
+    for (i=0; i<size; i++) {
+        if ( P_getreal(CURRENT,parname,&value,i+1) )
+	    abort_message("getarray: problem getting array element %d.\n",i+1);
+	*val += value;
+	
+    }
+}
+
+void getParSum2(const char *par1, const char *par2, double *val)
+{
+    int      size,i;
+    vInfo    varinfo;
+    double val1;
+    double val2;
+
+    if ( P_getVarInfo(CURRENT, par1, &varinfo) )
+        abort_message("getarray: could not find the parameter \"%s\"\n",par1);
+    if ((int)varinfo.basicType != 1)
+        abort_message("getarray: \"%s\" is not an array of reals.\n",par1);
+    size = (int)varinfo.size;
+    if ( P_getVarInfo(CURRENT, par2, &varinfo) )
+        abort_message("getarray: could not find the parameter \"%s\"\n",par2);
+    if ((int)varinfo.basicType != 1)
+        abort_message("getarray: \"%s\" is not an array of reals.\n",par2);
+    size = (int)varinfo.size;
+
+    *val = 0.0;
+    for (i=0; i<size; i++) {
+        if ( P_getreal(CURRENT,par1,&val1,i+1) )
+	    abort_message("getarray: problem getting array element %d.\n",i+1);
+        if ( P_getreal(CURRENT,par2,&val2,i+1) )
+	    abort_message("getarray: problem getting array element %d.\n",i+1);
+	*val += val1*val2;
+    }
+}
+#endif  // NVPSG
 


### PR DESCRIPTION
Some warning were harmless but some point to actaul bugs. These changes let all imaging sequences compile (psggen) without warning on Ubuntu 22 and 24. This resolves issue #979