### PR TITLE
Fdf to dcm - fix UB and mark unimplemented code

### DIFF
--- a/src/IMAGE/imaging/maclib/aipSaveOutput
+++ b/src/IMAGE/imaging/maclib/aipSaveOutput
@@ -118,7 +118,7 @@ if ($action = 'save') then
       endif
     endif
     "Set cmd"
-    $cmd='aipOut "'+$command+'" "-'+aipType+'" '+$ptag+' "-in" "'+$indir+'" "-out" "'+$outdir+'"'+$conf_dir
+    $cmd='aipOut "'+$command+'" "-'+aipType+'" '+$ptag+' "-if" "'+$indir+'" "-of" "'+$outdir+'"'+$conf_dir
     write('line3','aipOutput: executing %s ....',$cmd)
     "Execute cmd"
     shell($cmd+' >'+curexp+'/aipOutput.txt 2>&1')

--- a/src/dicom_fdf/FdfToDcm/ConvertFdfFieldToTag.cpp
+++ b/src/dicom_fdf/FdfToDcm/ConvertFdfFieldToTag.cpp
@@ -220,11 +220,35 @@ extern int convertFdfFieldToTag(char *fieldType, char *fieldName,
 	}
 	else if((strcmp(fieldName, fdfInput[i].name) == 0) && (strcmp(fieldName, "*position1") == 0))
 	{
-		strncpy(fdfValues->position1, &fieldValue[1], strlen(fieldValue)-2);
+		size_t len = strlen(fieldValue);
+		if(len >= 2)
+		{
+			size_t copyLen = len - 2;
+			if(copyLen >= sizeof(fdfValues->position1))
+				copyLen = sizeof(fdfValues->position1) - 1;
+			strncpy(fdfValues->position1, &fieldValue[1], copyLen);
+			fdfValues->position1[copyLen] = '\0';
+		}
+		else
+		{
+			fdfValues->position1[0] = '\0';
+		}
 	}
 	else if((strcmp(fieldName, fdfInput[i].name) == 0) && (strcmp(fieldName, "*position2") == 0))
 	{
-		strncpy(fdfValues->position2, &fieldValue[1], strlen(fieldValue)-2);
+		size_t len = strlen(fieldValue);
+		if(len >= 2)
+		{
+			size_t copyLen = len - 2;
+			if(copyLen >= sizeof(fdfValues->position2))
+				copyLen = sizeof(fdfValues->position2) - 1;
+			strncpy(fdfValues->position2, &fieldValue[1], copyLen);
+			fdfValues->position2[copyLen] = '\0';
+		}
+		else
+		{
+			fdfValues->position2[0] = '\0';
+		}
 	}
 	else if((strcmp(fieldName, fdfInput[i].name) == 0) && (strcmp(fieldName, "TI") == 0))
 	{

--- a/src/dicom_fdf/FdfToDcm/ConvertFdfFieldToTag.cpp
+++ b/src/dicom_fdf/FdfToDcm/ConvertFdfFieldToTag.cpp
@@ -84,7 +84,7 @@ extern int convertFdfFieldToTag(char *fieldType, char *fieldName,
 		}
 	}
 	// If we didn't find a matching entry, return an error
-	if(fdfInput[i].name == NULL)
+	if(fdfInput[i].name[0] == '\0')
 	{
 		printf("Uknown field found, ignoring...\n");
 		return 1;

--- a/src/dicom_fdf/FdfToDcm/FdfHeader.h
+++ b/src/dicom_fdf/FdfToDcm/FdfHeader.h
@@ -110,7 +110,7 @@ const fdfInputEntry_t	fdfInput[] =
 		{ "float",  "orientation[]",	FDF_FLOATARRAY9 },
 		{ "int", 	"checksum", 		FDF_INT },
 		{ "char",	"appdirs",			FDF_CHARPTR	},
-		{ NULL, NULL, 0 }
+		{ '\0', '\0', 0 }
 };
 
 // Structure to hold FDF fields that have been converted to internal

--- a/src/dicom_fdf/FdfToDcm/FdfToDcm.cpp
+++ b/src/dicom_fdf/FdfToDcm/FdfToDcm.cpp
@@ -312,6 +312,8 @@ int main(int argc,char **argv)
 				if(fread(&c, 1, 1, fd) != 1)
 				{
 					fprintf(stderr, "Error locating end of FDF header!!", errno);
+					fclose(fd);
+					exit(1);
 				}
 			}
 
@@ -925,9 +927,14 @@ int main(int argc,char **argv)
 			{
 				perror("stat");
 			}
-			int tagSize = strlen(PROCPARTAGHEADER);
+			size_t tagSize = strlen(PROCPARTAGHEADER);
 			tagSize += strlen(PROCPARTAGFOOTER);
-			tagSize += sb.st_size;
+			tagSize += (size_t)sb.st_size;
+			if(sb.st_size < 0)
+			{
+				fprintf(stderr, "Invalid procpar file size, private tag will not be included!\n");
+				return 1;
+			}
 			char *privateBuf = (char *)malloc(tagSize + 4);
 			bzero(privateBuf, tagSize + 4);
 

--- a/src/dicom_fdf/FdfToDcm/FdfToDcm.cpp
+++ b/src/dicom_fdf/FdfToDcm/FdfToDcm.cpp
@@ -80,8 +80,8 @@ int main(int argc,char **argv)
         char                            syscmd[256];
         char                            stdid[256];
         char                            sha1[64];
-        char                            uidpbuf[NSHA1];
-        char                            uidfbuf[NSHA1];
+        char                            uidpbuf[NSHA1 + 1];
+        char                            uidfbuf[NSHA1 + 1];
         char                            tempbuf[256];
 
 	int				i,j;
@@ -1041,7 +1041,7 @@ static void makesha1uid(char *filepath, char *filename, char *uidbuf)
   j=0;
   for(i=0;i<NSHA1;i++)
     {
-      if((isdigit(sha1[i])) && (sha1[i] != '0'))
+      if((isdigit(sha1[i])) && (sha1[i] != '0') && (j < NSHA1 - 1))
 	uidbuf[j++]=sha1[i];
     }
   uidbuf[j]='\0';

--- a/src/dicom_fdf/FdfToDcm/FdfToDcm.cpp
+++ b/src/dicom_fdf/FdfToDcm/FdfToDcm.cpp
@@ -414,6 +414,7 @@ int main(int argc,char **argv)
 			}
 			printf("Scaling factor: %f\n", scaleFactor);
 			fclose(fd);
+			free(pixelBuf);
 			printf("Pixel bytes written: %d\n", pixels);
 		}	// End if(isfdf)
 		else

--- a/src/dicom_fdf/FdfToDcm/FdfToDcm.cpp
+++ b/src/dicom_fdf/FdfToDcm/FdfToDcm.cpp
@@ -73,9 +73,9 @@ int main(int argc,char **argv)
 	char				customtagPath[PATH_MAX];
 	char				inputfilename[PATH_MAX];
 	char				outdcmfilename[PATH_MAX];
-	char				uidSuffix[64];
-	char				studyUID[128];
-	char				seriesUID[128];
+	char				uidSuffix[PATH_MAX];
+	char				studyUID[256];
+	char				seriesUID[PATH_MAX + 64];
 	char 				*pixelBuf;
         char                            syscmd[256];
         char                            stdid[256];
@@ -116,7 +116,7 @@ int main(int argc,char **argv)
 
 	struct dirent 		**namelist;
 	int 				nFiles;
-	FILE				*fd, *procparfd, *customfd, *fdf_fd, *fsha;
+	FILE				*fd, *procparfd, *customfd, *fdf_fd = NULL, *fsha;
 
 	GetNamedOptions 		options(argc,argv);
 	InputOptions			input_options(options);
@@ -210,7 +210,7 @@ int main(int argc,char **argv)
 
 	//UI Series Instance UID 	 VR=<UI>   VL=<0x0032>
 	//Example: <1.3.6.1.4.1.670589.1.3.0.123.127440.31032.8323329>
-	sprintf(seriesUID, "1.3.6.1.4.1.%s.1.3.0.123.%s", VARIAN_COMPANY_ID, uidSuffix);
+	snprintf(seriesUID, sizeof(seriesUID), "1.3.6.1.4.1.%s.1.3.0.123.%s", VARIAN_COMPANY_ID, uidSuffix);
 
 	while(nFiles--)
 	{
@@ -419,6 +419,11 @@ int main(int argc,char **argv)
 		else
 		{
 			ProcessFidData(fd, list, &fdfValues);
+			// Preserve the descriptor so the shared code below
+			// (ProcessCustomTags / fclose) has a valid FILE*,
+			// matching what the isfdf branch does.
+			fdf_fd = fd;
+			fd = NULL;
 		}
 		
 		// Setup the variables used to process the individual tags from the basic DICOM
@@ -540,7 +545,7 @@ int main(int argc,char **argv)
 
 		//sprintf(studyUID, "1.3.6.1.4.1.%s.1.2.0.%d", stdid, (unsigned int)gethostid());
 	
-		 sprintf(studyUID, "1.3.6.1.4.1.%s.1.2.0.%s_%s", strtok(fdfValues.studyid,"\""), strtok(fdfValues.oper,"\""),strtok(fdfValues.pname,"\""));
+		 snprintf(studyUID, sizeof(studyUID), "1.3.6.1.4.1.%s.1.2.0.%s_%s", strtok(fdfValues.studyid,"\""), strtok(fdfValues.oper,"\""), strtok(fdfValues.pname,"\""));
 
 		list+=new UIStringAttribute(TagFromName(StudyInstanceUID), studyUID);
 
@@ -713,6 +718,7 @@ int main(int argc,char **argv)
 
 		// Calculations are done differently depending on whether we're converting a
 		// 2D acquisition or a 3D acquisition.
+		float ctr[3] = {0.0f, 0.0f, 0.0f};
 		if(fdfValues.rank == 2)
 		{
 			// 1) Figure out distance from center of image to upper left corner:
@@ -889,13 +895,20 @@ int main(int argc,char **argv)
 		// If we found the file, process the custom tags
 		if(haveTagFile)
 		{
-		  ProcessCustomTags(customtagPath, procparPath, fdf_fd, list);
+		  if(fdf_fd != NULL)
+		  {  
+			  ProcessCustomTags(customtagPath, procparPath, fdf_fd, list);
+		  }
 		}
 		else
 		{
 			printf("Custom tag file not found, ignoring...\n");
 		}
-		fclose(fdf_fd); // now done with fdf file
+		if(fdf_fd != NULL)
+		{
+			fclose(fdf_fd); // now done with fdf file
+			fdf_fd = NULL;
+		}
 
 		// Add procpar file as a custom tag
 //		OtherByteLargeNonPixelAttribute(Tag t,BinaryInputStream &stream,OurStreamPos pos)
@@ -993,25 +1006,27 @@ static void makesha1uid(char *filepath, char *filename, char *uidbuf)
 {
   int i,j;
   char sha1Path[256];
-  char fpath[256];
-  char sha1[NSHA1];
-  char   syscmd[256];
+  char fpath[512];
+  char sha1[NSHA1 + 1];
+  char   syscmd[800];
   FILE *fsha;
 
   // get its sha1sum to use for UID
-  (void)strcpy(sha1Path,"/vnmr/tmp");
-  (void)strcat(sha1Path,"/sha1.txt");
+  (void)snprintf(sha1Path, sizeof(sha1Path), "/vnmr/tmp/sha1.txt");
 
-  (void)strcpy(fpath,filepath);
-  (void)strcat(fpath,"/");
-  (void)strcat(fpath,filename);
+  (void)snprintf(fpath, sizeof(fpath), "%s/%s", filepath, filename);
 
-  (void)sprintf(syscmd,"sha1sum %s > %s \n",fpath,sha1Path);
+  (void)snprintf(syscmd, sizeof(syscmd), "sha1sum %s > %s \n", fpath, sha1Path);
   (void)system(syscmd);
 
   //read it in
   fsha=fopen(sha1Path,"r");
-  if(!fsha)printf("Could not open sha1 for %s \n",fpath);
+  if(!fsha)
+  {
+	  printf("Could not open sha1 for %s \n",fpath);
+	  uidbuf[0] = '\0';
+	  return;
+  }
   fscanf(fsha,"%10s",sha1);
   (void)fclose(fsha);
   unlink(sha1Path);

--- a/src/dicom_fdf/FdfToDcm/GetScaleFactor.cpp
+++ b/src/dicom_fdf/FdfToDcm/GetScaleFactor.cpp
@@ -69,8 +69,15 @@ int GetScaleFactor(const char *path, float *minPixel, float *maxPixel)
 			sprintf(filename, "%s/%s", path, namelist[nFiles]->d_name);
 
 			printf("Processing FID file: %s\n", namelist[nFiles]->d_name);
-			GetFIDMinMax(namelist[nFiles]->d_name, &tempMin, &tempMax);
-			nImageFiles++;
+			if(GetFIDMinMax(filename, &tempMin, &tempMax) == 0)
+			{
+				nImageFiles++;
+			}
+			else
+			{
+				fprintf(stderr, "Skipping min/max for unimplemented fid handling: %s\n", filename);
+				continue;
+			}
 		}
 		else
 		{
@@ -158,6 +165,15 @@ int GetFDFMinMax(char *path, float *fileMin, float *fileMax)
 
 int GetFIDMinMax(char *path, float *fileMin, float *fileMax)
 {
+	(void)path;
+	(void)fileMin;
+	(void)fileMax;
 
+	fprintf(stderr,
+            "WARNING: GetFIDMinMax('%s') is not yet implemented; "
+            "min/max pixel values for this fid file were NOT computed.\n",
+            path);
+
+	return -1;
 }
 

--- a/src/dicom_fdf/FdfToDcm/GetScaleFactor.cpp
+++ b/src/dicom_fdf/FdfToDcm/GetScaleFactor.cpp
@@ -156,6 +156,8 @@ int GetFDFMinMax(char *path, float *fileMin, float *fileMax)
 	printf("File: %s - Min Pixel: %f\n", path, minPixel);
 	printf("File: %s - Max Pixel: %f\n", path, maxPixel);
 
+	free(pixelBuf);
+
 	if(minPixel < *fileMin) *fileMin = minPixel;
 	if(maxPixel > *fileMax) *fileMax = maxPixel;
 

--- a/src/dicom_fdf/FdfToDcm/GetScaleFactor.cpp
+++ b/src/dicom_fdf/FdfToDcm/GetScaleFactor.cpp
@@ -89,6 +89,7 @@ int GetScaleFactor(const char *path, float *minPixel, float *maxPixel)
 	}
 
 	printf("%d Files processed for min and max pixel values...\n", nImageFiles);
+	return 0;
 }
 
 int GetFDFMinMax(char *path, float *fileMin, float *fileMax)

--- a/src/dicom_fdf/FdfToDcm/ProcessCustomTags.cpp
+++ b/src/dicom_fdf/FdfToDcm/ProcessCustomTags.cpp
@@ -389,6 +389,7 @@ int	FindProcparValue(char *procparPath, char *fieldName, char *retptr)
 						if(fscanf(procparfd, "%s", str1) != 1)
 						{
 							fprintf(stderr, "Error reading string values...\n");
+							break;
 						}
 						k = 0;
 						if(str1[0] == '"') k++; /* skip leading quote */

--- a/src/dicom_fdf/FdfToDcm/ProcessCustomTags.cpp
+++ b/src/dicom_fdf/FdfToDcm/ProcessCustomTags.cpp
@@ -105,11 +105,12 @@ int ProcessCustomTags(char *filepath, char *procparPath, FILE *fdf_file, class M
 			// Check for values that are tied to procpar.  Indicated by '=' leading char
 			if(valuestr[0] == '=')
 			  {
-			    if(FindFDFValue(fdf_file, ++valuestr, str1) ==0)
+			      ++valuestr;
+				  if(FindFDFValue(fdf_file, valuestr, str1) ==0)
 			      {
 				strcpy(valuestr, str1);
 			      }
-			    else if(FindProcparValue(procparPath, ++valuestr, str1) == 0)
+			    else if(FindProcparValue(procparPath, valuestr, str1) == 0)
 			      {					
 				strcpy(valuestr, str1);
 			      }
@@ -126,9 +127,11 @@ int ProcessCustomTags(char *filepath, char *procparPath, FILE *fdf_file, class M
 			valuestr = NULL;
 			break;
 		default:
+			char *end = str + sizeof(str) - 1;   // last valid byte in the line buffer
 			cptr = valuestr;
-			while(!isspace(*cptr++));
-			*(cptr - 1) = '\0';
+			while(cptr < end && *cptr != '\0' && !isspace((unsigned char)*cptr))
+				cptr++;
+			*cptr = '\0';
 			break;
 		}
 		if(valuestr == NULL) continue;
@@ -392,10 +395,11 @@ int	FindProcparValue(char *procparPath, char *fieldName, char *retptr)
 
 						for(k = k ; k < strlen(str1) ; k++)
 						{
-							str2[l++]=str1[k]; /* copy to str2 */
+							if(l < (int)sizeof(str2) - 1)
+								str2[l++]=str1[k]; /* copy to str2 */
 						}
 
-						if(str1[strlen(str1)-1] != '"') str2[l++]=' '; /* add white space */
+						if(str1[strlen(str1)-1] != '"' && l < (int)sizeof(str2) - 1) str2[l++]=' '; /* add white space */
 					} while(str1[strlen(str1)-1] != '"');
 
 					str2[--l]=0; /* NULL terminate */
@@ -476,5 +480,6 @@ int	FindProcparValue(char *procparPath, char *fieldName, char *retptr)
 				break;
 		}
 	}
+	return 0;
 }
 

--- a/src/dicom_fdf/FdfToDcm/ProcessFdfHeader.cpp
+++ b/src/dicom_fdf/FdfToDcm/ProcessFdfHeader.cpp
@@ -52,6 +52,12 @@ int ProcessFdfHeader(FILE *fd, 	fdfEntries_t *fdfValues)
 	char		fieldName[PATH_MAX];
 	char		fieldValue[PATH_MAX];
 
+	if(fd == NULL)
+	{
+		fprintf(stderr, "ProcessFdfHeader: NULL file pointer passed in\n");
+		return(-1);
+	}
+	
 	// Read each field out of the FDF file and convert them to the appropriate
 	// DICOM tag and add to the list of tags that will be written to the converted
 	// file by the caller.

--- a/src/dicom_fdf/FdfToDcm/ProcessFidData.cpp
+++ b/src/dicom_fdf/FdfToDcm/ProcessFidData.cpp
@@ -273,6 +273,7 @@ int ProcessFidData(FILE *fidfd, class ManagedAttributeList& list, fdfEntries_t *
 			fwrite(&pix, 1, sizeof(float), floatfd);
 			fprintf(pixfd, "%f\n", pix);
 		}
+		free(pixelBuf);
 	}
 	fclose(pixfd);
 	rewind(floatfd);

--- a/src/dicom_fdf/FdfToDcm/ProcessProcpar.cpp
+++ b/src/dicom_fdf/FdfToDcm/ProcessProcpar.cpp
@@ -150,10 +150,12 @@ int ProcessProcpar(FILE *procparfd, class ManagedAttributeList& list,
 
 						for(k = k ; k < strlen(str1) ; k++)
 						{
-							str2[l++]=str1[k]; /* copy to str2 */
+							if(l < (int)sizeof(str2) - 1)
+								str2[l++]=str1[k]; /* copy to str2 */
 						}
 
-						if(str1[strlen(str1)-1] != '"') str2[l++]=' '; /* add white space */
+						if(str1[strlen(str1)-1] != '"' && l < (int)sizeof(str2) - 1) 
+							str2[l++]=' '; /* add white space */
 					} while(str1[strlen(str1)-1] != '"');
 
 					str2[--l]=0; /* NULL terminate */

--- a/src/dicom_fdf/FdfToDcm/ProcessProcpar.cpp
+++ b/src/dicom_fdf/FdfToDcm/ProcessProcpar.cpp
@@ -144,6 +144,7 @@ int ProcessProcpar(FILE *procparfd, class ManagedAttributeList& list,
 						if(fscanf(procparfd, "%s", str1) != 1)
 						{
 							fprintf(stderr, "Error reading string values...\n");
+							break;
 						}
 						k = 0;
 						if(str1[0] == '"') k++; /* skip leading quote */

--- a/src/dicom_fdf/FdfToDcm/SConstruct
+++ b/src/dicom_fdf/FdfToDcm/SConstruct
@@ -88,7 +88,7 @@ d3LibList = [ os.path.join(d3LibPath,'libdctl.a'), os.path.join(d3LibPath,'libdl
 
 
 env= Environment(CC         = 'g++',
-                     CCFLAGS    = '-Wno-deprecated -Wno-write-strings -O -g',
+                     CCFLAGS    = '-Wno-deprecated -Wno-write-strings -O2 -D_FORTIFY_SOURCE=2',
 #debug: -g 
 #profile: -pg
                      CPPDEFINES = ['DDEFAULTUIDROOT=\"1.3.6.1.4.1.670589.1\"', 


### PR DESCRIPTION
On AlmaLinux 9, at least, this code enters an infinite loop in procpar processing or segfaults (when built with GCC 11). The undefined behavior flagged by GCC 15 has been fixed here, and the conversion now works. It would be good to update dicom3tools, doing so requires a couple more modifications to update the DICOM dictionary and a new build parameter.