### PR TITLE
Recover from corrupted global and experiment files

### DIFF
--- a/src/common/maclib/mfaction
+++ b/src/common/maclib/mfaction
@@ -5,6 +5,7 @@ if($# < 0.5) then return endif
 if($1 = 'init') then
     exists('buttonMode','parameter','global'):$e
     if (not $e) then
+      rebuildglobal
       mfpars
     endif
     buttonMode = 0

--- a/src/common/maclib/rebuildglobal
+++ b/src/common/maclib/rebuildglobal
@@ -1,0 +1,32 @@
+write('error','Locked workspace detected, may need to unlock')
+exists('appmode','parameter','global'):$e
+if not $e then
+  write('error','OpenVnmrJ improperly exited: rebuilding global file')
+  exists(userdir+'/global','file'):$g
+  if $g then
+    $date=''
+    systemtime('%Y-%m-%dT%H:%M:%S'):$date
+    cp(userdir+'/global',userdir+'/global'+$date)
+  endif
+  cp(systemdir+'/user_templates/global',userdir)
+endif
+
+fread(userdir+'/global','global','reset')
+exists('cpglobals','modules'):$mex,$cmodule
+fread($cmodule,'global')
+
+jexp:$e
+if ($e) then
+  $pars='seqfil','array','arraydim','layout','axis'
+  $e=1
+  $num=size('$pars')
+  $i=0
+  while ($i < $num) and ($e = 1) do
+    $i=$i+1
+    exists($pars[$i],'parameter'):$e
+  endwhile
+  if $i < $num then 
+    write('error','Experiment directory also corrupted: bringing in new PROTON parameters')
+    rtp(systemdir+'/parlib/PROTON')
+  endif
+endif

--- a/src/common/maclib/rtp
+++ b/src/common/maclib/rtp
@@ -1,7 +1,10 @@
 "macro rtp"
 " rtp - retrieve parameter set"
 
-if axis='SS' then aspAnno('clear') axis='p' endif
+exists('axis','parameter'):$i
+if ($i) then
+  if axis='SS' then aspAnno('clear') axis='p' endif
+endif
 
 if ($# > 0.5) then
   length($1):$len

--- a/src/layouts/layout/exp0/workspace.xml
+++ b/src/layouts/layout/exp0/workspace.xml
@@ -12,20 +12,75 @@
     enable="no"
     reference="workspace"
     useref="no"
-    subtype="Basic"
+    subtype="Untitled"
     expanded="yes"
+    rows="1"
+    columns="1"
     >
-    <label loc="10 5" size="285 25"
-      style="Info"
-      label="No workspace (experiment) selected"
+    <menu loc="205 105" size="50 20"
+      style="PlainText"
+      label="menu"
+      vc="exec('$VALUE')"
+      editable="No"
+      >
+      <mlabel 
+        label="1"
+        chval="unlock(1,'force')"
+        />
+      <mlabel 
+        label="2"
+        chval="unlock(2,'force')"
+        />
+      <mlabel 
+        label="3"
+        chval="unlock(3,'force')"
+        />
+      <mlabel 
+        label="4"
+        chval="unlock(4,'force')"
+        />
+      <mlabel 
+        label="5"
+        chval="unlock(5,'force')"
+        />
+      <mlabel 
+        label="6"
+        chval="unlock(6,'force')"
+        />
+      <mlabel 
+        label="7"
+        chval="unlock(7,'force')"
+        />
+      <mlabel 
+        label="8"
+        chval="unlock(8,'force')"
+        />
+      <mlabel 
+        label="9"
+        chval="unlock(9,'force')"
+        />
+    </menu>
+    <entry loc="315 105" size="50 20"
+      style="PlainText"
+      vc="if ('$VALUE'&lt;&gt;'') then unlock($VALUE,'force') endif"
+      disable="Grayed out"
+      />
+    <entry loc="315 55" size="50 20"
+      style="PlainText"
+      vc="if ('$VALUE'&lt;&gt;'') then exec('jexp'+'$VALUE') endif"
+      disable="Grayed out"
+      />
+    <label loc="260 105" size="55 20"
+      style="Label1"
+      label="or exp#"
       justify="Left"
       />
-    <button loc="170 90" size="50 20"
-      style="Heading2"
-      label="Next"
-      vc="jnewexp"
+    <label loc="260 55" size="55 20"
+      style="Label1"
+      label="or exp#"
+      justify="Left"
       />
-    <menu loc="170 60" size="50 20"
+    <menu loc="205 55" size="50 20"
       style="PlainText"
       label="menu"
       vc="exec('$VALUE')"
@@ -68,48 +123,56 @@
         chval="jexp9"
         />
     </menu>
-    <label loc="10 90" size="150 20"
-      style="Label1"
-      label="Create workspace (exp)"
-      justify="Left"
-      />
-    <label loc="10 25" size="540 25"
-      style="Info"
-      label="Either select an existing workspace (experiment) or create a new workspace (experiment)"
-      justify="Left"
-      />
-    <label loc="10 60" size="150 20"
-      style="Label1"
-      label="Select  workspace (exp)"
-      justify="Left"
-      />
-    <label loc="230 60" size="55 20"
-      style="Label1"
-      label="or exp#"
-      justify="Left"
-      />
-    <entry loc="280 60" size="50 20"
-      style="PlainText"
-      vc="if ('$VALUE'&lt;&gt;'') then exec('jexp'+'$VALUE') endif"
-      disable="Grayed out"
-      />
-    <label loc="230 90" size="55 20"
-      style="Label1"
-      label="or exp#"
-      justify="Left"
-      />
-    <entry loc="280 90" size="50 20"
+    <entry loc="315 80" size="50 20"
       style="PlainText"
       vc="if ('$VALUE'&lt;&gt;'') then cexp('$VALUE') exec('jexp'+'$VALUE') endif"
       disable="Grayed out"
       />
-    <textfile loc="10 120" size="615 195"
+    <label loc="260 80" size="55 20"
+      style="Label1"
+      label="or exp#"
+      justify="Left"
+      />
+    <button loc="205 80" size="50 20"
+      style="Heading2"
+      label="Next"
+      vc="jnewexp"
+      bg="transparent"
+      justify="Center"
+      decor1="yes"
+      />
+    <label loc="10 105" size="195 20"
+      style="Label1"
+      label="Force unlock workspace (exp)"
+      justify="Left"
+      />
+    <label loc="10 80" size="150 20"
+      style="Label1"
+      label="Create workspace (exp)"
+      justify="Left"
+      />
+    <textfile loc="10 135" size="615 180"
       style="StdPar"
       vq="alphatext"
       set="alphatextname:$VALUE"
       editable="yes"
       wrap="yes"
       units="char"
+      />
+    <label loc="10 25" size="580 25"
+      style="Info"
+      label="Either select an existing workspace (experiment) or create a new workspace (experiment)"
+      justify="Left"
+      />
+    <label loc="10 55" size="150 20"
+      style="Label1"
+      label="Select  workspace (exp)"
+      justify="Left"
+      />
+    <label loc="10 5" size="285 25"
+      style="Info"
+      label="No workspace (experiment) selected"
+      justify="Left"
       />
   </group>
 </template>


### PR DESCRIPTION
After a power failure, for example, global and experiment files may be corrupted. These changes try to rebuild thing rather than giving a bunch of error messages. Thanks to Bert Heise.