### PR TITLE
On AlmaLinux 9, java may not be installed

### DIFF
--- a/src/scripts/installpkgs.sh
+++ b/src/scripts/installpkgs.sh
@@ -407,8 +407,8 @@ if [ ! -x /usr/bin/dpkg ]; then
        if [[ ! -z $jdk ]]; then
           yum remove -y $jdk &>> $logfile
        fi
-       packageList="$packageList java-17-openjdk"
     fi
+    packageList="$packageList java-17-openjdk"
   elif [ $version -ge 8 ]; then
     epelList="$epelList kdiff3 k3b ImageMagick rsh rsh-server"
     commonList="$commonList tcsh compat-openssl10 compat-libgfortran-48"


### PR DESCRIPTION
If upgraded from Alma 8.10, the test to check if java needs to be installed may fail, due to the presence of java-1.8.0-openjdk. A java-17-openjdk-headless became the active version of java. It now tries to install java-17-openjdk  in all cases. If it is already installed, yum will just skip it. Thanks to Eugenio Alvarado for help with this problem.