### PR TITLE
Fixes for annotate.c and aipSpecData.C

### DIFF
--- a/src/aip/aipGframe.C
+++ b/src/aip/aipGframe.C
@@ -595,8 +595,8 @@ bool Gframe::saveCanvasBackup(Roi *roi) {
     if (!viewList->empty()) {
         spViewInfo_t view = *viewList->begin();
         spImgInfo_t img = view->imgInfo;
-        drawAnnotation(img->getDataInfo()->getKey().c_str(), pixstx, pixsty, pixwd, pixht, getGframeNumber(), id,
-                0);
+        drawAnnotation(img->getDataInfo()->getKey().c_str(),
+			pixstx, pixsty, pixwd, pixht, getGframeNumber(), id);
     }
 
     aipCallDisplayListeners(id, false);
@@ -1112,7 +1112,7 @@ void Gframe::draw() {
             view = *viewList->begin();
             img = view->imgInfo;
             drawAnnotation(img->getDataInfo()->getKey().c_str(), pixstx, pixsty, pixwd, pixht, getGframeNumber(),
-                    id, changeFlag);
+                    id);
             //view->pixstx, view->pixsty, view->pixwd, view->pixht);
         }
         if (isImage && !movieStopped) {

--- a/src/aip/aipSpecData.C
+++ b/src/aip/aipSpecData.C
@@ -67,9 +67,9 @@ bool SpecData::fillSpecStruct(DDLSymbolTable *newSt, specStruct_t *newSs) {
      Werrprintf("No \"storage\" in FDF header\n");
   } else strcpy(newSs->storage, str);
   
-  if (!newSt->GetValue("fidpath", str)) {
-     strcpy(newSs->fidpath,"");
-  } else strcpy(newSs->fidpath, str);
+//  if (!newSt->GetValue("fidpath", str)) {
+//     strcpy(newSs->fidpath,"");
+//  } else strcpy(newSs->fidpath, str);
   
   if (!newSt->GetValue("type", str)) {
      strcpy(newSs->type,"absval");

--- a/src/aip/aipSpecDataMgr.C
+++ b/src/aip/aipSpecDataMgr.C
@@ -432,10 +432,10 @@ int SpecDataMgr::getYminmax(string nucleus,double &ymin, double &ymax) {
 	for(int i=1; i<(ss->rank); i++) {
 	   npnt *= ss->matrix[i];
 	} 
-	register float  *data = ss->data;
-	register float maxval = -0.1*FLT_MAX;
-	register float minval = FLT_MAX;
-	register float tmp;
+	float  *data = ss->data;
+	float maxval = -0.1*FLT_MAX;
+	float minval = FLT_MAX;
+	float tmp;
 	while (--npnt)
 	{
 	   tmp = *data++;

--- a/src/aip/aipSpecStruct.h
+++ b/src/aip/aipSpecStruct.h
@@ -25,7 +25,7 @@
 
 typedef struct _specStruct {
    float *data;
-   char fidpath[MAXPATHLEN];
+//   char fidpath[MAXPATHLEN];
    char type[MAXWORDLEN];        // E.g., "absval", "real", "imag", "complex" 
    char dataType[MAXWORDLEN];    // E.g., "spectrum", "baseline", "fitting"
    char storage[MAXWORDLEN];     // E.g., "float" 

--- a/src/aip/aipVnmrFuncs.h
+++ b/src/aip/aipVnmrFuncs.h
@@ -110,7 +110,7 @@ extern "C" {
     void interrupt_end(void);
     void interrupt_begin(void);
     // key is fullpath +' '+ fdf filename, (x, y) is upper left corner of the frame. 
-    int drawAnnotation(const char *key, int x, int y, int w, int h, int num, int id, bool f);
+    int drawAnnotation(const char *key, int x, int y, int w, int h, int num, int id);
     void Winfoprintf(const char *format, ...)  __attribute__((format(printf,1,2)));
     int appdirFind(const char *filename, const char *lib, char *fullpath, const char *suffix, int perm);
     int copy_file(char* origpath, char* destpath);

--- a/src/vnmr/annotate.c
+++ b/src/vnmr/annotate.c
@@ -423,10 +423,9 @@ get_value()
 static int
 get_type(char *s)
 {
-    int type, len, k;
+    int len, k;
     char *d, *d1;
 
-    type = 0;
     d = s;
     inPtr = NULL;
     while (*d == ' ' || *d == '\t') d++;
@@ -2836,12 +2835,11 @@ check_aipAnnotation()
 }
 
 int drawAnnotation(const char *key, int x, int y, int w, int h,
-                   int frameNum, int frameId, int newFlag)
+                   int frameNum, int frameId)
 {
     int  newKey, newSize;
     int  i, k;
 
-    (void) newFlag;
     if (w < 50 || h < 50) {
         if (printErr)
            Werrprintf("Window size is too small for annotation.");


### PR DESCRIPTION
Removed unused final argument newFlag from drawAnnotation. It was defined as both int and bool. The fidpath field of the struct _specStruct was set but never used. This caused some "lto" warnings. Removed the field. Removed register keyword from aipSpecDataMgr.C.