### PR TITLE
java mx option deprecated

### DIFF
--- a/src/scripts/cryomon.sh
+++ b/src/scripts/cryomon.sh
@@ -100,5 +100,5 @@ fi
   #echo -------- USERDIR=$USERDIR
   #echo -------- DISPLAY=$DISPLAY
 
-  eval $JAVA -mx128m -classpath $SYSDIR/java/cryomon.jar -Dsysdir=$SYSDIR -Duserdir=$USERDIR vnmr.cryomon.CryoMonitorControls  $VNMRJ $GUIFLAG $MASTER $DEBUG &
+  eval $JAVA -Xmx128m -classpath $SYSDIR/java/cryomon.jar -Dsysdir=$SYSDIR -Duserdir=$USERDIR vnmr.cryomon.CryoMonitorControls  $VNMRJ $GUIFLAG $MASTER $DEBUG &
 

--- a/src/scripts/managedb.sh
+++ b/src/scripts/managedb.sh
@@ -84,7 +84,7 @@ endif
 set vjclasspath="$vnmrsystem/java/managedb.jar"
 set sysdir="$vnmrsystem"
 
-$javacmd -mx256m -classpath $vjclasspath -Dsysdir="$sysdir" -Duserdir="$tmpdir" -Ddbhost=$dbhost -Ddbport=$dbport -Ddbnet_server=$dbnet_server  -Dsfudirwindows="$sfudir" -Dsfudirinterix="$sfudir_interix" -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption" -Ddebug="$debugargs" -Duser.name=$id vnmr.ui.shuf.FillDBManager $argv[*]
+$javacmd -Xmx256m -classpath $vjclasspath -Dsysdir="$sysdir" -Duserdir="$tmpdir" -Ddbhost=$dbhost -Ddbport=$dbport -Ddbnet_server=$dbnet_server  -Dsfudirwindows="$sfudir" -Dsfudirinterix="$sfudir_interix" -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption" -Ddebug="$debugargs" -Duser.name=$id vnmr.ui.shuf.FillDBManager $argv[*]
 
 if ( "$tmpdir" == "$vnmrsystem/tmp" ) then
    chmod 666 "$tmpdir"/ManagedbMsgLog

--- a/src/scripts/probeid.sh
+++ b/src/scripts/probeid.sh
@@ -647,7 +647,7 @@ if [[ ! -f $JAVA ]]; then
    JAVA="java"
 fi
 
-# one common option: JAVAOPTS="-mx128m"
+# one common option: JAVAOPTS="-Xmx128m"
 # java debugger option: 
 #    JAVADBG="-agentlib:jdwp=transport=dt_socket,suspend=y,address=localhost:8000"
 JADADBG=

--- a/src/scripts/protune.sh
+++ b/src/scripts/protune.sh
@@ -177,5 +177,5 @@ fi
   JAR="$SYSDIR/java/apt.jar:$SYSDIR/java/probeid.jar:$SYSDIR/java/junit.jar:$SYSDIR/java/vnmrutil.jar"
   MAIN="vnmr.apt.ProbeTune"
 
-  eval $JAVA $DBG -mx128m -classpath $JAR -Dsysdir=$SYSDIR -Duserdir=$USERDIR $MAIN $DEB $PROBEID -probe $PROBE $SW $STO $GUIFLAG $INFOFLAG $UCUT $LCUT -sweep mt $IP -lockPort $LOCKPORT -systunedir $SYSTUNEDIR $MATCH $TUNEMODE $TUNECMD $MATCH2 $TUNEMODE2 $TUNECMD2 $EXEC > /dev/null &
+  eval $JAVA $DBG -Xmx128m -classpath $JAR -Dsysdir=$SYSDIR -Duserdir=$USERDIR $MAIN $DEB $PROBEID -probe $PROBE $SW $STO $GUIFLAG $INFOFLAG $UCUT $LCUT -sweep mt $IP -lockPort $LOCKPORT -systunedir $SYSTUNEDIR $MATCH $TUNEMODE $TUNECMD $MATCH2 $TUNEMODE2 $TUNECMD2 $EXEC > /dev/null &
 

--- a/src/scripts/vnmrj.sh
+++ b/src/scripts/vnmrj.sh
@@ -150,9 +150,9 @@ fi
 # Set java memory usage
 if [ x$VJMEM = "x" ]
 then
-    vjmem=-mx1500m
+    vjmem=-Xmx1500m
 else
-    vjmem=-mx"$VJMEM"m
+    vjmem=-Xmx"$VJMEM"m
 fi
 
 sysdir=$vnmrsystem

--- a/src/scripts/xmlToCsv.sh
+++ b/src/scripts/xmlToCsv.sh
@@ -54,4 +54,4 @@ fi
 
 vjclasspath="$vnmrsystem/java/vnmrj.jar"
 
-$javabin -mx600m -classpath $vjclasspath  -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption"  vnmr.ui.XmlToCsvUtil "$@"
+$javabin -Xmx600m -classpath $vjclasspath  -Dshtoolcmd="$shtoolcmd" -Dshtooloption="$shtooloption"  vnmr.ui.XmlToCsvUtil "$@"


### PR DESCRIPTION
The -mx option is replaced with the equivalent -Xmx If -mx is used, annoying warnings are displayed in java 25