### PR TITLE
Build on MacOS was failing

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -223,9 +223,11 @@ javaLink = os.path.join(ovjtools, 'java')
 
 for i in buildList:
    SConscript(os.path.join('src',i, 'SConstruct'))
-if ( not os.path.exists(os.path.join('src','datastation'))) :
-   for i in build2List:
-      SConscript(os.path.join('src',i, 'SConstruct'))
+
+if ( 'darwin' not in platform):
+   if ( not os.path.exists(os.path.join('src','datastation'))) :
+      for i in build2List:
+         SConscript(os.path.join('src',i, 'SConstruct'))
 
 # Check for link to java home on Linux only (darwin uses the System java)
 if os.path.exists(javaLink) or 'linux' not in platform:

--- a/src/bin/SConstruct.bin
+++ b/src/bin/SConstruct.bin
@@ -51,11 +51,11 @@ env = Environment(CCFLAGS = '-O2 -Wall -Wno-implicit-function-declaration -Wno-i
 
 if ('darwin' in platform):
     env.Replace(CC = 'clang')
-    env.Replace(CCFLAGS = '-Os -Wall -Wno-implicit-function-declaration ')
+    env.Replace(CCFLAGS = '-Os -arch x86_64 -arch arm64 -Wall -Wno-implicit-function-declaration -Wno-implicit-int')
     osxflags = os.getenv('osxflags')
     if osxflags:
        env.Append(CCFLAGS = os.getenv('osxflags'))
-    env.Replace(LINKFLAGS = '-Os')
+    env.Replace(LINKFLAGS = '-Os -arch x86_64 -arch arm64')
 else:
 # test if gcc version is >= 15
     if 'gcc' in env['CC']:

--- a/src/bin/SConstruct.pbox
+++ b/src/bin/SConstruct.pbox
@@ -19,7 +19,7 @@ env = Environment(CCFLAGS = '-O2 -Wall -Wno-implicit-function-declaration -Wno-i
 
 if ('darwin' in platform):
     env.Replace(CC = 'clang')
-    env.Replace(CCFLAGS = '-Os -Wall -Wno-implicit-function-declaration ')
+    env.Replace(CCFLAGS = '-Os -Wall -Wno-implicit-function-declaration -Wno-implicit-int ')
     osxflags = os.getenv('osxflags')
     if osxflags:
        env.Append(CCFLAGS = os.getenv('osxflags'))

--- a/src/nvpsg/SConstruct
+++ b/src/nvpsg/SConstruct
@@ -50,6 +50,9 @@ s2pulTarget        = 's2pul'
 if (platform=="darwin"):
     paramSharedTarget  = 'libparam.dylib'
     psglibSharedTarget = 'libpsglib.dylib'
+    ncommLib = 'libacqcomm.dylib'
+else:
+    ncommLib = 'libacqcomm.so'
 
 # we need to specify an absolute path so this SConstruct file
 # can be called from any other SConstruct file
@@ -57,7 +60,8 @@ cwd = os.getcwd()
 
 # library dependancies
 ncommPath = os.path.join(cwd, os.pardir, 'ncomm')
-SConscript(os.path.join(ncommPath, 'SConstruct'))
+if not os.path.exists(os.path.join(ncommPath,ncommLib)):
+   SConscript(os.path.join(ncommPath, 'SConstruct'))
 
 srcNcommHeaderList = [ 'mfileObj.h' ]
 

--- a/src/psglib/SConstruct
+++ b/src/psglib/SConstruct
@@ -11,8 +11,14 @@ platform = sys.platform
 cwd = os.getcwd()
 
 # library dependancies
+if ('darwin' in platform):
+    ncommLib = 'libacqcomm.dylib'
+else:
+    ncommLib = 'libacqcomm.so'
+
 ncommPath = os.path.join(cwd, os.pardir, 'ncomm')
-SConscript(os.path.join(ncommPath, 'SConstruct'))
+if not os.path.exists(os.path.join(ncommPath,ncommLib)):
+    SConscript(os.path.join(ncommPath, 'SConstruct'))
 
 # dependancies
 binPath = os.path.join(cwd, os.pardir, 'bin')


### PR DESCRIPTION
The SConscript function on MacOS gave an error
when building ncomm. This does not happen on Linux. The makeovj script in ovjTools now builds ncomm
prior to anything else.