### PR TITLE
Updated nm2d macro

### DIFF
--- a/src/common/maclib/nm2d
+++ b/src/common/maclib/nm2d
@@ -33,6 +33,7 @@ $trace=trace
 
 " find maximum signal and noise in entire spectrum and adjust vs2d and th"
 trace='f1' peak2d:$max,$max2,$max3,$max1
+$max1 = $max1 * vs2d
 if $max<0 then $max=-$max endif
 
 if $safety*$max1*4/$max>1 then $max=$safety*$max1*4 endif


### PR DESCRIPTION
The recent change to peak2d (PR #1038) broke the nm2d macro by removing the vs2d factor from the noise value.