### PR TITLE
Adapt for compiler auto-vectorization (SIMD)

### DIFF
--- a/src/vnmr/matrix.c
+++ b/src/vnmr/matrix.c
@@ -17,8 +17,6 @@
 #include <string.h>
 #include "vnmrsys.h"			/* To define UNIX (or VMS)	*/
 
-#pragma GCC optimize ("O3")
-
 #define COMPLETE	0
 #define ERROR		1
 #define REAL		1		/* real word length		*/
@@ -253,7 +251,7 @@ static void itrans(float *matrix, int max2, int max1, int datatype)
 	blocks,
 	length1,
 	length2;
-   void (*invertfunc)();	/* pointer to a function */
+   void (*invertfunc)(float *, int, int, int, int, int);	/* pointer to a function */
 
 
    if (datatype == HYPERCOMPLEX)

--- a/src/vnmr/matrix.c
+++ b/src/vnmr/matrix.c
@@ -371,8 +371,106 @@ int xposebufalloc(int nbytes, int bufstatus)
 
    return(COMPLETE);
 }   
+  
+/* Unified SIMD-friendly tile-transpose template */
+#ifndef RBS
+#define RBS 16  /* REAL tile size (elements per side)  */
+#endif
+#ifndef CBS
+#define CBS 16  /* COMPLEX tile size */
+#endif
+#ifndef HBS
+#define HBS 8   /* HYPERCOMPLEX tile size */
+#endif
+
+#define DEFINE_TILE_XPOSE(SUFFIX, ELEM_T, BS)                                \
+static inline __attribute__((always_inline))                                 \
+void t##SUFFIX(const ELEM_T s[BS][BS], ELEM_T d[BS][BS])                     \
+{                                                                             \
+   for (int i = 0; i < BS; i++)                                              \
+      for (int j = 0; j < BS; j++)                                           \
+         d[j][i] = s[i][j];                                                  \
+}                                                                             \
+static inline __attribute__((always_inline))                                 \
+void tile_##SUFFIX(const ELEM_T *src, int src_ld, ELEM_T *dst, int dst_ld)   \
+{                                                                             \
+   ELEM_T in[BS][BS], out[BS][BS];                                           \
+   for (int i = 0; i < BS; i++)                                              \
+      memcpy(in[i], src + (size_t)i * src_ld, BS * sizeof(ELEM_T));          \
+   t##SUFFIX(in, out);                                                       \
+   for (int i = 0; i < BS; i++)                                              \
+      memcpy(dst + (size_t)i * dst_ld, out[i], BS * sizeof(ELEM_T));         \
+}
  
+#define DEFINE_SCALAR_BLOCK(SUFFIX, ELEM_T)                                  \
+static void scalar_block_##SUFFIX(const ELEM_T *src, ELEM_T *dst,            \
+                                   int bi, int bj, int bh, int bw,           \
+                                   int src_cols, int dst_cols)               \
+{                                                                             \
+   for (int i = 0; i < bh; i++)                                              \
+      for (int j = 0; j < bw; j++)                                           \
+         dst[(bj+j)*dst_cols + (bi+i)] = src[(bi+i)*src_cols + (bj+j)];      \
+}
  
+#define DEFINE_INPLACE_SQUARE(SUFFIX, ELEM_T, BS)                            \
+static void symxpose_##SUFFIX(ELEM_T *mat, int n)                            \
+{                                                                             \
+   int i, j;                                                                 \
+   for (i = 0; i + BS <= n; i += BS) {                                       \
+      tile_##SUFFIX(mat+(size_t)i*n+i, n, mat+(size_t)i*n+i, n);             \
+      for (j = i + BS; j + BS <= n; j += BS) {                               \
+         ELEM_T a_in[BS][BS], a_out[BS][BS], b_in[BS][BS], b_out[BS][BS];    \
+         for (int k = 0; k < BS; k++) {                                      \
+            memcpy(a_in[k], mat+(size_t)(i+k)*n+j, BS*sizeof(ELEM_T));       \
+            memcpy(b_in[k], mat+(size_t)(j+k)*n+i, BS*sizeof(ELEM_T));       \
+         }                                                                   \
+         t##SUFFIX(a_in, a_out); t##SUFFIX(b_in, b_out);                     \
+         for (int k = 0; k < BS; k++) {                                      \
+            memcpy(mat+(size_t)(i+k)*n+j, b_out[k], BS*sizeof(ELEM_T));      \
+            memcpy(mat+(size_t)(j+k)*n+i, a_out[k], BS*sizeof(ELEM_T));      \
+         }                                                                   \
+      }                                                                      \
+   }                                                                         \
+   for (int r = 0; r < n; r++) {                                             \
+      int cstart = (r >= i) ? 0 : i;                                         \
+      for (int c = (r+1 > cstart ? r+1 : cstart); c < n; c++) {              \
+         ELEM_T tmp_ = mat[r*n+c]; mat[r*n+c] = mat[c*n+r]; mat[c*n+r] = tmp_;\
+      }                                                                      \
+   }                                                                         \
+}
+ 
+#define DEFINE_OUTOFPLACE(SUFFIX, ELEM_T, BS)                                \
+static void xpose_into_buffer_##SUFFIX(const ELEM_T *matrix, ELEM_T *buffer, \
+                                        int ncols, int nrows)                \
+{                                                                             \
+   int i, j;                                                                 \
+   for (i = 0; i + BS <= nrows; i += BS) {                                   \
+      for (j = 0; j + BS <= ncols; j += BS)                                  \
+         tile_##SUFFIX(matrix+(size_t)i*ncols+j, ncols,                      \
+                        buffer+(size_t)j*nrows+i, nrows);                    \
+      if (j < ncols)                                                         \
+         scalar_block_##SUFFIX(matrix, buffer, i, j, BS, ncols-j, ncols, nrows); \
+   }                                                                         \
+   if (i < nrows)                                                            \
+      scalar_block_##SUFFIX(matrix, buffer, i, 0, nrows-i, ncols, ncols, nrows); \
+}
+ 
+DEFINE_TILE_XPOSE(real,  float,        RBS)
+DEFINE_TILE_XPOSE(cplx,  fcomplex,     CBS)
+DEFINE_TILE_XPOSE(hyper, hypercomplex, HBS)
+ 
+DEFINE_SCALAR_BLOCK(real,  float)
+DEFINE_SCALAR_BLOCK(cplx,  fcomplex)
+DEFINE_SCALAR_BLOCK(hyper, hypercomplex)
+ 
+DEFINE_INPLACE_SQUARE(real,  float,        RBS)
+DEFINE_INPLACE_SQUARE(cplx,  fcomplex,     CBS)
+DEFINE_INPLACE_SQUARE(hyper, hypercomplex, HBS)
+ 
+DEFINE_OUTOFPLACE(real,  float,        RBS)
+DEFINE_OUTOFPLACE(cplx,  fcomplex,     CBS)
+DEFINE_OUTOFPLACE(hyper, hypercomplex, HBS)
+
 /*-----------------------------------------------
 |                                               |
 |                  symxpose()/3                 |
@@ -383,103 +481,12 @@ int xposebufalloc(int nbytes, int bufstatus)
 |                                               |
 +----------------------------------------------*/
 
-/* SIMD-friendly blocks for symxpose's inner loop */
-#define RBS 8
-#define CBS 4
- 
-static inline __attribute__((always_inline)) void t8x8(const float s[RBS][RBS], float d[RBS][RBS])
-{ for (int i=0;i<RBS;i++) for (int j=0;j<RBS;j++) d[j][i]=s[i][j]; }
- 
-static inline __attribute__((always_inline)) void t4x4(const double s[CBS][CBS], double d[CBS][CBS])
-{ for (int i=0;i<CBS;i++) for (int j=0;j<CBS;j++) d[j][i]=s[i][j]; }
- 
-static void symxpose_real(float *mat, int n)
-{
-   int i, j;
-   for (i = 0; i + RBS <= n; i += RBS) {
-      float in[RBS][RBS], out[RBS][RBS];
-      for (int k=0;k<RBS;k++) memcpy(in[k], mat+(size_t)(i+k)*n+i, RBS*sizeof(float));
-      t8x8(in, out);
-      for (int k=0;k<RBS;k++) memcpy(mat+(size_t)(i+k)*n+i, out[k], RBS*sizeof(float));
-      for (j = i + RBS; j + RBS <= n; j += RBS) {
-         float a_in[RBS][RBS], a_out[RBS][RBS], b_in[RBS][RBS], b_out[RBS][RBS];
-         for (int k=0;k<RBS;k++) {
-            memcpy(a_in[k], mat+(size_t)(i+k)*n+j, RBS*sizeof(float));
-            memcpy(b_in[k], mat+(size_t)(j+k)*n+i, RBS*sizeof(float));
-         }
-         t8x8(a_in, a_out); t8x8(b_in, b_out);
-         for (int k=0;k<RBS;k++) {
-            memcpy(mat+(size_t)(i+k)*n+j, b_out[k], RBS*sizeof(float));
-            memcpy(mat+(size_t)(j+k)*n+i, a_out[k], RBS*sizeof(float));
-         }
-      }
-   }
-   for (int r = 0; r < n; r++) {
-      int cstart = (r >= i) ? 0 : i;
-      for (int c = (r+1 > cstart ? r+1 : cstart); c < n; c++) {
-         float t = mat[r*n+c]; mat[r*n+c] = mat[c*n+r]; mat[c*n+r] = t;
-      }
-   }
-}
- 
-static void symxpose_complex(float *matf, int n)
-{
-   double *mat = (double *)matf;
-   int i, j;
-   for (i = 0; i + CBS <= n; i += CBS) {
-      double in[CBS][CBS], out[CBS][CBS];
-      for (int k=0;k<CBS;k++) memcpy(in[k], mat+(size_t)(i+k)*n+i, CBS*sizeof(double));
-      t4x4(in, out);
-      for (int k=0;k<CBS;k++) memcpy(mat+(size_t)(i+k)*n+i, out[k], CBS*sizeof(double));
-      for (j = i + CBS; j + CBS <= n; j += CBS) {
-         double a_in[CBS][CBS], a_out[CBS][CBS], b_in[CBS][CBS], b_out[CBS][CBS];
-         for (int k=0;k<CBS;k++) {
-            memcpy(a_in[k], mat+(size_t)(i+k)*n+j, CBS*sizeof(double));
-            memcpy(b_in[k], mat+(size_t)(j+k)*n+i, CBS*sizeof(double));
-         }
-         t4x4(a_in, a_out); t4x4(b_in, b_out);
-         for (int k=0;k<CBS;k++) {
-            memcpy(mat+(size_t)(i+k)*n+j, b_out[k], CBS*sizeof(double));
-            memcpy(mat+(size_t)(j+k)*n+i, a_out[k], CBS*sizeof(double));
-         }
-      }
-   }
-   for (int r = 0; r < n; r++) {
-      int cstart = (r >= i) ? 0 : i;
-      for (int c = (r+1 > cstart ? r+1 : cstart); c < n; c++) {
-         double t = mat[r*n+c]; mat[r*n+c] = mat[c*n+r]; mat[c*n+r] = t;
-      }
-   }
-}
- 
-static void symxpose_hyper(float *mat, int n)
-{
-   const int TILE = 32;
-   for (int bi = 0; bi < n; bi += TILE) {
-      int ih = bi+TILE<n ? TILE : n-bi;
-      for (int bj = bi; bj < n; bj += TILE) {
-         int jw = bj+TILE<n ? TILE : n-bj;
-         for (int i = 0; i < ih; i++) {
-            int j0 = (bj==bi) ? i+1 : 0;
-            for (int j = j0; j < jw; j++) {
-               int r = bi+i, c = bj+j;
-               if (r >= c && bj == bi) continue;
-               float tmp[4];
-               memcpy(tmp, mat+((size_t)r*n+c)*4, 16);
-               memcpy(mat+((size_t)r*n+c)*4, mat+((size_t)c*n+r)*4, 16);
-               memcpy(mat+((size_t)c*n+r)*4, tmp, 16);
-            }
-         }
-      }
-   }
-}
-
 /* npoints      number of "datatype" points			*/
 /* datatype     1 = real    2 = complex    4 = hypercomplex	*/
 static void symxpose(float *matrix, int npoints, int datatype)
 {
-  if (datatype == HYPERCOMPLEX)      symxpose_hyper(matrix, npoints);
-  else if (datatype == COMPLEX)      symxpose_complex(matrix, npoints);
+  if (datatype == HYPERCOMPLEX)      symxpose_hyper((hypercomplex *)matrix, npoints);
+  else if (datatype == COMPLEX)      symxpose_cplx((fcomplex *)matrix, npoints);
   else if (datatype == REAL)         symxpose_real(matrix, npoints);
 }
 
@@ -500,74 +507,6 @@ static int is_pow2(int n)
 |                                               |
 +----------------------------------------------*/
 
-/* SIMD-friendly blocks for nonsymxpose's copy-into-buffer */
-static inline __attribute__((always_inline)) void tile_real_np(const float *src, int src_ld, float *dst, int dst_ld)
-{
-    float in[RBS][RBS], out[RBS][RBS];
-    for (int i=0;i<RBS;i++) memcpy(in[i], src+(size_t)i*src_ld, RBS*sizeof(float));
-    t8x8(in, out);
-    for (int i=0;i<RBS;i++) memcpy(dst+(size_t)i*dst_ld, out[i], RBS*sizeof(float));
-}
- 
-static inline __attribute__((always_inline)) void tile_complex_np(const double *src, int src_ld, double *dst, int dst_ld)
-{
-    double in[CBS][CBS], out[CBS][CBS];
-    for (int i=0;i<CBS;i++) memcpy(in[i], src+(size_t)i*src_ld, CBS*sizeof(double));
-    t4x4(in, out);
-    for (int i=0;i<CBS;i++) memcpy(dst+(size_t)i*dst_ld, out[i], CBS*sizeof(double));
-}
- 
-static void scalar_block_real(const float *src, float *dst, int bi, int bj, int bh, int bw, int src_cols, int dst_cols)
-{
-    for (int i=0;i<bh;i++) for (int j=0;j<bw;j++)
-        dst[(bj+j)*dst_cols+(bi+i)] = src[(bi+i)*src_cols+(bj+j)];
-}
- 
-static void scalar_block_complex(const double *src, double *dst, int bi, int bj, int bh, int bw, int src_cols, int dst_cols)
-{
-    for (int i=0;i<bh;i++) for (int j=0;j<bw;j++)
-        dst[(bj+j)*dst_cols+(bi+i)] = src[(bi+i)*src_cols+(bj+j)];
-}
- 
-static void xpose_into_buffer_real(const float *matrix, float *buffer, int ncols, int nrows)
-{
-    int i, j;
-    for (i = 0; i + RBS <= nrows; i += RBS) {
-        for (j = 0; j + RBS <= ncols; j += RBS)
-            tile_real_np(matrix+(size_t)i*ncols+j, ncols, buffer+(size_t)j*nrows+i, nrows);
-        if (j < ncols) scalar_block_real(matrix, buffer, i, j, RBS, ncols-j, ncols, nrows);
-    }
-    if (i < nrows) scalar_block_real(matrix, buffer, i, 0, nrows-i, ncols, ncols, nrows);
-}
- 
-static void xpose_into_buffer_complex(const float *matrixf, float *bufferf, int ncols, int nrows)
-{
-    const double *matrix = (const double *)matrixf;
-    double *buffer = (double *)bufferf;
-    int i, j;
-    for (i = 0; i + CBS <= nrows; i += CBS) {
-        for (j = 0; j + CBS <= ncols; j += CBS)
-            tile_complex_np(matrix+(size_t)i*ncols+j, ncols, buffer+(size_t)j*nrows+i, nrows);
-        if (j < ncols) scalar_block_complex(matrix, buffer, i, j, CBS, ncols-j, ncols, nrows);
-    }
-    if (i < nrows) scalar_block_complex(matrix, buffer, i, 0, nrows-i, ncols, ncols, nrows);
-}
- 
-static void xpose_into_buffer_hyper(const float *matrix, float *buffer, int ncols, int nrows)
-{
-    const int TILE = 32;
-    for (int bi = 0; bi < nrows; bi += TILE) {
-        int ih = bi+TILE<nrows ? TILE : nrows-bi;
-        for (int bj = 0; bj < ncols; bj += TILE) {
-            int jw = bj+TILE<ncols ? TILE : ncols-bj;
-            for (int i = 0; i < ih; i++)
-                for (int j = 0; j < jw; j++)
-                    memcpy(buffer+((size_t)(bj+j)*nrows+(bi+i))*4,
-                           matrix+((size_t)(bi+i)*ncols+(bj+j))*4, 4*sizeof(float));
-        }
-    }
-}
-
 static int nonsymxpose(float *matrix, int ncols, int nrows, int datatype)
 {
    int                  nbytes;
@@ -576,10 +515,7 @@ static int nonsymxpose(float *matrix, int ncols, int nrows, int datatype)
                         skip1,
                         skip2;
  
-
-   skip1 = datatype;
-   skip2 = skip1 * (nrows - 1);
-   nbytes = sizeof(float) * nrows * ncols * skip1;
+   nbytes = sizeof(float) * nrows * ncols * datatype;
  
    if (xposebufalloc(nbytes, BUF_ALLOCATE))
    {
@@ -592,12 +528,12 @@ static int nonsymxpose(float *matrix, int ncols, int nrows, int datatype)
       return(COMPLETE);
    }
 
-   if (skip1 == REAL)
+   if (datatype == REAL)
       xpose_into_buffer_real(matrix, xpose.bufferpntr, ncols, nrows);
-   else if (skip1 == COMPLEX)
-      xpose_into_buffer_complex(matrix, xpose.bufferpntr, ncols, nrows);
-   else if (skip1 == HYPERCOMPLEX)
-      xpose_into_buffer_hyper(matrix, xpose.bufferpntr, ncols, nrows);
+   else if (datatype == COMPLEX)
+      xpose_into_buffer_cplx((const fcomplex *)matrix, (fcomplex *)xpose.bufferpntr, ncols, nrows);
+   else if (datatype == HYPERCOMPLEX)
+      xpose_into_buffer_hyper((const hypercomplex *)matrix, (hypercomplex *)xpose.bufferpntr, ncols, nrows);
  
    memcpy(matrix, xpose.bufferpntr, nbytes);
 

--- a/src/vnmr/matrix.c
+++ b/src/vnmr/matrix.c
@@ -17,6 +17,8 @@
 #include <string.h>
 #include "vnmrsys.h"			/* To define UNIX (or VMS)	*/
 
+#pragma GCC optimize ("O3")
+
 #define COMPLETE	0
 #define ERROR		1
 #define REAL		1		/* real word length		*/

--- a/src/vnmr/matrix.c
+++ b/src/vnmr/matrix.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "vnmrsys.h"			/* To define UNIX (or VMS)	*/
 
 #define COMPLETE	0
@@ -379,47 +380,111 @@ int xposebufalloc(int nbytes, int bufstatus)
 |   complex half-transformed 2D data set.       |
 |                                               |
 +----------------------------------------------*/
+
+/* SIMD-friendly blocks for symxpose's inner loop */
+#define RBS 8
+#define CBS 4
+ 
+static inline __attribute__((always_inline)) void t8x8(const float s[RBS][RBS], float d[RBS][RBS])
+{ for (int i=0;i<RBS;i++) for (int j=0;j<RBS;j++) d[j][i]=s[i][j]; }
+ 
+static inline __attribute__((always_inline)) void t4x4(const double s[CBS][CBS], double d[CBS][CBS])
+{ for (int i=0;i<CBS;i++) for (int j=0;j<CBS;j++) d[j][i]=s[i][j]; }
+ 
+static void symxpose_real(float *mat, int n)
+{
+   int i, j;
+   for (i = 0; i + RBS <= n; i += RBS) {
+      float in[RBS][RBS], out[RBS][RBS];
+      for (int k=0;k<RBS;k++) memcpy(in[k], mat+(size_t)(i+k)*n+i, RBS*sizeof(float));
+      t8x8(in, out);
+      for (int k=0;k<RBS;k++) memcpy(mat+(size_t)(i+k)*n+i, out[k], RBS*sizeof(float));
+      for (j = i + RBS; j + RBS <= n; j += RBS) {
+         float a_in[RBS][RBS], a_out[RBS][RBS], b_in[RBS][RBS], b_out[RBS][RBS];
+         for (int k=0;k<RBS;k++) {
+            memcpy(a_in[k], mat+(size_t)(i+k)*n+j, RBS*sizeof(float));
+            memcpy(b_in[k], mat+(size_t)(j+k)*n+i, RBS*sizeof(float));
+         }
+         t8x8(a_in, a_out); t8x8(b_in, b_out);
+         for (int k=0;k<RBS;k++) {
+            memcpy(mat+(size_t)(i+k)*n+j, b_out[k], RBS*sizeof(float));
+            memcpy(mat+(size_t)(j+k)*n+i, a_out[k], RBS*sizeof(float));
+         }
+      }
+   }
+   for (int r = 0; r < n; r++) {
+      int cstart = (r >= i) ? 0 : i;
+      for (int c = (r+1 > cstart ? r+1 : cstart); c < n; c++) {
+         float t = mat[r*n+c]; mat[r*n+c] = mat[c*n+r]; mat[c*n+r] = t;
+      }
+   }
+}
+ 
+static void symxpose_complex(float *matf, int n)
+{
+   double *mat = (double *)matf;
+   int i, j;
+   for (i = 0; i + CBS <= n; i += CBS) {
+      double in[CBS][CBS], out[CBS][CBS];
+      for (int k=0;k<CBS;k++) memcpy(in[k], mat+(size_t)(i+k)*n+i, CBS*sizeof(double));
+      t4x4(in, out);
+      for (int k=0;k<CBS;k++) memcpy(mat+(size_t)(i+k)*n+i, out[k], CBS*sizeof(double));
+      for (j = i + CBS; j + CBS <= n; j += CBS) {
+         double a_in[CBS][CBS], a_out[CBS][CBS], b_in[CBS][CBS], b_out[CBS][CBS];
+         for (int k=0;k<CBS;k++) {
+            memcpy(a_in[k], mat+(size_t)(i+k)*n+j, CBS*sizeof(double));
+            memcpy(b_in[k], mat+(size_t)(j+k)*n+i, CBS*sizeof(double));
+         }
+         t4x4(a_in, a_out); t4x4(b_in, b_out);
+         for (int k=0;k<CBS;k++) {
+            memcpy(mat+(size_t)(i+k)*n+j, b_out[k], CBS*sizeof(double));
+            memcpy(mat+(size_t)(j+k)*n+i, a_out[k], CBS*sizeof(double));
+         }
+      }
+   }
+   for (int r = 0; r < n; r++) {
+      int cstart = (r >= i) ? 0 : i;
+      for (int c = (r+1 > cstart ? r+1 : cstart); c < n; c++) {
+         double t = mat[r*n+c]; mat[r*n+c] = mat[c*n+r]; mat[c*n+r] = t;
+      }
+   }
+}
+ 
+static void symxpose_hyper(float *mat, int n)
+{
+   const int TILE = 32;
+   for (int bi = 0; bi < n; bi += TILE) {
+      int ih = bi+TILE<n ? TILE : n-bi;
+      for (int bj = bi; bj < n; bj += TILE) {
+         int jw = bj+TILE<n ? TILE : n-bj;
+         for (int i = 0; i < ih; i++) {
+            int j0 = (bj==bi) ? i+1 : 0;
+            for (int j = j0; j < jw; j++) {
+               int r = bi+i, c = bj+j;
+               if (r >= c && bj == bi) continue;
+               float tmp[4];
+               memcpy(tmp, mat+((size_t)r*n+c)*4, 16);
+               memcpy(mat+((size_t)r*n+c)*4, mat+((size_t)c*n+r)*4, 16);
+               memcpy(mat+((size_t)c*n+r)*4, tmp, 16);
+            }
+         }
+      }
+   }
+}
+
 /* npoints      number of "datatype" points			*/
 /* datatype     1 = real    2 = complex    4 = hypercomplex	*/
 static void symxpose(float *matrix, int npoints, int datatype)
 {
-   register int         inc1,
-                        inc2,
-                        skip,
-                        k;
-   register float       *tptr1,
-                        *tptr2,
-                        *pntr1,
-                        *pntr2,
-                        tmp;
- 
-   skip = datatype;
-   inc1 = npoints - 1;
-   inc2 = npoints*skip;
-   pntr2 = matrix + inc2;
- 
-   for (pntr1 = matrix + skip; pntr1 < (matrix + (inc2 * npoints));
-           pntr1 += (inc2 + skip))
-   {
-      tptr2 = pntr2;
-      tptr1 = pntr1;
-      while (tptr1 < (pntr1 + (skip * inc1)))
-      {
-         for (k = 0; k < skip; k++)
-         {
-            tmp = *tptr1;
-            *tptr1++ = *tptr2;
-            *tptr2++ = tmp;
-         }
- 
-         tptr2 += (inc2 - skip);
-      }
- 
-     pntr2 += (inc2 + skip);
-     inc1 -= 1;
-   }
+  if (datatype == HYPERCOMPLEX)      symxpose_hyper(matrix, npoints);
+  else if (datatype == COMPLEX)      symxpose_complex(matrix, npoints);
+  else if (datatype == REAL)         symxpose_real(matrix, npoints);
 }
- 
+
+static int is_pow2(int n)
+{
+   return (n > 0) && ((n & (n - 1)) == 0);
+}
  
 /*-----------------------------------------------
 |                                               |
@@ -432,6 +497,75 @@ static void symxpose(float *matrix, int npoints, int datatype)
 |   handled within this routine.                |
 |                                               |
 +----------------------------------------------*/
+
+/* SIMD-friendly blocks for nonsymxpose's copy-into-buffer */
+static inline __attribute__((always_inline)) void tile_real_np(const float *src, int src_ld, float *dst, int dst_ld)
+{
+    float in[RBS][RBS], out[RBS][RBS];
+    for (int i=0;i<RBS;i++) memcpy(in[i], src+(size_t)i*src_ld, RBS*sizeof(float));
+    t8x8(in, out);
+    for (int i=0;i<RBS;i++) memcpy(dst+(size_t)i*dst_ld, out[i], RBS*sizeof(float));
+}
+ 
+static inline __attribute__((always_inline)) void tile_complex_np(const double *src, int src_ld, double *dst, int dst_ld)
+{
+    double in[CBS][CBS], out[CBS][CBS];
+    for (int i=0;i<CBS;i++) memcpy(in[i], src+(size_t)i*src_ld, CBS*sizeof(double));
+    t4x4(in, out);
+    for (int i=0;i<CBS;i++) memcpy(dst+(size_t)i*dst_ld, out[i], CBS*sizeof(double));
+}
+ 
+static void scalar_block_real(const float *src, float *dst, int bi, int bj, int bh, int bw, int src_cols, int dst_cols)
+{
+    for (int i=0;i<bh;i++) for (int j=0;j<bw;j++)
+        dst[(bj+j)*dst_cols+(bi+i)] = src[(bi+i)*src_cols+(bj+j)];
+}
+ 
+static void scalar_block_complex(const double *src, double *dst, int bi, int bj, int bh, int bw, int src_cols, int dst_cols)
+{
+    for (int i=0;i<bh;i++) for (int j=0;j<bw;j++)
+        dst[(bj+j)*dst_cols+(bi+i)] = src[(bi+i)*src_cols+(bj+j)];
+}
+ 
+static void xpose_into_buffer_real(const float *matrix, float *buffer, int ncols, int nrows)
+{
+    int i, j;
+    for (i = 0; i + RBS <= nrows; i += RBS) {
+        for (j = 0; j + RBS <= ncols; j += RBS)
+            tile_real_np(matrix+(size_t)i*ncols+j, ncols, buffer+(size_t)j*nrows+i, nrows);
+        if (j < ncols) scalar_block_real(matrix, buffer, i, j, RBS, ncols-j, ncols, nrows);
+    }
+    if (i < nrows) scalar_block_real(matrix, buffer, i, 0, nrows-i, ncols, ncols, nrows);
+}
+ 
+static void xpose_into_buffer_complex(const float *matrixf, float *bufferf, int ncols, int nrows)
+{
+    const double *matrix = (const double *)matrixf;
+    double *buffer = (double *)bufferf;
+    int i, j;
+    for (i = 0; i + CBS <= nrows; i += CBS) {
+        for (j = 0; j + CBS <= ncols; j += CBS)
+            tile_complex_np(matrix+(size_t)i*ncols+j, ncols, buffer+(size_t)j*nrows+i, nrows);
+        if (j < ncols) scalar_block_complex(matrix, buffer, i, j, CBS, ncols-j, ncols, nrows);
+    }
+    if (i < nrows) scalar_block_complex(matrix, buffer, i, 0, nrows-i, ncols, ncols, nrows);
+}
+ 
+static void xpose_into_buffer_hyper(const float *matrix, float *buffer, int ncols, int nrows)
+{
+    const int TILE = 32;
+    for (int bi = 0; bi < nrows; bi += TILE) {
+        int ih = bi+TILE<nrows ? TILE : nrows-bi;
+        for (int bj = 0; bj < ncols; bj += TILE) {
+            int jw = bj+TILE<ncols ? TILE : ncols-bj;
+            for (int i = 0; i < ih; i++)
+                for (int j = 0; j < jw; j++)
+                    memcpy(buffer+((size_t)(bj+j)*nrows+(bi+i))*4,
+                           matrix+((size_t)(bi+i)*ncols+(bj+j))*4, 4*sizeof(float));
+        }
+    }
+}
+
 static int nonsymxpose(float *matrix, int ncols, int nrows, int datatype)
 {
    int                  nbytes;
@@ -439,9 +573,6 @@ static int nonsymxpose(float *matrix, int ncols, int nrows, int datatype)
                         j,
                         skip1,
                         skip2;
-   register float       *data,
-                        *tmp,
-                        *svtmp;
  
 
    skip1 = datatype;
@@ -450,68 +581,24 @@ static int nonsymxpose(float *matrix, int ncols, int nrows, int datatype)
  
    if (xposebufalloc(nbytes, BUF_ALLOCATE))
    {
+/* itrans()'s block-recursive in-place algorithm
+ * only produces correct output when BOTH dimensions 
+ * are individually powers of two  */
+	  if (!is_pow2(nrows) || !is_pow2(ncols))
+         return(ERROR);
       itrans(matrix, ncols, nrows, datatype);
       return(COMPLETE);
    }
 
-   tmp = xpose.bufferpntr;
-   svtmp = tmp;
-   data = matrix;
- 
    if (skip1 == REAL)
-   {
-      for (i = 0; i < nrows; i++)
-      {
-         tmp = svtmp;
-         for (j = 0; j < ncols; j++)
-         {
-            *tmp++ = *data++;
-            tmp += skip2;
-         }
- 
-         svtmp += skip1;
-      }
-   }
+      xpose_into_buffer_real(matrix, xpose.bufferpntr, ncols, nrows);
    else if (skip1 == COMPLEX)
-   {
-      for (i = 0; i < nrows; i++)
-      {
-         tmp = svtmp;
-         for (j = 0; j < ncols; j++)
-         {
-            *tmp++ = *data++;
-            *tmp++ = *data++;
-            tmp += skip2;
-         }
-
-         svtmp += skip1;
-      }   
-   }
+      xpose_into_buffer_complex(matrix, xpose.bufferpntr, ncols, nrows);
    else if (skip1 == HYPERCOMPLEX)
-   {
-      for (i = 0; i < nrows; i++)
-      {
-         tmp = svtmp;
-         for (j = 0; j < ncols; j++)
-         {
-            *tmp++ = *data++;
-            *tmp++ = *data++;
-            *tmp++ = *data++;
-            *tmp++ = *data++;
-            tmp += skip2;
-         }
+      xpose_into_buffer_hyper(matrix, xpose.bufferpntr, ncols, nrows);
+ 
+   memcpy(matrix, xpose.bufferpntr, nbytes);
 
-         svtmp += skip1;
-      }
-   }
- 
-   tmp = xpose.bufferpntr;
-   data = matrix;
-   ncols *= (nrows * skip1);
- 
-   for (i = 0; i < ncols; i++)
-      *data++ = *tmp++;
- 
    return(COMPLETE);
 }
 

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -151,9 +151,6 @@ void skyadd(float *in1, float *in2, float *out, int n)
 /* sum 	 sum of the points */
 /* npnt  number of points */
 /*****************************************/
-#ifndef MACOS
-__attribute__((optimize("associative-math","no-signed-zeros","no-trapping-math")))
-#endif
 void vrsum(float *restrict in1, int is1, float *restrict sum, int npnt)
 /*****************************************/
 { float *inptr;
@@ -166,11 +163,25 @@ void vrsum(float *restrict in1, int is1, float *restrict sum, int npnt)
   total   = 0.0f;
  if (is1 == 1)
   {
-    for (i = 0; i < npnt; i++) total += in1[i];
+      float acc0=0,acc1=0,acc2=0,acc3=0,acc4=0,acc5=0,acc6=0,acc7=0;
+      for (i = 0; i + 8 <= npnt; i += 8)
+      {
+         acc0 += in1[i+0]; acc1 += in1[i+1]; acc2 += in1[i+2]; acc3 += in1[i+3];
+         acc4 += in1[i+4]; acc5 += in1[i+5]; acc6 += in1[i+6]; acc7 += in1[i+7];
+      }
+      total = ((acc0+acc1)+(acc2+acc3)) + ((acc4+acc5)+(acc6+acc7));
+      for (; i < npnt; i++) total += in1[i];
   }
   else if (is1 == 2)
   {
-    for (i = 0; i < npnt; i++) total += in1[i * 2];
+      float acc0=0,acc1=0,acc2=0,acc3=0,acc4=0,acc5=0,acc6=0,acc7=0;
+      for (i = 0; i + 8 <= npnt; i += 8)
+      {
+         acc0 += in1[(i+0)*2]; acc1 += in1[(i+1)*2]; acc2 += in1[(i+2)*2]; acc3 += in1[(i+3)*2];
+         acc4 += in1[(i+4)*2]; acc5 += in1[(i+5)*2]; acc6 += in1[(i+6)*2]; acc7 += in1[(i+7)*2];
+      }
+      total = ((acc0+acc1)+(acc2+acc3)) + ((acc4+acc5)+(acc6+acc7));
+      for (; i < npnt; i++) total += in1[i*2];
   }
   else
  {

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -333,7 +333,19 @@ void vvvcmult(void *in1, int is1, void *in2, int is2, void *out1, int os1, int n
    input1 = (fcomplex *)in1;
    input2 = (fcomplex *)in2;
    output = (fcomplex *)out1;
- 
+
+   if (is1 == 1 && is2 == 0 && os1 == 1)
+    {
+      float scalar_re = input2->re, scalar_im = input2->im;
+      for (i = 0; i < npoints; i++)
+      {
+         tmp = (input1[i].re * scalar_re) - (input1[i].im * scalar_im);
+         output[i].im = (input1[i].im * scalar_re) + (input1[i].re * scalar_im);
+         output[i].re = tmp;
+      }
+      return;
+    }
+	
    for (i = 0; i < npoints; i++)
    {
       tmp = (input1->re * input2->re) - (input1->im * input2->im);

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -14,6 +14,7 @@
 +--------------------------------------------------------------*/
 
 #include <stdio.h>
+#include <string.h>
 #include <math.h>
 
 #ifndef M_PI
@@ -119,12 +120,30 @@ void skyrel()
 
 /* vector,vector,vector multiply, real vectors */
 /**********************************/
-void vvvrmult(float *in1, int is1, float *in2, int is2, float *out1, int os1, int n)
+void vvvrmult(float *restrict in1, int is1, float *in2, int is2, float *out1, int os1, int n)
 /**********************************/
 { register int i;
   register int is1r,is2r,os1r;
   register float *in1r,*in2r,*out1r;
 
+ if (is1 == 1 && is2 == os1)
+  {
+    switch (is2)
+    {
+      case 1:
+        for (i = 0; i < n; i++) out1[i] = in1[i] * in2[i];
+        return;
+      case 2:
+        for (i = 0; i < n; i++) out1[i * 2] = in1[i] * in2[i * 2];
+        return;
+      case 4:
+        for (i = 0; i < n; i++) out1[i * 4] = in1[i] * in2[i * 4];
+        return;
+      default:
+        break; /* uncommon stride: fall through to generic below */
+    }
+  }
+ {
   is1r = is1; is2r = is2; os1r = os1;
   in1r = in1; in2r = in2; out1r = out1;
   i = n;
@@ -132,6 +151,7 @@ void vvvrmult(float *in1, int is1, float *in2, int is2, float *out1, int os1, in
     { *out1r = *in1r * *in2r; 
       in1r += is1r; in2r += is2r; out1r += os1r; 
     }
+ }
 }
 
 
@@ -187,7 +207,7 @@ void skyadd(float *in1, float *in2, float *out, int n)
 /* sum 	 sum of the points */
 /* npnt  number of points */
 /*****************************************/
-void vrsum(float *in1, int is1, float *sum, int npnt)
+void vrsum(float *restrict in1, int is1, float *restrict sum, int npnt)
 /*****************************************/
 { register float *inptr;
   register int    inincr;
@@ -197,12 +217,23 @@ void vrsum(float *in1, int is1, float *sum, int npnt)
   inptr   = in1;
   inincr  = is1;
   total   = 0.0;
+ if (is1 == 1)
+  {
+    for (i = 0; i < npnt; i++) total += in1[i];
+  }
+  else if (is1 == 2)
+  {
+    for (i = 0; i < npnt; i++) total += in1[i * 2];
+  }
+  else
+ {
   i       = npnt;
   while (i--)
   {
     total += *inptr;
     inptr += inincr;
   }
+ }
   *sum = total;
 }
 
@@ -243,6 +274,18 @@ void vvrramp(float *in1, int is1, float *out1, int os1, float start, float delta
   register float  incr;
   register int    i;
 
+ if (is1 == 1 && os1 == 1)
+  {
+    for (i = 0; i < npnt; i++)
+      out1[i] = in1[i] + (start + (float)i * delta);
+  }
+  else if (is1 == 2 && os1 == 2)
+  {
+    for (i = 0; i < npnt; i++)
+      out1[i * 2] = in1[i * 2] + (start + (float)i * delta);
+  }
+  else
+ {
   inptr   = in1;
   inincr  = is1;
   outptr  = out1;
@@ -257,6 +300,7 @@ void vvrramp(float *in1, int is1, float *out1, int os1, float start, float delta
     inptr  += inincr;
     level  += incr;
   }
+ }
 }
 
 
@@ -442,7 +486,7 @@ void scabs(float *frompntr, int fromincr, float mult, short *topntr, int toincr,
       a = mult * srcpntr[0];
       b = mult * srcpntr[1];
       /* Don't worry about floating overflow; r should be reasonable size. */
-      r = sqrt(a * a + b * b);
+      r = sqrtf(a * a + b * b);
       *destpntr = r > 32767.499 ? sgn * MAX16INT : sgn * (short)(r + 0.5);
 
       srcpntr += fromincr;
@@ -466,18 +510,17 @@ void scabs(float *frompntr, int fromincr, float mult, short *topntr, int toincr,
 +--------------------------------------*/
 /* int	n,		number of real t1 data points/2 */
 /* 	datatype;	2 = complex    4 = hypercomplex */
-void preproc(float *datapntr, int n, int datatype)
+void preproc(float *restrict datapntr, int n, int datatype)
 {
    register int		i,
 			j;
-   register float	mult_factor;
 
-   mult_factor = 1;
    for (i = 0; i < n; i++)
    {
+	  float sign = (i & 1) ? -1.0f : 1.0f;
+      float *restrict row = datapntr + (long)i * datatype;
       for (j = 0; j < datatype; j++)
-         *datapntr++ *= mult_factor;
-      mult_factor *= (-1);
+         row[j] *= sign;
    }
 }
 
@@ -678,48 +721,21 @@ void combine(float *combinebuf, float *outp, int npoints, int datatype,
 /* Both shiftpts and npoints are numbers of complex pairs */
 void shiftComplexData(float *ptr, int shiftpts, int npoints, int len)
 {
-   register int		i;
-   register float	*endptr,
-			*sptr;
-
    if (shiftpts == 0)
       return;
    if (shiftpts > 0) /* right shift */
    {
       if (npoints > len - shiftpts)
-      {
          npoints = len - shiftpts;
-      }
-      sptr = ptr+(npoints)*2 -1;
-      endptr = ptr+(npoints+shiftpts)*2 - 1;
 
-      for (i = 0; i < npoints; i++)
-      { 
-         *endptr-- = *sptr--; 
-         *endptr-- = *sptr--; 
-      }
-      for (i = 0; i < shiftpts; i++)
-      { 
-         *endptr-- = 0.0;
-         *endptr-- = 0.0;
-      }
+	   memmove(ptr + (long)shiftpts * 2, ptr, (size_t)npoints * 2 * sizeof(float));
+       memset(ptr, 0, (size_t)shiftpts * 2 * sizeof(float));
    }
    else if (shiftpts < 0) /* left shift */
    {
-      shiftpts *= -1;
-      sptr = ptr+(shiftpts)*2;
-      endptr = ptr;
-
-      for (i = 0; i < npoints - shiftpts; i++)
-      { 
-         *endptr++ = *sptr++; 
-         *endptr++ = *sptr++; 
-      }
-      for (i = 0; i < shiftpts; i++)
-      { 
-         *endptr++ = 0.0;
-         *endptr++ = 0.0;
-      }
+      int nshift = -shiftpts;
+      memmove(ptr, ptr + (long)nshift * 2, (size_t)(npoints - nshift) * 2 * sizeof(float));
+      memset(ptr + (long)(npoints - nshift) * 2, 0, (size_t)nshift * 2 * sizeof(float));
    }
 }
 
@@ -776,30 +792,23 @@ void negateimaginary(float *data, int npoints, int datatype)
 /* inp;		pointer to 32-bit, integer FID data		*/
 /* scalefactor,	scaling factor					*/
 /* outp;	pointer to 32-bit, floating point FID data	*/
-void cnvrts32(float scalefactor, int *inp, float *outp, int npx, int lsfidx)
+void cnvrts32(float scalefactor, int *restrict inp, float *restrict outp, int npx, int lsfidx)
 {
    register int	  i;
-   register int   *datain;
-   register float *dataout;
 
 
    if (lsfidx < 0)
    {
-      datain = inp + npx;
-      dataout = outp + npx - lsfidx;
       for (i = 0; i < npx; i++)
-         *(--dataout) = scalefactor * ( (float) (*(--datain)) );
+         outp[i - lsfidx] = scalefactor * (float)inp[i];
 
       for (i = 0; i < (-1)*lsfidx; i++)
-         *(--dataout) = 0.0;
+         outp[i] = 0.0f;
    }
    else
    {
-      datain = inp + lsfidx;
-      dataout = outp;
-
       for (i = 0; i < (npx - lsfidx); i++) 
-         *dataout++ = scalefactor * ( (float) (*datain++) );
+         outp[i] = scalefactor * (float)inp[i + lsfidx];
    }
 }
 
@@ -818,29 +827,23 @@ void cnvrts32(float scalefactor, int *inp, float *outp, int npx, int lsfidx)
 /* short *inp;		pointer to 16-bit, integer FID data		*/
 /* float scalefactor,	scaling factor				*/
 /* 	*outp;		pointer to 32-bit, floating point FID data	*/
-void cnvrts16(float scalefactor, short *inp, float *outp, int npx, int lsfidx)
+void cnvrts16(float scalefactor, short *restrict inp, float *restrict outp, int npx, int lsfidx)
 {
    register int		i;
-   register short	*datain;
-   register float	*dataout;
+
 
    if (lsfidx < 0)
    {
-      datain = inp + npx;
-      dataout = outp + npx - lsfidx;
       for (i = 0; i < npx; i++)
-         *(--dataout) = scalefactor * ( (float) (*(--datain)) );
+         outp[i - lsfidx] = scalefactor * (float)inp[i];
     
       for (i = 0; i < (-1)*lsfidx; i++)
-         *(--dataout) = 0.0;
+         outp[i] = 0.0f;
    }
    else
    {
-      datain = inp + lsfidx;
-      dataout = outp;
-
       for (i = 0; i < (npx - lsfidx); i++) 
-         *dataout++ = scalefactor * ( (float) (*datain++) );
+         outp[i] = scalefactor * (float)inp[i + lsfidx];
    }
 }
 

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -534,7 +534,7 @@ void preproc(float *restrict datapntr, int n, int datatype)
    {
       for (i = 0; i < n; i++)
       {
-         float sign = (i & 1) ? -1.0f : 1.0f;
+         float sign = 1.0f - 2.0f * (float)(i & 1);
          datapntr[i*2]   *= sign;
          datapntr[i*2+1] *= sign;
       }
@@ -543,7 +543,7 @@ void preproc(float *restrict datapntr, int n, int datatype)
    {
       for (i = 0; i < n; i++)
       {
-         float sign = (i & 1) ? -1.0f : 1.0f;
+         float sign = 1.0f - 2.0f * (float)(i & 1);
          datapntr[i*4]   *= sign;
          datapntr[i*4+1] *= sign;
          datapntr[i*4+2] *= sign;
@@ -554,7 +554,7 @@ void preproc(float *restrict datapntr, int n, int datatype)
    {
     for (i = 0; i < n; i++)
     {
-	  float sign = (i & 1) ? -1.0f : 1.0f;
+	  float sign = 1.0f - 2.0f * (float)(i & 1);
       float *restrict row = datapntr + (long)i * datatype;
       for (j = 0; j < datatype; j++)
          row[j] *= sign;

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -853,10 +853,14 @@ void cnvrts32(float scalefactor, int *restrict inp, float *restrict outp, int np
 {
    register int	  i;
 
-
-   if (lsfidx < 0)
+   if (lsfidx == 0)
    {
       for (i = 0; i < npx; i++)
+         outp[i] = scalefactor * (float)inp[i];
+   }
+   else if (lsfidx < 0)
+   {
+      for (i = 0; i < npx+lsfidx; i++)
          outp[i - lsfidx] = scalefactor * (float)inp[i];
 
       for (i = 0; i < (-1)*lsfidx; i++)
@@ -866,6 +870,8 @@ void cnvrts32(float scalefactor, int *restrict inp, float *restrict outp, int np
    {
       for (i = 0; i < (npx - lsfidx); i++) 
          outp[i] = scalefactor * (float)inp[i + lsfidx];
+	  for (i = 0; i < lsfidx; i++)
+         outp[i+npx-lsfidx] = 0.0f;
    }
 }
 
@@ -888,10 +894,14 @@ void cnvrts16(float scalefactor, short *restrict inp, float *restrict outp, int 
 {
    register int		i;
 
-
-   if (lsfidx < 0)
+   if (lsfidx == 0)
    {
       for (i = 0; i < npx; i++)
+         outp[i] = scalefactor * (float)inp[i];
+   }
+   else if (lsfidx < 0)
+   {
+      for (i = 0; i < npx+lsfidx; i++)
          outp[i - lsfidx] = scalefactor * (float)inp[i];
     
       for (i = 0; i < (-1)*lsfidx; i++)
@@ -901,6 +911,8 @@ void cnvrts16(float scalefactor, short *restrict inp, float *restrict outp, int 
    {
       for (i = 0; i < (npx - lsfidx); i++) 
          outp[i] = scalefactor * (float)inp[i + lsfidx];
+	  for (i = 0; i < lsfidx; i++)
+         outp[i+npx-lsfidx] = 0.0f;
    }
 }
 

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -767,12 +767,10 @@ void shiftComplexData(float *ptr, int shiftpts, int npoints, int len)
       return;
    if (shiftpts > 0) /* right shift */
    {
-	if (len < 8)
-	{
-      if (npoints > len - shiftpts)
-      {
+	if (npoints > len - shiftpts)
          npoints = len - shiftpts;
-      }
+	if (npoints < 16)
+	{
 	  sptr = ptr+(npoints)*2 -1;
       endptr = ptr+(npoints+shiftpts)*2 - 1;
 
@@ -789,16 +787,13 @@ void shiftComplexData(float *ptr, int shiftpts, int npoints, int len)
 	}
 	 else
 	{
-      if (npoints > len - shiftpts)
-         npoints = len - shiftpts;
-
 	   memmove(ptr + (long)shiftpts * 2, ptr, (size_t)npoints * 2 * sizeof(float));
        memset(ptr, 0, (size_t)shiftpts * 2 * sizeof(float));
 	}
    }
    else if (shiftpts < 0) /* left shift */
    {
-	if (len < 8)
+	if (npoints + shiftpts < 16)
 	{
       shiftpts *= -1;
       sptr = ptr+(shiftpts)*2;

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -530,12 +530,35 @@ void preproc(float *restrict datapntr, int n, int datatype)
    register int		i,
 			j;
 
-   for (i = 0; i < n; i++)
+   if (datatype == 2)
    {
+      for (i = 0; i < n; i++)
+      {
+         float sign = (i & 1) ? -1.0f : 1.0f;
+         datapntr[i*2]   *= sign;
+         datapntr[i*2+1] *= sign;
+      }
+   }
+   else if (datatype == 4)
+   {
+      for (i = 0; i < n; i++)
+      {
+         float sign = (i & 1) ? -1.0f : 1.0f;
+         datapntr[i*4]   *= sign;
+         datapntr[i*4+1] *= sign;
+         datapntr[i*4+2] *= sign;
+         datapntr[i*4+3] *= sign;
+      }
+   }
+   else
+   {
+    for (i = 0; i < n; i++)
+    {
 	  float sign = (i & 1) ? -1.0f : 1.0f;
       float *restrict row = datapntr + (long)i * datatype;
       for (j = 0; j < datatype; j++)
          row[j] *= sign;
+    }
    }
 }
 

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -209,6 +209,7 @@ void skyadd(float *in1, float *in2, float *out, int n)
 /* sum 	 sum of the points */
 /* npnt  number of points */
 /*****************************************/
+__attribute__((optimize("associative-math","no-signed-zeros","no-trapping-math")))
 void vrsum(float *restrict in1, int is1, float *restrict sum, int npnt)
 /*****************************************/
 { register float *inptr;

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -823,7 +823,7 @@ void cnvrts32(float scalefactor, int *restrict inp, float *restrict outp, int np
    }
    else if (lsfidx < 0)
    {
-      for (i = 0; i < npx+lsfidx; i++)
+      for (i = 0; i < npx; i++)
          outp[i - lsfidx] = scalefactor * (float)inp[i];
 
       for (i = 0; i < (-1)*lsfidx; i++)
@@ -864,7 +864,7 @@ void cnvrts16(float scalefactor, short *restrict inp, float *restrict outp, int 
    }
    else if (lsfidx < 0)
    {
-      for (i = 0; i < npx+lsfidx; i++)
+      for (i = 0; i < npx; i++)
          outp[i - lsfidx] = scalefactor * (float)inp[i];
     
       for (i = 0; i < (-1)*lsfidx; i++)

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -735,21 +735,64 @@ void combine(float *combinebuf, float *outp, int npoints, int datatype,
 /* Both shiftpts and npoints are numbers of complex pairs */
 void shiftComplexData(float *ptr, int shiftpts, int npoints, int len)
 {
+   register int		i;
+   register float	*endptr,
+			*sptr;
+	
    if (shiftpts == 0)
       return;
    if (shiftpts > 0) /* right shift */
    {
+	if (len < 8)
+	{
+	  sptr = ptr+(npoints)*2 -1;
+      endptr = ptr+(npoints+shiftpts)*2 - 1;
+
+      for (i = 0; i < npoints; i++)
+      { 
+         *endptr-- = *sptr--; 
+         *endptr-- = *sptr--; 
+      }
+      for (i = 0; i < shiftpts; i++)
+      { 
+         *endptr-- = 0.0;
+         *endptr-- = 0.0;
+      }
+	}
+	 else
+	{
       if (npoints > len - shiftpts)
          npoints = len - shiftpts;
 
 	   memmove(ptr + (long)shiftpts * 2, ptr, (size_t)npoints * 2 * sizeof(float));
        memset(ptr, 0, (size_t)shiftpts * 2 * sizeof(float));
+	}
    }
    else if (shiftpts < 0) /* left shift */
    {
+	if (len < 8)
+	{
+      shiftpts *= -1;
+      sptr = ptr+(shiftpts)*2;
+      endptr = ptr;
+
+      for (i = 0; i < npoints - shiftpts; i++)
+      { 
+         *endptr++ = *sptr++; 
+         *endptr++ = *sptr++; 
+      }
+      for (i = 0; i < shiftpts; i++)
+      { 
+         *endptr++ = 0.0;
+         *endptr++ = 0.0;
+      }
+	}
+	else
+	{
       int nshift = -shiftpts;
       memmove(ptr, ptr + (long)nshift * 2, (size_t)(npoints - nshift) * 2 * sizeof(float));
       memset(ptr + (long)(npoints - nshift) * 2, 0, (size_t)nshift * 2 * sizeof(float));
+	}
    }
 }
 

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -17,8 +17,6 @@
 #include <string.h>
 #include <math.h>
 
-#pragma GCC optimize ("O3")
-
 #ifndef M_PI
 #define M_PI    3.14159265358979323846
 #endif 
@@ -64,69 +62,13 @@ extern int debug1;
 #define DPRINT4(str, arg1, arg2, arg3, arg4) 
 #endif 
 
-
-/*-------------------------------
-|				|
-|	     skywt()/0		|
-|				|
-|   Wait for array processor	|
-|   to be done.			|
-|				|
-+------------------------------*/
-void skywt()
-{ 
-}
-
-
-/*-------------------------------
-|				|
-|	   skyinit()/0		|
-|				|
-|  Initialize array processor.	|
-|				|
-+------------------------------*/
-void skyinit()
-{
-}
-
-
-/*-------------------------------
-|				|
-|	    skygo()/0		|
-|				|
-+------------------------------*/
-void skygo()
-{
-}
-
-
-/*-------------------------------
-|				|
-|	   skyinit()/0		|
-|				|
-+------------------------------*/
-void skyend()
-{
-}
-
-
-/*-------------------------------
-|				|
-|	    skyrel()/0		|
-|				|
-+------------------------------*/
-void skyrel()
-{
-}
-
-
 /* vector,vector,vector multiply, real vectors */
 /**********************************/
 void vvvrmult(float *restrict in1, int is1, float *in2, int is2, float *out1, int os1, int n)
 /**********************************/
-{ register int i;
-  register int is1r,is2r,os1r;
-  register float *in1r,*in2r,*out1r;
+{ int i;
+  int is1r,is2r,os1r;
+  float *in1r,*in2r,*out1r;
 
  if (is1 == 1 && is2 == os1)
   {
@@ -164,9 +106,9 @@ void vvvrmult(float *restrict in1, int is1, float *in2, int is2, float *out1, in
 +--------------------------------------*/
 void datafill(float *buffer, int n, float value)
 {
-   register int         i;
-   register float       *buffer0,
-                        d;
+   int         i;
+   float       *buffer0,
+               d;
 
    buffer0 = buffer;
    d = value;
@@ -179,8 +121,8 @@ void datafill(float *buffer, int n, float value)
 /*******************/
 void skymax(float *in1, float *in2, float *out, int n)
 /*******************/
-{ register int i;
-  register float *i1,*i2,*o1;
+{ int i;
+  float *i1,*i2,*o1;
 
   i1 = in1; i2 = in2; o1 = out;
   i = n;
@@ -193,8 +135,8 @@ void skymax(float *in1, float *in2, float *out, int n)
 /*******************/
 void skyadd(float *in1, float *in2, float *out, int n)
 /*******************/
-{ register int i;
-  register float *i1,*i2,*o1;
+{ int i;
+  float *i1,*i2,*o1;
 
   i1 = in1; i2 = in2; o1 = out;
   i = n;
@@ -209,17 +151,19 @@ void skyadd(float *in1, float *in2, float *out, int n)
 /* sum 	 sum of the points */
 /* npnt  number of points */
 /*****************************************/
+#ifndef MACOS
 __attribute__((optimize("associative-math","no-signed-zeros","no-trapping-math")))
+#endif
 void vrsum(float *restrict in1, int is1, float *restrict sum, int npnt)
 /*****************************************/
-{ register float *inptr;
-  register int    inincr;
-  register float  total;
-  register int i;
+{ float *inptr;
+  int    inincr;
+  float  total;
+  int i;
 
   inptr   = in1;
   inincr  = is1;
-  total   = 0.0;
+  total   = 0.0f;
  if (is1 == 1)
   {
     for (i = 0; i < npnt; i++) total += in1[i];
@@ -247,10 +191,10 @@ void vrsum(float *restrict in1, int is1, float *restrict sum, int npnt)
 /************************/
 void vssubr(float *inptr, float val, float *outptr, int n)
 /************************/
-{ register float d;
-  register int i;
-  register float *inp;
-  register float *outp;
+{ float d;
+  int   i;
+  float *inp;
+  float *outp;
 
   inp = inptr;
   outp = outptr;
@@ -269,13 +213,13 @@ void vssubr(float *inptr, float val, float *outptr, int n)
 /*****************************************/
 void vvrramp(float *in1, int is1, float *out1, int os1, float start, float delta, int npnt)
 /*****************************************/
-{ register float *inptr;
-  register int    inincr;
-  register float *outptr;
-  register int    outincr;
-  register float  level;
-  register float  incr;
-  register int    i;
+{ float *inptr;
+  int    inincr;
+  float *outptr;
+  int    outincr;
+  float  level;
+  float  incr;
+  int    i;
 
  if (is1 == 1 && os1 == 1)
   {
@@ -327,11 +271,11 @@ void vvrramp(float *in1, int is1, float *out1, int os1, float start, float delta
 /*         npoints;     number of complex points             */
 void vvvcmult(void *in1, int is1, void *in2, int is2, void *out1, int os1, int npoints)
 {
-   register int         i;
-   register float       tmp;
-   register fcomplex     *input1,
-                        *input2,
-			*output;
+   int         i;
+   float       tmp;
+   fcomplex 	*input1,
+				*input2,
+				*output;
 
    input1 = (fcomplex *)in1;
    input2 = (fcomplex *)in2;
@@ -381,15 +325,15 @@ void vvvcmult(void *in1, int is1, void *in2, int is2, void *out1, int os1, int n
 /*                 npoints;     number of hypercomplex points	*/
 void vvvhcmult(void *in1, int is1, void *in2, int is2, void *out1, int os1, int npoints)
 {
-   register int                 i;
-   register float               rere,
-                                reim,
-                                imre,
-                                imim,
-				tmp;
-   register hypercomplex        *input1,
-                                *input2,
-                                *output;
+   int                 i;
+   float               rere,
+                       reim,
+                       imre,
+                       imim,
+					   tmp;
+   hypercomplex        *input1,
+                       *input2,
+                       *output;
  
    input1 = (hypercomplex *)in1;
    input2 = (hypercomplex *)in2;
@@ -446,9 +390,9 @@ void vvvhcmult(void *in1, int is1, void *in2, int is2, void *out1, int os1, int 
 /* 	mult;		scaling factor				*/
 void scfix1(float *frompntr, int fromincr, float mult, short *topntr, int toincr, int npnts)
 {
-   register short	*destpntr;
-   register int		i;
-   register float	r,
+   short	*destpntr;
+   int		i;
+   float	r,
 			*srcpntr;
 
    srcpntr = frompntr;
@@ -488,9 +432,9 @@ void scfix1(float *frompntr, int fromincr, float mult, short *topntr, int toincr
 /* 	mult;		scaling factor				*/
 void scabs(float *frompntr, int fromincr, float mult, short *topntr, int toincr, int npnts, int sgn)
 {
-   register short	*destpntr;
-   register int		i;
-   register float	a,b,r,
+   short	*destpntr;
+   int		i;
+   float	a,b,r,
 			*srcpntr;
 
    srcpntr = frompntr;
@@ -527,7 +471,7 @@ void scabs(float *frompntr, int fromincr, float mult, short *topntr, int toincr,
 /* 	datatype;	2 = complex    4 = hypercomplex */
 void preproc(float *restrict datapntr, int n, int datatype)
 {
-   register int		i,
+   int		i,
 			j;
 
    if (datatype == 2)
@@ -578,14 +522,14 @@ void preproc(float *restrict datapntr, int n, int datatype)
 /* 	datatype;	2 = complex      4 = hypercomplex */
 void postproc(float *datapntr, int n,  int datatype)
 {
-  int			i,
+  int		i,
 			j,
 			skip;
-  register int		i1,
+  int		i1,
 			i2,
 			i3,
 			i4;
-  float			c1,
+  float		c1,
 			c2,
 			h1r,
 			hli,
@@ -597,15 +541,15 @@ void postproc(float *datapntr, int n,  int datatype)
 			d2,
 			d3,
 			d4;
-  register float	*pi1,
+  float  	*pi1,
 			*pi2,
 			*pi3,
 			*pi4;
-  double		wpr,
+  double	wpr,
 			wpi,
 			wtemp,
 			theta;
-  register double	wr,
+  double	wr,
 			wi;
 
 
@@ -725,8 +669,8 @@ void postproc(float *datapntr, int n,  int datatype)
 void combine(float *combinebuf, float *outp, int npoints, int datatype,
              float r1, float r2, float r3, float r4)
 {
-   register int		i;
-   register float	*combuffer,
+   int		i;
+   float	*combuffer,
 			*output;
 
    combuffer = combinebuf;
@@ -759,42 +703,25 @@ void combine(float *combinebuf, float *outp, int npoints, int datatype,
 /* Both shiftpts and npoints are numbers of complex pairs */
 void shiftComplexData(float *ptr, int shiftpts, int npoints, int len)
 {
-   register int		i;
-   register float	*endptr,
-			*sptr;
-	
    if (shiftpts == 0)
       return;
    if (shiftpts > 0) /* right shift */
    {
 	if (npoints > len - shiftpts)
          npoints = len - shiftpts;
-	if (npoints < 16)
-	{
-	  sptr = ptr+(npoints)*2 -1;
-      endptr = ptr+(npoints+shiftpts)*2 - 1;
 
-      for (i = 0; i < npoints; i++)
-      { 
-         *endptr-- = *sptr--; 
-         *endptr-- = *sptr--; 
-      }
-      for (i = 0; i < shiftpts; i++)
-      { 
-         *endptr-- = 0.0;
-         *endptr-- = 0.0;
-      }
-	}
-	 else
-	{
-	   memmove(ptr + (long)shiftpts * 2, ptr, (size_t)npoints * 2 * sizeof(float));
-       memset(ptr, 0, (size_t)shiftpts * 2 * sizeof(float));
-	}
+	memmove(ptr + (long)shiftpts * 2, ptr, (size_t)npoints * 2 * sizeof(float));
+    memset(ptr, 0, (size_t)shiftpts * 2 * sizeof(float));
    }
    else if (shiftpts < 0) /* left shift */
    {
-	if (npoints + shiftpts < 16)
+	// For this case, memmove is very slow
+	if (shiftpts > -16)
 	{
+	  int	i;
+      float	*endptr,
+			*sptr;
+
       shiftpts *= -1;
       sptr = ptr+(shiftpts)*2;
       endptr = ptr;
@@ -806,8 +733,8 @@ void shiftComplexData(float *ptr, int shiftpts, int npoints, int len)
       }
       for (i = 0; i < shiftpts; i++)
       { 
-         *endptr++ = 0.0;
-         *endptr++ = 0.0;
+         *endptr++ = 0.0f;
+         *endptr++ = 0.0f;
       }
 	}
 	else
@@ -834,8 +761,8 @@ void shiftComplexData(float *ptr, int shiftpts, int npoints, int len)
 /* float *data;		pointer to complex/hypercomplex data		*/
 void negateimaginary(float *data, int npoints, int datatype)
 {
-   register int		i;
-   register float	*tmp;
+   int		i;
+   float	*tmp;
 
    tmp = data + (datatype/2);
    if (datatype == HYPERCOMPLEX)
@@ -874,7 +801,7 @@ void negateimaginary(float *data, int npoints, int datatype)
 /* outp;	pointer to 32-bit, floating point FID data	*/
 void cnvrts32(float scalefactor, int *restrict inp, float *restrict outp, int npx, int lsfidx)
 {
-   register int	  i;
+   int	  i;
 
    if (lsfidx == 0)
    {
@@ -915,7 +842,7 @@ void cnvrts32(float scalefactor, int *restrict inp, float *restrict outp, int np
 /* 	*outp;		pointer to 32-bit, floating point FID data	*/
 void cnvrts16(float scalefactor, short *restrict inp, float *restrict outp, int npx, int lsfidx)
 {
-   register int		i;
+   int		i;
 
    if (lsfidx == 0)
    {
@@ -937,24 +864,4 @@ void cnvrts16(float scalefactor, short *restrict inp, float *restrict outp, int 
 	  for (i = 0; i < lsfidx; i++)
          outp[i+npx-lsfidx] = 0.0f;
    }
-}
-
-
-/*-----------------------------------------------
-|						|
-|		AP_bootup_msg()			|
-|						|
-|   This is merely a message line to be gen-	|
-|   erated (conditionally) in bootup.c.  By	|
-|   putting the message here (sky.c), sky.c is	|
-|   now the only source code file which uses	|
-|   the "AP" conditional compile flag, thus	|
-|   simplifying maintenance.			|
-|						|
-+----------------------------------------------*/
-void AP_bootup_msg()
-{
-#ifdef AP
-   Wscrprintf( "              Version for Sky Array Processor\n");
-#endif 
 }

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -746,6 +746,10 @@ void shiftComplexData(float *ptr, int shiftpts, int npoints, int len)
    {
 	if (len < 8)
 	{
+      if (npoints > len - shiftpts)
+      {
+         npoints = len - shiftpts;
+      }
 	  sptr = ptr+(npoints)*2 -1;
       endptr = ptr+(npoints+shiftpts)*2 - 1;
 

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -17,6 +17,8 @@
 #include <string.h>
 #include <math.h>
 
+#pragma GCC optimize ("O3")
+
 #ifndef M_PI
 #define M_PI    3.14159265358979323846
 #endif 

--- a/src/vnmr/sky.c
+++ b/src/vnmr/sky.c
@@ -471,38 +471,40 @@ void scabs(float *frompntr, int fromincr, float mult, short *topntr, int toincr,
 /* 	datatype;	2 = complex    4 = hypercomplex */
 void preproc(float *restrict datapntr, int n, int datatype)
 {
-   int		i,
-			j;
+   int		i, j;
 
    if (datatype == 2)
    {
-      for (i = 0; i < n; i++)
+      float *restrict ptr = datapntr + datatype;
+      for (i = 1; i < n; i += 2)
       {
-         float sign = 1.0f - 2.0f * (float)(i & 1);
-         datapntr[i*2]   *= sign;
-         datapntr[i*2+1] *= sign;
+         ptr[0] *= -1.0f;
+         ptr[1] *= -1.0f;
+         ptr += datatype*2;
       }
    }
    else if (datatype == 4)
    {
-      for (i = 0; i < n; i++)
+      float *restrict ptr = datapntr + datatype;
+      for (i = 1; i < n; i += 2)
       {
-         float sign = 1.0f - 2.0f * (float)(i & 1);
-         datapntr[i*4]   *= sign;
-         datapntr[i*4+1] *= sign;
-         datapntr[i*4+2] *= sign;
-         datapntr[i*4+3] *= sign;
+         ptr[0] *= -1.0f;
+         ptr[1] *= -1.0f;
+         ptr[2] *= -1.0f;
+         ptr[3] *= -1.0f;
+         ptr += datatype*2;
       }
    }
    else
    {
-    for (i = 0; i < n; i++)
-    {
-	  float sign = 1.0f - 2.0f * (float)(i & 1);
-      float *restrict row = datapntr + (long)i * datatype;
-      for (j = 0; j < datatype; j++)
-         row[j] *= sign;
-    }
+      float *restrict ptr = datapntr + datatype;
+      long stride = (long)datatype * 2;
+      for (i = 1; i < n; i += 2)
+      {
+         for (j = 0; j < datatype; j++)
+            ptr[j] *= -1.0f;
+         ptr += stride;
+      }
    }
 }
 

--- a/src/vnmr/sky.h
+++ b/src/vnmr/sky.h
@@ -10,24 +10,24 @@
 #ifndef SKY_H
 #define SKY_H
 
-extern void vvvrmult(float *in1, int is1, float *in2, int is2, float *out1, int os1, int n);
+extern void vvvrmult(float *restrict in1, int is1, float *in2, int is2, float *out1, int os1, int n);
 extern void datafill(float *buffer, int n, float value);
 extern void skymax(float *in1, float *in2, float *out, int n);
 extern void skyadd(float *in1, float *in2, float *out, int n);
-extern void vrsum(float *in1, int is1, float *sum, int npnt);
+extern void vrsum(float *restrict in1, int is1, float *restrict sum, int npnt);
 extern void vssubr(float *inptr, float val, float *outptr, int n);
 extern void vvrramp(float *in1, int is1, float *out1, int os1, float start, float delta, int npnt);
 extern void vvvcmult(void *in1, int is1, void *in2, int is2, void *out1, int os1, int npoints);
 extern void vvvhcmult(void *in1, int is1, void *in2, int is2, void *out1, int os1, int npoints);
 extern void scfix1(float *frompntr, int fromincr, float mult, short *topntr, int toincr, int npnts);
 extern void scabs(float *frompntr, int fromincr, float mult, short *topntr, int toincr, int npnts, int sgn);
-extern void preproc(float *datapntr, int n, int datatype);
+extern void preproc(float *restrict datapntr, int n, int datatype);
 extern void postproc(float *datapntr, int n,  int datatype);
 extern void combine(float *combinebuf, float *outp, int npoints, int datatype,
                     float r1, float r2, float r3, float r4);
 extern void shiftComplexData(float *ptr, int shiftpts, int npoints, int len);
 extern void negateimaginary(float *data, int npoints, int datatype);
-extern void cnvrts32(float scalefactor, int *inp, float *outp, int npx, int lsfidx);
-extern void cnvrts16(float scalefactor, short *inp, float *outp, int npx, int lsfidx);
+extern void cnvrts32(float scalefactor, int *restrict inp, float *restrict outp, int npx, int lsfidx);
+extern void cnvrts16(float scalefactor, short *restrict inp, float *restrict outp, int npx, int lsfidx);
 
 #endif 


### PR DESCRIPTION
Since we are on a 64-bit architecture, SSE2/NEON/etc support is always available, and utilizing them costs virtually nothing compared to emulating vector functions with scalar code. We simply need to assist the compiler, as (unlike vector processors of the past) it cannot handle strides at runtime (exception march=armv8.5-a+sve2 vectorize for any stride).