### PR TITLE
Added USB option for configuring the sample changer port

### DIFF
--- a/src/common/maclib/iconfig
+++ b/src/common/maclib/iconfig
@@ -69,6 +69,8 @@ if ($op = 'init') or ($op = 'auto') then
     if ($osname='Linux') then
        write('file',$file,'Com1 c1')
        write('file',$file,'Com2 ttyS1')
+       write('file',$file,'USB0 ttyUSB0')
+       write('file',$file,'USB1 ttyUSB1')
     else
        write('file',$file,'Port_A a')
        write('file',$file,'Port_B b')

--- a/src/common/maclib/mconfig
+++ b/src/common/maclib/mconfig
@@ -40,6 +40,8 @@ if ($op = 'init') or ($op = 'auto') then
     if ($osname='Linux') then
        write('file',$file,'Com1 c1')
        write('file',$file,'Com2 ttyS1')
+       write('file',$file,'USB0 ttyUSB0')
+       write('file',$file,'USB1 ttyUSB1')
     else
        write('file',$file,'Port_A a')
        write('file',$file,'Port_B b')

--- a/src/common/maclib/vconfig
+++ b/src/common/maclib/vconfig
@@ -108,6 +108,8 @@ if ($op = 'init') or ($op = 'auto') then
     if ($osname='Linux') then
        write('file',$file,'Com1 c1')
        write('file',$file,'Com2 ttyS1')
+       write('file',$file,'USB0 ttyUSB0')
+       write('file',$file,'USB1 ttyUSB1')
     else
        write('file',$file,'Port_A a')
        write('file',$file,'Port_B b')


### PR DESCRIPTION
Many PCs no longer have a RS232 port but instead have USB ports. This change allows selection of the USB port for communication with the sampek changer, provided a USB to serial adaptor, such as the one from Prolific, is used. Thanks to Pierre Audet for testing this.