### PR TITLE
Updates for accounting package

### DIFF
--- a/src/common/manual/vnmr_accounting
+++ b/src/common/manual/vnmr_accounting
@@ -136,3 +136,24 @@ doAcct -from 2017/1/1 -to 2017/12/31
 
 selects the entire year 2017.
 
+There are several files involved with the accounting package.
+In the /vnmr/adm/users/profiles/users directory, there are files corresponding
+to individual owners. These represent Linux login accounts, each with
+their own vnmrsys directories. One of the lines in those files may define
+additional operators who share the vnmrsys directories with that owner.
+The accounting package lists all the owners and operators in the
+"Owners and operators" scrolling window in the Accounts tab.
+
+The /vnmr/adm/accounting/accounts directory contains files with a .txt
+suffix that represent individual accounts for which billing information
+will be collected.  These files define the account billing information,
+such as the address and the rate table. The last line in those files
+defines the owners and operators whose use will be identified with
+that account. These files can have the same name as the corresponding
+operator but they do not need to.
+
+The /vnmr/adm/accounting/acctLog.xml file contains the actual login /
+ logout and acquisition activity by the users of the spectrometer.
+The accounting package parses this file to identify the owners and
+operators and then uses the rate tables to calculate the usage and
+charges.

--- a/src/scripts/upgrade.nmr.sh
+++ b/src/scripts/upgrade.nmr.sh
@@ -249,7 +249,10 @@ doUpgrade () {
     ignoreFiles="
         acq/info
         p11/part11Config
+        adm/accounting/accounts/accounting.prop
+        adm/accounting/group
         adm/accounting/loggingParamList
+        adm/users/operators/automation.conf
         adm/users/profiles/accPolicy
         adm/users/userDefaults
         pulsecal

--- a/src/scripts/vnmr_accounting.sh
+++ b/src/scripts/vnmr_accounting.sh
@@ -27,4 +27,9 @@ fi
 
 LANG=en_US.UTF8
 $javabin -jar $vnmrsystem/java/account.jar "$@"
+
+if [ -f $vnmrsystem/adm/accounting/acctLog.xml ]
+then
+   chmod 666 $vnmrsystem/adm/accounting/acctLog.xml
+fi
 exit 0


### PR DESCRIPTION
The upgrade.nmr script no longer modifies accounting options. The vnmr_accounting script also reset mode of acctLog.xml to 666, in case something changes it.
Doucemnted the files used be accounting.