### PR TITLE
Updated setNIC

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -1,6 +1,15 @@
 OpenVnmrJ Release Notes.
 
-Feb 2025
+March 2025
+    Parameter values can use multi-byte characters such as
+      umlauts.
+    Installation of java on AlmaLinux 9 could fail in some cases.
+    Compiling imaging sequences with seqgen gave warnings.
+    Link for Spinsights Community Help Site fixed.
+    Compiling OVJ with gcc 14 failed.
+    Added ascii option to writespectrum. See manual/writespectrum.
+    ll2d command has new 'peakno' keyword. See manual/ll2d.
+    atcmd active keyword re-defined to mean any currently active OVJ.
     readspectrum can import complex 1D spectra. See manual/readspectrum
     write, copystr, and appendstr support writing to multiple files
     BUG: The copy command could fail if the file being written to
@@ -16,7 +25,7 @@ Feb 2025
       pathnames prefaced with a /.
     Added dc1d parameters to change the default behavior for FID drift
       correction. See manual/ft
-    BUG: setacq / setNIC could fail on Ubuntu 24.\
+    BUG: setacq / setNIC could fail on Ubuntu 24.
     pl('side') would truncate negative peaks.
     pscharsize parameter was not functional for write('plotter',...)
 

--- a/src/scripts/setNIC.sh
+++ b/src/scripts/setNIC.sh
@@ -142,7 +142,13 @@ EOF
 }
 
 addToNetplan() {
-   file=$(ls /etc/netplan/*network-manager*yaml)
+   file="/etc/netplan/01-network-manager-all.yaml"
+   if [[ ! -f $file ]]; then
+      echo "# Let NetworkManager manage all devices on this system" > $file
+      echo "network:" >> $file
+      echo "  version: 2" >> $file
+      echo "  renderer: NetworkManager" >> $file
+   fi
    grep OpenVnmrJ $file > /dev/null
    if [[ $? -eq 0 ]]; then
       sed --in-place '/# OpenVnmrJ Start/,/# OpenVnmrJ End/d' $file
@@ -160,6 +166,7 @@ EOF
       echo "      macaddress: ${hwaddr}" >> ${file}
    fi
    echo "# OpenVnmrJ End" >> ${file}
+   chmod 600 $file
    netplan apply
 }
 


### PR DESCRIPTION
On some systems, the file 01-network-manager-all.yaml does not exist. setNIC will create it if needed. Updated Notes.txt